### PR TITLE
Add CI validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,38 @@
+name: validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      # actions/checkout v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: bash syntax check
+        run: bash -n scripts/*.sh
+
+      - name: shellcheck (warning and above)
+        run: shellcheck -S warning scripts/*.sh
+
+      - name: validate policy
+        run: ./scripts/validate-policy.sh --all
+
+      - name: policy fail-closed tests
+        run: ./scripts/test-policy.sh
+
+      - name: gitconfig safety tests
+        run: ./scripts/test-gitconfig.sh
+
+      - name: npmrc hardening tests
+        run: ./scripts/test-npmrc.sh
+
+      - name: git diff check
+        run: git diff --check

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -99,12 +99,14 @@ main 直 commit は例外扱いにする。
 
 ## 最低限の validation
 
-変更内容に応じて実行する。
+以下は GitHub Actions(`.github/workflows/validate.yml`)が PR ごとに自動実行する(shellcheck は warning 以上で fail)。手元での事前実行も引き続き推奨する。
 
 ```sh
 ./scripts/validate-policy.sh --all
 ./scripts/test-policy.sh
-bash -n scripts/lib-policy.sh scripts/validate-policy.sh scripts/preflight.sh scripts/doctor.sh scripts/test-policy.sh
+./scripts/test-gitconfig.sh
+./scripts/test-npmrc.sh
+bash -n scripts/*.sh
 git diff --check
 ```
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -190,4 +190,3 @@ command_status() {
   warn "$command_name: not found"
   return 1
 }
-if [[

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -190,3 +190,4 @@ command_status() {
   warn "$command_name: not found"
   return 1
 }
+if [[


### PR DESCRIPTION
## Summary

- `.github/workflows/validate.yml` を追加した。PR ごと、および main への push 時に標準 validation を自動実行する。
  - `bash -n scripts/*.sh`
  - `shellcheck -S warning scripts/*.sh`(warning 以上で fail。info / style は通す)
  - `./scripts/validate-policy.sh --all`
  - `./scripts/test-policy.sh` / `./scripts/test-gitconfig.sh` / `./scripts/test-npmrc.sh`
  - `git diff --check`
- `permissions: contents: read` に絞り、外部 action は `actions/checkout` のみ・SHA pin(v4.2.2)。
- `docs/github-workflow.md` の「最低限の validation」を CI 自動実行の記載に更新し、コマンド一覧を現行のテスト構成に追随させた。

## Linked Issue

Closes #18

## Validation

- [x] 手元で全 validation pass(validate-policy --all / test-policy / test-gitconfig / test-npmrc / bash -n / git diff --check)
- [ ] この PR 上で workflow が pass すること(CI 実行待ち → 結果をコメントで追記)
- [ ] 意図的に壊した commit で fail すること(確認後 revert)

## Side Effects

- Install side effects: none(CI runner 内のみ)
- Secret access: none(GITHUB_TOKEN の read 権限のみ)
- Network changes: none
- `chezmoi apply`: no

## Residual Risk

- shellcheck は手元未導入のため、この PR の CI が初回実行になる。warning が出た場合はこの PR 内で修正する。
- test-gitconfig.sh は Linux runner 上で初実行(macOS 固有挙動には依存していない想定)。

## Notes

secret、token、private endpoint は含まれていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)