### PR TITLE
Add report-only Git remote URL credential scan

### DIFF
--- a/docs/supply-chain-git.md
+++ b/docs/supply-chain-git.md
@@ -1,0 +1,36 @@
+# Supply Chain: Git
+
+`supply-chain/git` module の方針。Git 経由の credential 漏洩を防ぐ。
+
+## 二段構え
+
+1. 予防: `transfer.credentialsInUrl = die`(`dot_gitconfig.tmpl`)
+   - password 部を含む URL での fetch / push / clone を Git 自体が拒否する。
+2. 検出: `doctor.sh` の remote URL scan(report-only)
+   - すでに設定済みの remote URL に credential らしき userinfo(`scheme://user:password@host`)が残っていないかを検査する。
+   - `transfer.credentialsInUrl` は転送時にしか効かないため、設定済み remote の棚卸しは doctor が担当する。
+
+## doctor の remote URL scan
+
+- 検査対象: dotfiles repo 自身と、known project roots(`~/src/{personal,work,client,sandbox,agent}`)配下の Git repository。
+- 検出時は repo path と remote 名だけを表示する。URL や credential の値は表示しない。
+- report-only。remote の変更・削除はしない。warning だけでは exit code を変えない。
+- username のみの userinfo(`https://user@host`)は警告しない。Git の `credentialsInUrl` と同様に、password 部があるものだけを対象にする。
+- 検出ロジックは `scripts/lib-policy.sh` の `git_remotes_with_credentials` に置き、`scripts/test-gitconfig.sh` の fixture で検証する。
+
+## 検出された場合の対処
+
+remote URL から credential を取り除き、credential helper(macOS keychain、`gh auth` など)に移す。
+
+```sh
+git -C <repo> remote set-url <remote> <credential を含まない URL>
+```
+
+この操作は手動で行う。script からは実行しない。
+
+## 対象外
+
+- Git remote の自動変更・修復。
+- credential の削除や書き換え。
+- 会社・クライアント固有 host の列挙や allow / deny list。
+- secret store へのアクセス。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,8 +48,9 @@ policy validation が失敗した場合は exit 1。
 
 ## doctor.sh
 
-導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、npm、Corepack、runtime、VS Code、1Password、project root の状態を表示する。
+導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
+remote URL scan の方針は `docs/supply-chain-git.md` に従う。
 
 ```sh
 ./scripts/doctor.sh personal
@@ -91,10 +92,12 @@ policy validation が失敗した場合は exit 1。
 - local fixture で、known root 外では commit が失敗すること。
 - local fixture で、`~/src/personal/` 配下では identity file の identity が解決されること。
 - credential 入り remote URL が拒否されること。
+- credential らしき remote URL(`scheme://user:password@host`)を `git_remotes_with_credentials` が検出すること。
+- credential なし・username のみの remote URL は誤検出しないこと。
 
 fixture は一時 directory に作り、実際の home や global Git config には触れない。
 
 ## lib-policy.sh
 
 他 script から source される共通 helper。
-data file path、profile/module/capability 取得、出力 helper、command availability check を提供する。
+data file path、profile/module/capability 取得、出力 helper、command availability check、Git remote credential 検出(`git_remotes_with_credentials`。remote 名のみを出力し、URL 値は出力しない)を提供する。

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -68,6 +68,32 @@ for context in personal work client sandbox agent; do
   fi
 done
 
+section "Git remote URLs"
+if ! command -v git >/dev/null 2>&1; then
+  warn "git not found, skipping remote URL scan"
+else
+  scanned_repos=0
+  flagged_remotes=0
+  for root in "$DOTFILES_ROOT" "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/sandbox" "$HOME/src/agent"; do
+    [[ -d "$root" ]] || continue
+    while IFS= read -r git_marker; do
+      repo="$(dirname "$git_marker")"
+      scanned_repos=$((scanned_repos + 1))
+      while IFS= read -r remote_name; do
+        [[ -z "$remote_name" ]] && continue
+        flagged_remotes=$((flagged_remotes + 1))
+        warn "credential-like userinfo in remote URL: repo=$repo remote=$remote_name (URL not shown)"
+      done < <(git_remotes_with_credentials "$repo")
+    done < <(find "$root" -maxdepth 4 -name .git -prune -print 2>/dev/null)
+  done
+  ok "scanned repositories: $scanned_repos"
+  if [[ "$flagged_remotes" -eq 0 ]]; then
+    ok "no credential-like userinfo in remote URLs"
+  else
+    warn "remotes with credential-like userinfo: $flagged_remotes"
+  fi
+fi
+
 section "npm hardening"
 npm_mode="$(capability_value "$profile" npmHardeningMode)"
 ok "npmHardeningMode=$npm_mode"

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -168,6 +168,19 @@ is_allowed_environment_kind() {
   esac
 }
 
+# Print names of remotes whose URL embeds password-like userinfo
+# (scheme://user:password@host). URL values are never printed.
+git_remotes_with_credentials() {
+  local repo="$1"
+  git -C "$repo" config --local --get-regexp '^remote\..*\.url$' 2>/dev/null |
+    awk '$2 ~ /:\/\/[^\/@]*:[^\/@]+@/ {
+      name = $1
+      sub(/^remote\./, "", name)
+      sub(/\.url$/, "", name)
+      print name
+    }'
+}
+
 command_status() {
   local command_name="$1"
   if command -v "$command_name" >/dev/null 2>&1; then

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -128,6 +128,33 @@ else
   status=1
 fi
 
+section "fixture checks: remote URL credentials"
+
+# Write remote URLs via `git config` so the check never depends on
+# transport behavior. Values stay inside the fixture.
+run_git "$fixture/src/personal/demo" config remote.origin.url "https://invalid.example/repo.git"
+run_git "$fixture/src/personal/demo" config remote.upstream.url "https://user@invalid.example/repo.git"
+
+flagged="$(git_remotes_with_credentials "$fixture/src/personal/demo")"
+if [[ -z "$flagged" ]]; then
+  ok "test passed: clean and username-only remotes are not flagged"
+else
+  fail "test failed: unexpected flagged remotes: $flagged"
+  status=1
+fi
+
+mkdir -p "$fixture/src/personal/remote-demo"
+run_git "$fixture/src/personal/remote-demo" init --quiet --initial-branch=main
+run_git "$fixture/src/personal/remote-demo" config remote.origin.url "https://user:secret-placeholder@invalid.example/repo.git"
+
+flagged="$(git_remotes_with_credentials "$fixture/src/personal/remote-demo")"
+if [[ "$flagged" == "origin" ]]; then
+  ok "test passed: credential-like remote URL detected"
+else
+  fail "test failed: expected flagged remote 'origin', got: ${flagged:-<none>}"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "gitconfig tests passed"
 fi


### PR DESCRIPTION
## Summary

- `scripts/lib-policy.sh` に `git_remotes_with_credentials` を追加した。remote URL に password らしき userinfo(`scheme://user:password@host`)が含まれる remote の **名前だけ** を出力する。URL の値は一切出力しない。
- `doctor.sh` に「Git remote URLs」section を追加した。dotfiles repo 自身と known project roots(`~/src/{personal,work,client,sandbox,agent}`)配下の Git repository を走査し、検出時は repo path と remote 名のみを `[warn]` で表示する。report-only で exit code は変えない。
- `docs/supply-chain-git.md` を追加し、予防(`transfer.credentialsInUrl=die`)と検出(doctor scan)の責務分担、検出時の手動対処、対象外を文書化した。
- `scripts/test-gitconfig.sh` に fixture test を追加した。credential 入り remote URL の検出と、credential なし / username のみ URL を誤検出しないことを確認する。fixture への URL 設定は transport を経由しない `git config` 書き込みで行い、`credentialsInUrl=die` 環境でもテストが壊れないようにした。
- `scripts/README.md` を追随更新した。

## Linked Issue

Closes #4

## Validation

- [x] `./scripts/validate-policy.sh --all` → exit 0
- [x] `./scripts/test-policy.sh` → exit 0
- [x] `./scripts/test-gitconfig.sh` → exit 0(検出 / 非検出の両 fixture を含む全 20 check pass)
- [x] `bash -n scripts/lib-policy.sh scripts/validate-policy.sh scripts/preflight.sh scripts/doctor.sh scripts/test-policy.sh scripts/test-gitconfig.sh` → exit 0
- [x] `./scripts/doctor.sh work-minimal` → exit 0(scanned repositories: 1、credential 検出なし)
- [x] `./scripts/preflight.sh work-minimal` → exit 0
- [x] `git diff --check` → clean

## Side Effects

- Install side effects: none
- Secret access: none
- Network changes: none(scan は local の git config 読み取りのみ)
- Git remote mutation: none
- `chezmoi apply`: no

## Residual Risk

- 検出は `scheme://` 形式の URL のみ対象。scp-like 形式(`git@host:path`)は password を持てないため対象外(意図どおり)。
- scan の探索深さは known roots から `-maxdepth 4`(`work/<org>/<repo>/.git` まで)。それより深い非標準配置の repo は走査されない。
- username のみの userinfo(`https://user@host`)は Git 本体の `credentialsInUrl` と同様に警告しない。

## Notes

secret、credential、会社・クライアント固有値は含まれていない。test fixture 内の credential は明示的な placeholder 値のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)