### PR TITLE
Record identity file management decision

### DIFF
--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -27,6 +27,15 @@ identity file の中身は最小限にする。
 	email = example@example.invalid
 ```
 
+## 管理方式の決定(2026-06-11、Issue #19)
+
+identity file は当面、完全手動・local only とする。
+
+- chezmoi の prompt による半管理(`promptStringOnce` で値を聞いて local state に保存)は採用しない。
+- 1Password など secret store からの参照も採用しない。identity は secret というより設定値で、`allowSecretsAccess=false` の profile で使えなくなるため。
+- 新 host のセットアップで手動作成が実際に苦になった時点で、personal context に限った prompt 半管理を別 Issue として再検討する。
+- 作り忘れは該当 context での commit 失敗(fail-closed)と `doctor.sh` の warning で検知できる。
+
 ## Local identity file の扱い
 
 - identity file は手元で作成し、この repository には commit しない。


### PR DESCRIPTION
## Summary

- Issue #19 の判断を確定し、`docs/git-identity.md` に記録した。
  - identity file(`~/.config/git/<context>.gitconfig`)は当面、完全手動・local only。
  - chezmoi prompt 半管理、1Password 参照はどちらも採用しない(理由を docs に記載)。
  - 手動作成が実際に苦になった時点で、personal context 限定の prompt 半管理を別 Issue として再検討する。
- 実装ロードマップ(Notion)の Phase 2 残項目(`private_dot_config/git/*.gitconfig.tmpl`)はこの決定により取り下げる(Notion 側は merge 後に更新)。

## Linked Issue

Closes #19

## Validation

- [x] `./scripts/test-gitconfig.sh` → exit 0
- [x] `git diff --check` → clean
- [ ] CI(validate workflow)pass

docs のみの変更。

## Side Effects

- Install side effects: none
- Secret access: none
- Network changes: none
- `chezmoi apply`: no

## Residual Risk

- なし(挙動の変更はない。現状運用の明文化)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)