### PR TITLE
Implement Corepack policy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ chezmoi apply --source ~/dotfiles
 - `doctor` は副作用を持たない。
 - `preflight` は導入前の危険検知に限定する。
 - npm hardening の方針と `ignore-scripts=true` の逃げ道は [docs/supply-chain-npm.md](docs/supply-chain-npm.md) を参照する。
+- Corepack は暗黙に enable しない。方針は [docs/supply-chain-corepack.md](docs/supply-chain-corepack.md) を参照する。
 
 ## GitHub Workflow
 

--- a/docs/supply-chain-corepack.md
+++ b/docs/supply-chain-corepack.md
@@ -1,0 +1,53 @@
+# Supply Chain: Corepack
+
+`supply-chain/corepack` module の方針。Corepack の availability と `packageManager` field の扱いを `corepackMode` capability で段階制御する。
+
+## Mode
+
+```text
+off     何も管理しない。doctor も Corepack を検査しない前提の profile 向け。
+report  doctor が Corepack の availability と version を表示するだけ(default)。
+enable  明示 opt-in。`corepack enable` を実行済みであることを前提に doctor が shim を確認する。
+```
+
+- 現在の全 profile は `report`。
+- `enable` にしても、dotfiles の script が `corepack enable` を実行することはない。有効化は必ず手動で行う。
+
+```sh
+corepack enable
+```
+
+## `packageManager` field の方針
+
+- project ごとに `package.json` の `packageManager` field で package manager を exact version で pin する。
+
+```json
+{
+  "packageManager": "pnpm@10.0.0"
+}
+```
+
+- pin は project 側の責務。dotfiles は global に package manager を強制しない。
+- project templates(Phase 6)に `packageManager` の例を含める予定。
+- range 指定や hash なしの曖昧な pin は避け、exact version を使う。
+
+## update policy との関係
+
+`docs/update-policy.md` の「自動 upgrade を避ける」方針と整合させる。
+
+- Corepack は `packageManager` の pin に従って package manager を取得する。pin が exact なら、勝手に新しい version へ上がることはない。
+- pin の更新は project 側での明示的な変更として行う。Corepack 側の自動 upgrade 機構には依存しない。
+- 注意: `corepack enable` 後、pin された package manager の初回実行時に Corepack が network から該当 version を取得する。これは `enable` の opt-in に含まれる副作用として扱う。
+
+## doctor の検査
+
+- `corepackMode` と Corepack の availability / version を表示する。
+- `off` では検査をスキップする。
+- `enable` では pnpm / yarn の shim が解決できるかを report-only で確認する。見つからない場合は `corepack enable` を手動実行するよう warning を出すだけで、実行はしない。
+
+## 対象外
+
+- Corepack の暗黙 enable(script からの `corepack enable` 実行)。
+- package manager の自動 install / upgrade。
+- project ごとの pin の強制。
+- private registry / token / auth config。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,7 +50,7 @@ policy validation が失敗した場合は exit 1。
 
 導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
-remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md` に従う。
+remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md`、Corepack の検査は `docs/supply-chain-corepack.md` に従う。
 `npmHardeningMode=enforce` の profile では、期待する npm config 値と現在値の不一致を `[warn]` で報告する(apply 前は不一致が正常)。
 
 ```sh

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -137,10 +137,22 @@ fi
 section "Corepack"
 corepack_mode="$(capability_value "$profile" corepackMode)"
 ok "corepackMode=$corepack_mode"
-if command -v corepack >/dev/null 2>&1; then
-  ok "corepack: $(corepack --version 2>/dev/null || true)"
-else
+if [[ "$corepack_mode" == "off" ]]; then
+  ok "corepack intentionally unmanaged"
+elif ! command -v corepack >/dev/null 2>&1; then
   warn "corepack not found"
+else
+  ok "corepack: $(corepack --version 2>/dev/null || true)"
+  if [[ "$corepack_mode" == "enable" ]]; then
+    for pm in pnpm yarn; do
+      pm_path="$(command -v "$pm" 2>/dev/null || true)"
+      if [[ -n "$pm_path" ]]; then
+        item "$pm shim: $pm_path"
+      else
+        warn "corepackMode=enable but $pm not resolvable (run 'corepack enable' manually)"
+      fi
+    done
+  fi
 fi
 
 section "runtime and shell"


### PR DESCRIPTION
## Summary

- `docs/supply-chain-corepack.md` を追加し、`corepackMode` の各 mode を文書化した。
  - `off`: 何も管理しない(doctor も検査スキップ)。
  - `report`(現在の全 profile の default): doctor が availability と version を表示するだけ。
  - `enable`: 明示 opt-in。`corepack enable` は必ず手動で実行し、script からは実行しない。
- `doctor.sh` の Corepack section を mode 対応にした。`enable` では pnpm / yarn が解決できるかを report-only で確認し、見つからない場合は手動実行を促す warning のみ出す。
- `packageManager` field は project 側で exact version pin とする方針を記載し、Phase 6 の project templates で例を入れることにした。
- `docs/update-policy.md` の自動 upgrade 回避方針との整合を整理した(exact pin なら Corepack が勝手に version を上げることはない。enable 後の初回実行時の network 取得は opt-in の副作用として明記)。
- root README に「Corepack は暗黙に enable しない」を追記した。

## Linked Issue

Closes #6

## Validation

- [x] `./scripts/validate-policy.sh --all` → exit 0
- [x] `./scripts/test-policy.sh` → exit 0
- [x] `./scripts/test-gitconfig.sh` → exit 0
- [x] `./scripts/test-npmrc.sh` → exit 0
- [x] `bash -n scripts/*.sh` → exit 0
- [x] `./scripts/doctor.sh work-minimal` → exit 0
- [x] `./scripts/doctor.sh personal` → exit 0(corepack 未導入のため `[warn] corepack not found`、report-only)
- [x] `git diff --check` → clean

## Side Effects

- Install side effects: none
- Secret access: none
- Network changes: none
- `chezmoi apply`: no

## Residual Risk

- `enable` mode の shim 確認は presence check のみで、shim が本当に Corepack 由来かまでは検査しない(report-only の範囲として許容)。
- 現在どの profile も `enable` ではないため、enable 経路の実機確認は将来 profile を切り替えたときに行う。

## Notes

secret、credential、private registry URL は含まれていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)