### PR TITLE
Implement npm hardening mode

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,0 +1,6 @@
+{{- $caps := index .profiles .profile "capabilities" -}}
+{{/* .npmrc is managed only when the profile enforces npm hardening.
+     In off/report modes the home .npmrc stays unmanaged. */}}
+{{ if ne $caps.npmHardeningMode "enforce" }}
+.npmrc
+{{ end }}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ chezmoi apply --source ~/dotfiles
 - unknown profile / module / capability は fail closed にする。
 - `doctor` は副作用を持たない。
 - `preflight` は導入前の危険検知に限定する。
+- npm hardening の方針と `ignore-scripts=true` の逃げ道は [docs/supply-chain-npm.md](docs/supply-chain-npm.md) を参照する。
 
 ## GitHub Workflow
 

--- a/docs/supply-chain-npm.md
+++ b/docs/supply-chain-npm.md
@@ -1,0 +1,62 @@
+# Supply Chain: npm
+
+`supply-chain/npm` module の方針。npm 経由の supply-chain 攻撃(install script、typosquatting、公開直後の悪性 version)への防御を `npmHardeningMode` capability で段階制御する。
+
+## Mode
+
+```text
+off     何も管理しない。doctor も npm hardening を検査しない前提の profile 向け。
+report  ~/.npmrc は管理しない。doctor が現在の npm config を表示するだけ。
+enforce chezmoi が ~/.npmrc を管理し、hardening 設定を出力する。
+```
+
+- `report` / `off` では `.chezmoiignore` により `~/.npmrc` は chezmoi の管理対象外になる(既存 `.npmrc` を上書きしない)。
+- `enforce` は現在 `personal` profile のみ。work 系は `report` で、会社側の npm 設定を壊さない。
+
+## enforce 時の `~/.npmrc`
+
+`dot_npmrc.tmpl` が出力する設定とその意図:
+
+```text
+ignore-scripts=true    install 時の lifecycle script(postinstall 等)を実行しない
+save-exact=true        依存を range ではなく exact version で保存する
+fund=false             funding 表示を抑制する(ノイズ削減)
+audit=true             install 時の audit を有効に保つ
+min-release-age=10080  公開から 7 日未満の version を install しない(分単位)
+```
+
+token、registry URL、auth 設定は一切含めない。それらは project 側または環境側の責務で、この repo では扱わない。
+
+## `ignore-scripts=true` の逃げ道
+
+build script が必要な package(esbuild、sharp など)は install 後に明示的に実行する。
+
+```sh
+npm install
+npm rebuild <package> --foreground-scripts
+```
+
+または、信頼できる project に限り project local で override する。
+
+```sh
+npm install --ignore-scripts=false
+```
+
+project の `.npmrc` に `ignore-scripts=false` を置く方法もあるが、その project の依存全体に効くため、理由を project 側に書き残すこと。
+
+## `min-release-age` の注意
+
+- npm 11.6 以降でサポートされる。古い npm では unknown config として warning が出るだけで、保護は効かない。
+- `doctor.sh` が npm version と各設定値を report-only で表示する。
+
+## doctor の検査
+
+- `npmHardeningMode` と npm version、主要 config 値を表示する。
+- `enforce` の場合は、期待値(上記)と現在の `npm config get` の値を比較し、不一致を `[warn]` で報告する。
+  apply 前は不一致になるのが正常。report-only で exit code は変えない。
+
+## 対象外
+
+- npm package の install / 削除。
+- private registry、token、auth config。
+- 会社・クライアント固有 registry の扱い(work 側環境の責務)。

--- a/dot_npmrc.tmpl
+++ b/dot_npmrc.tmpl
@@ -1,0 +1,10 @@
+{{- $caps := index .profiles .profile "capabilities" -}}
+{{- if eq $caps.npmHardeningMode "enforce" -}}
+# Managed by chezmoi from kosako/dotfiles (npmHardeningMode=enforce).
+# No tokens, no registry overrides. See docs/supply-chain-npm.md.
+ignore-scripts=true
+save-exact=true
+fund=false
+audit=true
+min-release-age=10080
+{{- end -}}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,7 +50,8 @@ policy validation が失敗した場合は exit 1。
 
 導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
-remote URL scan の方針は `docs/supply-chain-git.md` に従う。
+remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md` に従う。
+`npmHardeningMode=enforce` の profile では、期待する npm config 値と現在値の不一致を `[warn]` で報告する(apply 前は不一致が正常)。
 
 ```sh
 ./scripts/doctor.sh personal
@@ -96,6 +97,24 @@ policy validation が失敗した場合は exit 1。
 - credential なし・username のみの remote URL は誤検出しないこと。
 
 fixture は一時 directory に作り、実際の home や global Git config には触れない。
+
+## test-npmrc.sh
+
+`dot_npmrc.tmpl` と `.chezmoiignore` の npm hardening 設定を静的に検証する。
+
+```sh
+./scripts/test-npmrc.sh
+```
+
+検証内容:
+
+- template が `npmHardeningMode=enforce` でのみ内容を出力するよう gate されていること。
+- 期待する hardening 設定(`ignore-scripts=true` など)が定義されていること。
+- token、registry 設定が含まれないこと。
+- `.chezmoiignore` が enforce 以外で `.npmrc` を管理対象外にすること。
+- template の設定値と `doctor.sh` の enforce 期待値が一致していること。
+
+chezmoi が未導入でも実行できるよう、render はせず静的検査に留める。
 
 ## lib-policy.sh
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -97,14 +97,41 @@ fi
 section "npm hardening"
 npm_mode="$(capability_value "$profile" npmHardeningMode)"
 ok "npmHardeningMode=$npm_mode"
-if command -v npm >/dev/null 2>&1; then
-  ok "npm: $(npm --version)"
-  for key in min-release-age ignore-scripts fund audit userconfig globalconfig; do
+if [[ "$npm_mode" == "off" ]]; then
+  ok "npm hardening intentionally unmanaged"
+elif ! command -v npm >/dev/null 2>&1; then
+  warn "npm not found"
+else
+  npm_version="$(npm --version)"
+  ok "npm: $npm_version"
+  for key in min-release-age ignore-scripts save-exact fund audit userconfig globalconfig; do
     value="$(npm config get "$key" 2>/dev/null || true)"
     item "npm $key=$value"
   done
-else
-  warn "npm not found"
+  npm_major="${npm_version%%.*}"
+  npm_minor="$(printf '%s' "$npm_version" | cut -d. -f2)"
+  if [[ "$npm_major" -gt 11 || ( "$npm_major" -eq 11 && "$npm_minor" -ge 6 ) ]] 2>/dev/null; then
+    ok "npm supports min-release-age (>= 11.6)"
+  else
+    warn "npm older than 11.6, min-release-age is not enforced"
+  fi
+  if [[ "$npm_mode" == "enforce" ]]; then
+    while IFS='=' read -r key expected; do
+      [[ -z "$key" ]] && continue
+      actual="$(npm config get "$key" 2>/dev/null || true)"
+      if [[ "$actual" == "$expected" ]]; then
+        ok "npm $key=$expected"
+      else
+        warn "enforce expects npm $key=$expected, current: $actual (apply pending?)"
+      fi
+    done <<'EOF'
+ignore-scripts=true
+save-exact=true
+fund=false
+audit=true
+min-release-age=10080
+EOF
+  fi
 fi
 
 section "Corepack"

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+NPMRC_TEMPLATE="$DOTFILES_ROOT/dot_npmrc.tmpl"
+CHEZMOIIGNORE="$DOTFILES_ROOT/.chezmoiignore"
+
+status=0
+
+check_file_contains() {
+  local name="$1"
+  local file="$2"
+  local needle="$3"
+  if grep -Fq "$needle" "$file"; then
+    ok "test passed: $name"
+  else
+    fail "test failed: $name (missing in $file: $needle)"
+    status=1
+  fi
+}
+
+section "static checks: dot_npmrc.tmpl"
+
+if [[ ! -f "$NPMRC_TEMPLATE" ]]; then
+  fail "missing template: $NPMRC_TEMPLATE"
+  exit 1
+fi
+
+check_file_contains "gated on enforce mode" "$NPMRC_TEMPLATE" 'eq $caps.npmHardeningMode "enforce"'
+for needle in "ignore-scripts=true" "save-exact=true" "fund=false" "audit=true" "min-release-age=10080"; do
+  check_file_contains "hardening setting: $needle" "$NPMRC_TEMPLATE" "$needle"
+done
+
+if grep -Eq '_authToken|registry=|^//' "$NPMRC_TEMPLATE"; then
+  fail "test failed: template contains token or registry configuration"
+  status=1
+else
+  ok "test passed: no token or registry configuration in template"
+fi
+
+section "static checks: .chezmoiignore"
+
+if [[ ! -f "$CHEZMOIIGNORE" ]]; then
+  fail "missing file: $CHEZMOIIGNORE"
+  exit 1
+fi
+
+check_file_contains "ignores .npmrc outside enforce" "$CHEZMOIIGNORE" ".npmrc"
+check_file_contains "ignore gated on npmHardeningMode" "$CHEZMOIIGNORE" 'ne $caps.npmHardeningMode "enforce"'
+
+section "consistency: doctor enforce expectations"
+
+while IFS= read -r line; do
+  if grep -Fq "$line" "$SCRIPT_DIR/doctor.sh"; then
+    ok "test passed: doctor expects $line"
+  else
+    fail "test failed: doctor.sh does not expect template setting: $line"
+    status=1
+  fi
+done < <(grep -E '^[a-z-]+=' "$NPMRC_TEMPLATE")
+
+if [[ "$status" -eq 0 ]]; then
+  ok "npmrc tests passed"
+fi
+exit "$status"


### PR DESCRIPTION
## Summary

- `dot_npmrc.tmpl` を追加した。`npmHardeningMode=enforce` の profile でのみ hardening 設定(`ignore-scripts=true`、`save-exact=true`、`fund=false`、`audit=true`、`min-release-age=10080`)を出力する。token / registry / auth 設定は含まない。
- `.chezmoiignore` を追加し、`off` / `report` の profile では `~/.npmrc` を chezmoi の管理対象外にした(既存 `.npmrc` を上書きしない)。
- `doctor.sh` の npm section を mode 対応にした。`off` は検査スキップ、`report` は現在値の表示のみ、`enforce` は期待値と `npm config get` の比較を `[warn]` で報告(report-only、exit code 不変)。npm が `min-release-age` をサポートする version(>= 11.6)かどうかも表示する。
- `docs/supply-chain-npm.md` を追加し、各 mode の挙動、enforce 設定の意図、`ignore-scripts=true` の逃げ道(`npm rebuild <pkg> --foreground-scripts` など)を文書化した。
- `scripts/test-npmrc.sh` を追加した。template の enforce gate、hardening 設定の存在、token / registry 不在、`.chezmoiignore` の gate、template と doctor の期待値一致を静的に検証する。
- root README に supply-chain-npm docs への参照を追加した。

## Linked Issue

Closes #5

## Validation

- [x] `./scripts/validate-policy.sh --all` → exit 0
- [x] `./scripts/test-policy.sh` → exit 0
- [x] `./scripts/test-npmrc.sh` → exit 0(全 15 check pass)
- [x] `./scripts/test-gitconfig.sh` → exit 0
- [x] `bash -n scripts/*.sh` → exit 0
- [x] `./scripts/doctor.sh work-minimal`(report)→ exit 0
- [x] `./scripts/doctor.sh personal`(enforce)→ exit 0(apply 前のため期待値不一致が warn で出るのは想定どおり)
- [x] `git diff --check` → clean

chezmoi が host 未導入のため template render の実機確認は未実施。静的検査(`test-npmrc.sh`)で代替し、render 確認は Issue #9(初回 apply)の `chezmoi diff` で行う。

## Side Effects

- Install side effects: none
- Secret access: none
- Network changes: none
- `chezmoi apply`: no

## Residual Risk

- template render の実機確認は Issue #9 の `chezmoi diff` まで未実施(`.chezmoiignore` の gate 条件含む)。
- `min-release-age` は npm 11.6 未満では unknown config warning になるだけで保護が効かない(doctor が version を report する)。
- `enforce` は現在 `personal` のみ。work 系 profile は `report` のまま。

## Notes

token、registry URL、会社・クライアント固有値は含まれていない。`test-npmrc.sh` が token / registry 混入を継続的に検査する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)