### PR TITLE
Add Git identity separation foundation

### DIFF
--- a/docs/directory-convention.md
+++ b/docs/directory-convention.md
@@ -33,7 +33,12 @@ Git config では `user.useConfigOnly = true` を使い、known directory 外で
 
 [includeIf "gitdir:~/src/sandbox/"]
   path = ~/.config/git/sandbox.gitconfig
+
+[includeIf "gitdir:~/src/agent/"]
+  path = ~/.config/git/agent.gitconfig
 ```
+
+実体は `dot_gitconfig.tmpl` が管理する。identity file の置き場所と扱いは `docs/git-identity.md` に従う。
 
 ## Rules
 

--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -1,0 +1,62 @@
+# Git Identity
+
+Git identity の分離方針。実 identity 値(`user.name` / `user.email`)はこの repository に入れない。
+
+## 方針
+
+- `~/.gitconfig` は chezmoi が `dot_gitconfig.tmpl` から生成する。identity 値は含まない。
+- `user.useConfigOnly = true` により、identity が解決されない directory では commit が失敗する。
+- `transfer.credentialsInUrl = die` により、credential 入り remote URL を拒否する。
+- identity 値は context ごとの local file に置き、`includeIf` で directory convention に紐づける。
+
+## Identity context と local file
+
+| context | project root | identity file |
+| --- | --- | --- |
+| personal | `~/src/personal/` | `~/.config/git/personal.gitconfig` |
+| work | `~/src/work/` | `~/.config/git/work.gitconfig` |
+| client | `~/src/client/` | `~/.config/git/client.gitconfig` |
+| sandbox | `~/src/sandbox/` | `~/.config/git/sandbox.gitconfig` |
+| agent | `~/src/agent/` | `~/.config/git/agent.gitconfig` |
+
+identity file の中身は最小限にする。
+
+```ini
+[user]
+	name = Example Name
+	email = example@example.invalid
+```
+
+## Local identity file の扱い
+
+- identity file は手元で作成し、この repository には commit しない。
+- chezmoi の管理対象にもしない。secret store からの自動 fetch もしない。
+- 会社・クライアント固有の値(実名、メールアドレス、組織名、内部 URL)は identity file 側にのみ存在する。
+- 使わない context の identity file は作らなくてよい。その context では commit が失敗するだけで、安全側に倒れる。
+- client 配下で client ごとに identity を変える場合は、`client.gitconfig` の中でさらに `includeIf` を重ねる。重ねた先も local file に限る。
+
+## Unknown directory での挙動
+
+known project root(`~/src/{personal,work,client,sandbox,agent}/`)の外では、どの identity file も include されない。
+`useConfigOnly = true` のため、Git は identity を自動推測せず、commit は以下のように失敗する。
+
+```text
+fatal: no email was given and auto-detection is disabled
+```
+
+これは意図した挙動。誤った identity で commit するより、commit できない方を選ぶ。
+
+## 検査
+
+- `scripts/doctor.sh` は report-only で以下を確認する。
+  - `user.useConfigOnly=true` / `transfer.credentialsInUrl=die`
+  - 各 context の identity file が存在するか、意図的に未設定か。
+- `scripts/preflight.sh` は apply 前に既存の home Git config(`~/.gitconfig`、`~/.config/git/config`)と
+  global identity の設定有無を検知する。値そのものは表示しない。
+- `scripts/test-gitconfig.sh` は `dot_gitconfig.tmpl` の安全設定と includeIf の挙動を local fixture で検証する。
+
+## 対象外
+
+- Git signing(後続 `git-signing` module)。
+- secret store(1Password など)からの identity / signing material の取得。
+- Git remote mutation。

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -115,6 +115,12 @@ git diff --check
 ./scripts/doctor.sh work-minimal
 ```
 
+Git config template(`dot_gitconfig.tmpl`)を変更した場合:
+
+```sh
+./scripts/test-gitconfig.sh
+```
+
 ## 禁止事項
 
 - Issue なしで大きな scope を始める。

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,0 +1,27 @@
+# Managed by chezmoi from kosako/dotfiles.
+# This file must not contain real identity values.
+# Identity values live only in local files under ~/.config/git/.
+# See docs/git-identity.md.
+
+[user]
+	# Refuse to guess identity. Commits fail outside a configured context.
+	useConfigOnly = true
+
+[transfer]
+	# Refuse remote URLs that embed credentials.
+	credentialsInUrl = die
+
+[includeIf "gitdir:~/src/personal/"]
+	path = ~/.config/git/personal.gitconfig
+
+[includeIf "gitdir:~/src/work/"]
+	path = ~/.config/git/work.gitconfig
+
+[includeIf "gitdir:~/src/client/"]
+	path = ~/.config/git/client.gitconfig
+
+[includeIf "gitdir:~/src/sandbox/"]
+	path = ~/.config/git/sandbox.gitconfig
+
+[includeIf "gitdir:~/src/agent/"]
+	path = ~/.config/git/agent.gitconfig

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,7 +37,7 @@ unknown profile / module / capability や capability enum の不正値は policy
 
 ## preflight.sh
 
-導入前の危険検知を行う。既存 home file、必要 command、project root などを確認する。
+導入前の危険検知を行う。既存 home file、既存 Git config(`~/.gitconfig`、`~/.config/git/config`、global identity の設定有無。値は表示しない)、必要 command、project root などを確認する。
 副作用は持たない。既存 file や command 不足の warning は report-only として exit 0 のままにする。
 
 ```sh
@@ -48,7 +48,7 @@ policy validation が失敗した場合は exit 1。
 
 ## doctor.sh
 
-導入後または現状環境の健康診断を行う。chezmoi、Git、npm、Corepack、runtime、VS Code、1Password、project root の状態を表示する。
+導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、npm、Corepack、runtime、VS Code、1Password、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
 
 ```sh
@@ -74,6 +74,25 @@ policy validation が失敗した場合は exit 1。
 - unknown module を拒否すること。
 - unknown capability を拒否すること。
 - capability enum の不正値を拒否すること。
+
+## test-gitconfig.sh
+
+`dot_gitconfig.tmpl` の Git identity 安全境界を検証する。
+
+```sh
+./scripts/test-gitconfig.sh
+```
+
+検証内容:
+
+- template に `user.useConfigOnly = true` と `transfer.credentialsInUrl = die` が含まれること。
+- 全 context(personal / work / client / sandbox / agent)の `includeIf` と include path が定義されていること。
+- template に identity 値(`name =` / `email =`、email らしき値)が含まれないこと。
+- local fixture で、known root 外では commit が失敗すること。
+- local fixture で、`~/src/personal/` 配下では identity file の identity が解決されること。
+- credential 入り remote URL が拒否されること。
+
+fixture は一時 directory に作り、実際の home や global Git config には触れない。
 
 ## lib-policy.sh
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -55,6 +55,19 @@ else
   warn "git not found"
 fi
 
+section "Git identity contexts"
+for context in personal work client sandbox agent; do
+  identity_file="$HOME/.config/git/$context.gitconfig"
+  project_root="$HOME/src/$context"
+  if [[ -f "$identity_file" ]]; then
+    ok "identity file exists: $identity_file"
+  elif [[ -d "$project_root" ]]; then
+    warn "project root exists but identity file missing: $identity_file"
+  else
+    item "context unused, identity file not configured: $context"
+  fi
+done
+
 section "npm hardening"
 npm_mode="$(capability_value "$profile" npmHardeningMode)"
 ok "npmHardeningMode=$npm_mode"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -36,6 +36,31 @@ for file in "$HOME/.zshrc" "$HOME/.zprofile" "$HOME/.gitconfig" "$HOME/.ssh/conf
   fi
 done
 
+section "existing Git config"
+if [[ -e "$HOME/.config/git/config" ]]; then
+  warn "exists: $HOME/.config/git/config"
+else
+  ok "absent: $HOME/.config/git/config"
+fi
+for context in personal work client sandbox agent; do
+  identity_file="$HOME/.config/git/$context.gitconfig"
+  if [[ -e "$identity_file" ]]; then
+    item "identity file already present: $identity_file"
+  fi
+done
+if command -v git >/dev/null 2>&1; then
+  if git config --global --get user.name >/dev/null 2>&1; then
+    warn "global user.name is set (value not shown)"
+  else
+    ok "global user.name not set"
+  fi
+  if git config --global --get user.email >/dev/null 2>&1; then
+    warn "global user.email is set (value not shown)"
+  else
+    ok "global user.email not set"
+  fi
+fi
+
 section "commands"
 for command_name in git chezmoi brew op node npm corepack mise direnv code yq shellcheck shfmt; do
   command_status "$command_name" || true

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+GITCONFIG_TEMPLATE="$DOTFILES_ROOT/dot_gitconfig.tmpl"
+
+status=0
+tmp_roots=()
+
+cleanup() {
+  local dir
+  if [[ "${#tmp_roots[@]}" -eq 0 ]]; then
+    return 0
+  fi
+  for dir in "${tmp_roots[@]}"; do
+    rm -rf "$dir"
+  done
+}
+trap cleanup EXIT
+
+check_contains() {
+  local name="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$GITCONFIG_TEMPLATE"; then
+    ok "test passed: $name"
+  else
+    fail "test failed: $name (missing: $needle)"
+    status=1
+  fi
+}
+
+section "static checks: dot_gitconfig.tmpl"
+
+if [[ ! -f "$GITCONFIG_TEMPLATE" ]]; then
+  fail "missing template: $GITCONFIG_TEMPLATE"
+  exit 1
+fi
+
+check_contains "user.useConfigOnly enabled" "useConfigOnly = true"
+check_contains "transfer.credentialsInUrl die" "credentialsInUrl = die"
+
+for context in personal work client sandbox agent; do
+  check_contains "includeIf for $context" "[includeIf \"gitdir:~/src/$context/\"]"
+  check_contains "include path for $context" "path = ~/.config/git/$context.gitconfig"
+done
+
+if grep -Eq '^[[:space:]]*(name|email)[[:space:]]*=' "$GITCONFIG_TEMPLATE"; then
+  fail "test failed: template contains an identity assignment"
+  status=1
+else
+  ok "test passed: no identity assignment in template"
+fi
+
+if grep -q '@' "$GITCONFIG_TEMPLATE"; then
+  fail "test failed: template contains an @ (possible email value)"
+  status=1
+else
+  ok "test passed: no email-like value in template"
+fi
+
+section "fixture checks: identity resolution"
+
+if ! command -v git >/dev/null 2>&1; then
+  warn "git not found, skipping fixture checks"
+  exit "$status"
+fi
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-gitconfig-test.XXXXXX")"
+tmp_roots+=("$fixture")
+# includeIf "gitdir:~/..." compares against the physical git dir path,
+# so HOME must be the physical path too.
+fixture="$(cd "$fixture" && pwd -P)"
+
+run_git() {
+  local repo="$1"
+  shift
+  env -u EMAIL -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \
+    HOME="$fixture" \
+    XDG_CONFIG_HOME="$fixture/.config" \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL="$GITCONFIG_TEMPLATE" \
+    git -C "$repo" "$@"
+}
+
+mkdir -p "$fixture/src/personal/demo" "$fixture/outside/demo" "$fixture/.config/git"
+
+cat > "$fixture/.config/git/personal.gitconfig" <<'EOF'
+[user]
+	name = Dotfiles Test
+	email = dotfiles-test@example.invalid
+EOF
+
+run_git "$fixture/outside/demo" init --quiet --initial-branch=main
+if output="$(run_git "$fixture/outside/demo" commit --allow-empty -m test 2>&1)"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: commit succeeded outside known roots"
+  status=1
+else
+  ok "test passed: commit fails outside known roots"
+fi
+
+run_git "$fixture/src/personal/demo" init --quiet --initial-branch=main
+if output="$(run_git "$fixture/src/personal/demo" commit --allow-empty -m test 2>&1)"; then
+  author="$(run_git "$fixture/src/personal/demo" log -1 --format='%ae')"
+  if [[ "$author" == "dotfiles-test@example.invalid" ]]; then
+    ok "test passed: personal context resolves test identity"
+  else
+    fail "test failed: unexpected author email: $author"
+    status=1
+  fi
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: commit failed in personal context"
+  status=1
+fi
+
+if output="$(run_git "$fixture/src/personal/demo" ls-remote https://user:secret-placeholder@invalid.example/repo.git 2>&1)"; then
+  fail "test failed: credential URL was not rejected"
+  status=1
+elif grep -qi "credential" <<< "$output"; then
+  ok "test passed: credential URL rejected"
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: credential URL failed for another reason"
+  status=1
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "gitconfig tests passed"
+fi
+exit "$status"


### PR DESCRIPTION
## Summary

- `dot_gitconfig.tmpl` を追加し、Git の baseline safety 設定のみを入れた。
  - `user.useConfigOnly = true`(unknown directory では identity が解決されず commit が失敗する)
  - `transfer.credentialsInUrl = die`(credential 入り remote URL を拒否する)
  - directory convention に基づく 5 context(personal / work / client / sandbox / agent)の `includeIf`
- 実 identity 値の置き場所(`~/.config/git/<context>.gitconfig`、local only・commit しない)を `docs/git-identity.md` に定義した。
- `doctor.sh` に Git identity context の report-only check を追加した(identity file が存在するか、意図的に未設定か)。
- `preflight.sh` に apply 前の既存 Git config 検知を追加した(`~/.config/git/config`、既存 identity file、global `user.name` / `user.email` の設定有無。値は表示しない)。
- `scripts/test-gitconfig.sh` を追加し、local fixture で安全境界を検証できるようにした。
- `scripts/README.md` / `docs/github-workflow.md` / `docs/directory-convention.md` を追随更新した。

## Linked Issue

Closes #3

## Validation

- [x] `./scripts/validate-policy.sh --all` → exit 0
- [x] `./scripts/test-policy.sh` → exit 0
- [x] `./scripts/test-gitconfig.sh` → exit 0(static check、known root 外での commit 失敗、personal context での identity 解決、credential URL 拒否をすべて確認)
- [x] `bash -n scripts/lib-policy.sh scripts/validate-policy.sh scripts/preflight.sh scripts/doctor.sh scripts/test-policy.sh scripts/test-gitconfig.sh` → exit 0
- [x] `./scripts/doctor.sh work-minimal` → exit 0(report-only warning のみ)
- [x] `./scripts/preflight.sh work-minimal` → exit 0(report-only warning のみ)
- [x] `git diff --check` → clean

## Side Effects

- Install side effects: none
- Secret access: none
- Network changes: none
- `chezmoi apply`: no

## Residual Risk

- `dot_gitconfig.tmpl` はまだ host に apply していない。実際の `~/.gitconfig` 生成は後続の apply 作業で行う。
- identity file は手動作成の運用なので、作り忘れると該当 context で commit が失敗する(意図した fail-closed 挙動だが、doctor の warning で気づける)。
- `test-gitconfig.sh` の fixture は git の `includeIf gitdir:` 挙動に依存する。古い git(2.28 未満)では `--initial-branch` が使えない。

## Notes

実 identity 値、会社・クライアント固有情報、credential は含まれていない。template 内に identity 値や email らしき文字列が混入していないことは `test-gitconfig.sh` の static check で継続的に検査される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)