### PR TITLE
Adopt issue and PR workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,35 @@
+---
+name: Task
+about: Track an implementation unit for this dotfiles repo
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Scope
+
+What should change?
+
+## Done Criteria
+
+- [ ] The intended behavior or document exists.
+- [ ] Policy / capability impact is understood.
+- [ ] Validation is complete.
+
+## Validation Plan
+
+- [ ] `./scripts/validate-policy.sh --all`
+- [ ] `git diff --check`
+
+Add task-specific checks here.
+
+## Safety Notes
+
+- Install side effects: none / planned / unknown
+- Secret access: none / planned / unknown
+- Network changes: none / planned / unknown
+- `chezmoi apply`: no / planned / unknown
+
+## Notes
+
+Do not include secrets, tokens, private endpoints, internal URLs, or organization/client-specific confidential details.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+- 
+
+## Linked Issue
+
+Closes #
+
+## Validation
+
+- [ ] `./scripts/validate-policy.sh --all`
+- [ ] `git diff --check`
+
+Add task-specific checks here.
+
+## Side Effects
+
+- Install side effects: none / planned / unknown
+- Secret access: none / planned / unknown
+- Network changes: none / planned / unknown
+- `chezmoi apply`: no / planned / unknown
+
+## Residual Risk
+
+- 
+
+## Notes
+
+Do not include secrets, tokens, private endpoints, internal URLs, or organization/client-specific confidential details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,19 @@
 - `doctor` は副作用なしを維持する。
 - `preflight` は導入前の危険検知に限定する。
 
+## GitHub 運用
+
+Phase 2 以降の作業は、原則として Issue 作成、branch 作成、Pull Request、merge の順で進める。
+
+詳細は `docs/github-workflow.md` に従う。
+
+- Notion は roadmap、設計背景、作業ログ、引き継ぎに使う。
+- GitHub Issues は実装単位の scope、done criteria、validation plan に使う。
+- GitHub Pull Requests は変更内容、検証結果、残リスク、merge 記録に使う。
+- `main` への直接 commit は例外扱いにする。
+- script、policy、capability、profile、install、secret、network、AI agent 境界に関わる変更は PR 必須。
+- main 直 commit の例外を使った場合は、Notion worklog または follow-up Issue に理由を残す。
+
 ## 作業ログ
 
 作業した日は、日単位の作業ログを残す。作業ログは repository には置かず、外部の project notes に保存する。

--- a/README.md
+++ b/README.md
@@ -89,6 +89,18 @@ chezmoi apply --source ~/dotfiles
 - `doctor` は副作用を持たない。
 - `preflight` は導入前の危険検知に限定する。
 
+## GitHub Workflow
+
+Phase 2 以降の作業は Issue / Pull Request で管理する。
+
+```text
+Notion: roadmap / design background / worklog / handoff
+GitHub Issues: implementation scope / done criteria / validation plan
+GitHub PRs: change summary / validation result / residual risk / merge record
+```
+
+詳細は [docs/github-workflow.md](docs/github-workflow.md) を参照する。
+
 ## License
 
 MIT

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -1,0 +1,124 @@
+# GitHub Workflow
+
+この repository では、Phase 2 以降の作業を GitHub Issues / Pull Requests で管理する。
+
+## 目的
+
+- 実装単位、判断、検証結果を GitHub に残す。
+- Notion の設計背景と GitHub の実装証跡を分ける。
+- `main` に入る変更を PR で確認できる状態にする。
+- policy、capability、secret、install、AI agent 境界に関わる変更の理由を後から追えるようにする。
+
+## 役割分担
+
+```text
+Notion
+  roadmap / design background / worklog / handoff notes
+
+GitHub Issues
+  implementation task / scope / done criteria / validation plan
+
+GitHub Pull Requests
+  code or docs change / validation result / residual risk / merge record
+
+main
+  merged PR only
+```
+
+## 標準フロー
+
+1. Issue を作る。
+2. Issue の scope、done criteria、validation を書く。
+3. Issue 番号を含む branch を作る。
+4. 変更する。
+5. validation を実行する。
+6. PR を作る。
+7. PR に validation result と residual risk を書く。
+8. PR を merge する。
+9. 必要なら Notion worklog / handoff notes を更新する。
+
+推奨 branch 名:
+
+```text
+phase2/git-profile
+chore/issue-pr-workflow
+docs/ai-boundary
+fix/policy-validation
+```
+
+Issue 番号を明示したい場合:
+
+```text
+issue-12/git-profile
+```
+
+## Issue が必要な変更
+
+- script 変更。
+- profile / module / capability 変更。
+- policy document 変更。
+- chezmoi template 追加。
+- package install / GUI app install / macOS defaults に関係する変更。
+- secret access / network tunnel / AI tools に関係する変更。
+- Git identity、SSH、npm、Corepack、runtime に関係する変更。
+- Phase roadmap 上の task。
+
+## PR が必要な変更
+
+原則すべての変更は PR を通す。
+
+特に以下は PR 必須:
+
+- shell script の挙動変更。
+- validation / doctor / preflight の終了コード変更。
+- capability の追加、削除、意味変更。
+- profile の permission 変更。
+- install、secret、network、AI agent 境界に関わる変更。
+- `AGENTS.md` や repository 運用ルールの変更。
+
+## main 直 commit の例外
+
+main 直 commit は例外扱いにする。
+
+許容する例外:
+
+- merge 後に見つかった typo の即時修正。
+- broken commit の最小修正。
+- GitHub / Notion 運用移行中の bootstrap。
+
+例外を使った場合でも、Notion worklog または follow-up Issue に理由を残す。
+
+## PR に書くこと
+
+- Summary: 何を変えたか。
+- Linked Issue: 対応 Issue。
+- Validation: 実行した検証。
+- Side Effects: install / secret / network / apply の有無。
+- Residual Risk: 残っているリスク。
+- Next: 次にやること。
+
+## 最低限の validation
+
+変更内容に応じて実行する。
+
+```sh
+./scripts/validate-policy.sh --all
+./scripts/test-policy.sh
+bash -n scripts/lib-policy.sh scripts/validate-policy.sh scripts/preflight.sh scripts/doctor.sh scripts/test-policy.sh
+git diff --check
+```
+
+`preflight` / `doctor` を変更した場合:
+
+```sh
+./scripts/preflight.sh work-minimal
+./scripts/doctor.sh work-minimal
+```
+
+## 禁止事項
+
+- Issue なしで大きな scope を始める。
+- PR に validation を書かずに merge する。
+- policy violation と report-only warning を混同する。
+- secret、token、private endpoint、会社・クライアント固有情報を Issue / PR に書く。
+- `main` へ常用的に直接 commit する。


### PR DESCRIPTION
## Summary
- Document the standard Issue -> branch -> PR -> merge workflow for Phase 2 and later.
- Add GitHub issue and pull request templates.
- Update README and AGENTS.md so future work follows the workflow.

## Linked Issue
Closes #1

## Validation
- [x] ./scripts/validate-policy.sh --all
- [x] ./scripts/test-policy.sh
- [x] bash -n scripts/lib-policy.sh scripts/validate-policy.sh scripts/preflight.sh scripts/doctor.sh scripts/test-policy.sh
- [x] git diff --check

## Side Effects
- Install side effects: none
- Secret access: none
- Network changes: GitHub issue/PR creation and branch push only
- chezmoi apply: no

## Residual Risk
- GitHub labels are not configured yet; this can be a follow-up if the workflow starts to need labels.

## Notes
No secrets, private endpoints, or organization/client-specific details are included.