### PR TITLE
Add project templates

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,4 +1,12 @@
 {{- $caps := index .profiles .profile "capabilities" -}}
+{{/* Repo-management files are never applied to the home directory. */}}
+README.md
+AGENTS.md
+LICENSE
+docs
+scripts
+templates
+
 {{/* .npmrc is managed only when the profile enforces npm hardening.
      In off/report modes the home .npmrc stays unmanaged. */}}
 {{ if ne $caps.npmHardeningMode "enforce" }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -112,6 +112,7 @@ fixture は一時 directory に作り、実際の home や global Git config に
 - 期待する hardening 設定(`ignore-scripts=true` など)が定義されていること。
 - token、registry 設定が含まれないこと。
 - `.chezmoiignore` が enforce 以外で `.npmrc` を管理対象外にすること。
+- `.chezmoiignore` が repo 管理用 file(README、docs、scripts、templates など)を home に apply しないこと。
 - template の設定値と `doctor.sh` の enforce 期待値が一致していること。
 
 chezmoi が未導入でも実行できるよう、render はせず静的検査に留める。

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -51,6 +51,10 @@ fi
 check_file_contains "ignores .npmrc outside enforce" "$CHEZMOIIGNORE" ".npmrc"
 check_file_contains "ignore gated on npmHardeningMode" "$CHEZMOIIGNORE" 'ne $caps.npmHardeningMode "enforce"'
 
+for entry in README.md AGENTS.md LICENSE docs scripts templates; do
+  check_file_contains "never applies repo file: $entry" "$CHEZMOIIGNORE" "$entry"
+done
+
 section "consistency: doctor enforce expectations"
 
 while IFS= read -r line; do

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,29 @@
+# templates
+
+新規 repository 用の初期 file 置き場。
+
+この directory は chezmoi の apply 対象ではない(`.chezmoiignore` で除外)。script による自動展開もしない。必要な file を手でコピーして使う。
+
+## 使い方
+
+```sh
+# 共通(まず generic を入れる)
+cp ~/dotfiles/templates/project/generic/.editorconfig <repo>/
+cp ~/dotfiles/templates/project/generic/.gitignore <repo>/
+
+# Node project なら重ねる
+cp ~/dotfiles/templates/project/node/.npmrc <repo>/
+cat ~/dotfiles/templates/project/node/.gitignore >> <repo>/.gitignore
+# package.json は templates/project/node/package.json を参考に作る
+
+# Python project なら重ねる
+cat ~/dotfiles/templates/project/python/.gitignore >> <repo>/.gitignore
+cp ~/dotfiles/templates/project/python/.mise.toml <repo>/
+```
+
+## 方針
+
+- template には secret、token、registry URL、会社・クライアント固有値を入れない。
+- node の `.npmrc` / `packageManager` は `docs/supply-chain-npm.md` / `docs/supply-chain-corepack.md` の方針に従う。
+- runtime の version pin は project 側の `.mise.toml` の責務(exact pin)。
+- devcontainer template は現時点では追加しない。コンテナ前提の開発を始める時点で別 Issue として判断する。

--- a/templates/project/generic/.editorconfig
+++ b/templates/project/generic/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/templates/project/generic/.gitignore
+++ b/templates/project/generic/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+*.log
+tmp/
+
+# Secrets stay out of git. Commit .env.example instead.
+.env
+.env.*
+!.env.example

--- a/templates/project/node/.gitignore
+++ b/templates/project/node/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+build/
+coverage/
+*.tsbuildinfo
+npm-debug.log*

--- a/templates/project/node/.npmrc
+++ b/templates/project/node/.npmrc
@@ -1,0 +1,5 @@
+# Project-level npm settings. No registry, no tokens here.
+# Global hardening (ignore-scripts etc.) comes from ~/.npmrc.
+# See ~/dotfiles/docs/supply-chain-npm.md for the escape hatch
+# when a dependency genuinely needs install scripts.
+save-exact=true

--- a/templates/project/node/package.json
+++ b/templates/project/node/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "CHANGE_ME",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@10.12.1",
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/templates/project/python/.gitignore
+++ b/templates/project/python/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+dist/
+build/
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/templates/project/python/.mise.toml
+++ b/templates/project/python/.mise.toml
@@ -1,0 +1,4 @@
+# Pin runtimes per project with exact versions.
+# See ~/dotfiles/docs/runtime.md (global mise config stays minimal).
+[tools]
+python = "3.13.5"


### PR DESCRIPTION
## Summary

- `templates/project/generic`(`.editorconfig`、`.gitignore`)、`templates/project/node`(`.npmrc`、`.gitignore`、exact `packageManager` pin 付き `package.json`)、`templates/project/python`(`.gitignore`、exact pin 付き `.mise.toml`)を追加した。
- `templates/README.md` に使い方(手動コピーのみ。script による自動展開はしない)と、devcontainer template を当面追加しない判断を記録した。
- node の `.npmrc` / `packageManager` は `docs/supply-chain-npm.md` / `docs/supply-chain-corepack.md` の方針(token / registry なし、exact pin)と整合している。
- **修正**: `.chezmoiignore` に repo 管理用 file(`README.md`、`AGENTS.md`、`LICENSE`、`docs`、`scripts`、`templates`)を追加した。従来のままだと `chezmoi apply` がこれらを home にコピーしてしまう状態だった(Issue #9 の実施前に直せてよかった点)。`test-npmrc.sh` がこの ignore 設定を継続的に検査する。

## Linked Issue

Closes #13

## Validation

- [x] `./scripts/validate-policy.sh --all` → exit 0
- [x] `./scripts/test-policy.sh` → exit 0
- [x] `./scripts/test-gitconfig.sh` → exit 0
- [x] `./scripts/test-npmrc.sh` → exit 0(repo file の ignore 検査 6 件を含む)
- [x] `bash -n scripts/*.sh` → exit 0
- [x] `git diff --check` → clean
- [ ] CI(validate workflow)pass

## Side Effects

- Install side effects: none
- Secret access: none
- Network changes: none
- `chezmoi apply`: no

## Residual Risk

- `.chezmoiignore` の directory entry(`docs` など)の解釈は chezmoi の実機確認(Issue #9 の `chezmoi diff`)で最終確認する。
- template 内の version 例(`pnpm@10.12.1`、`python = "3.13.5"`)は時間経過で古くなる。使用時に更新する前提。

## Notes

secret、credential、registry URL、固有値は含まれていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)