### PR TITLE
Add mise runtime management

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -12,3 +12,9 @@ templates
 {{ if ne $caps.npmHardeningMode "enforce" }}
 .npmrc
 {{ end }}
+
+{{/* mise config is managed only when the profile enables runtime
+     management. */}}
+{{ if not $caps.enableRuntimeManagement }}
+.config/mise
+{{ end }}

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,26 @@
+# Runtime
+
+`runtime` module の方針。mise で runtime(node、python など)を管理する。
+
+## 方針
+
+- global の mise config(`~/.config/mise/config.toml`)は最小限に保ち、global に tool version を置かない。
+- version pin は project 側の `.mise.toml` の責務。exact version で pin する(例: `templates/project/python/.mise.toml`)。
+- runtime の自動 install はしない。`not_found_auto_install = false` を設定し、install は明示的な `mise install` で行う。
+- `mise trust` / `direnv allow` は自動化しない。
+- `enableRuntimeManagement=false` の profile では、`.chezmoiignore` により mise config を chezmoi 管理対象外にする。
+
+## capability との対応
+
+- `enableRuntimeManagement`: mise config の管理と `doctor.sh` の mise 検査を制御する。
+- `enableDirenv`: direnv の利用方針と `doctor.sh` の direnv 検査を制御する。
+
+## update policy との関係
+
+runtime の upgrade は project 側の pin 変更として明示的に行う。global での自動 upgrade はしない(`docs/update-policy.md`)。
+
+## 対象外
+
+- mise 自体の install(package install は後続 phase)。
+- runtime の自動 install / upgrade。
+- project ごとの version 強制。

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -1,0 +1,12 @@
+# Managed by chezmoi from kosako/dotfiles.
+# Global mise config stays minimal: no global tool versions.
+# Pin runtimes per project in .mise.toml with exact versions.
+# See docs/runtime.md.
+
+[settings]
+# Do not auto-install missing runtimes when a shim is invoked.
+# Installs happen only via an explicit `mise install`.
+not_found_auto_install = false
+
+[tools]
+# Intentionally empty. Global tool versions are not managed here.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -113,6 +113,7 @@ fixture は一時 directory に作り、実際の home や global Git config に
 - token、registry 設定が含まれないこと。
 - `.chezmoiignore` が enforce 以外で `.npmrc` を管理対象外にすること。
 - `.chezmoiignore` が repo 管理用 file(README、docs、scripts、templates など)を home に apply しないこと。
+- `.chezmoiignore` が `enableRuntimeManagement=false` で mise config を管理対象外にすること。
 - template の設定値と `doctor.sh` の enforce 期待値が一致していること。
 
 chezmoi が未導入でも実行できるよう、render はせず静的検査に留める。

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -156,7 +156,17 @@ else
 fi
 
 section "runtime and shell"
-for command_name in mise direnv zsh starship; do
+if [[ "$(capability_value "$profile" enableRuntimeManagement)" == "true" ]]; then
+  command_status mise || true
+else
+  ok "runtime management disabled for profile"
+fi
+if [[ "$(capability_value "$profile" enableDirenv)" == "true" ]]; then
+  command_status direnv || true
+else
+  ok "direnv disabled for profile"
+fi
+for command_name in zsh starship; do
   command_status "$command_name" || true
 done
 

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -55,6 +55,9 @@ for entry in README.md AGENTS.md LICENSE docs scripts templates; do
   check_file_contains "never applies repo file: $entry" "$CHEZMOIIGNORE" "$entry"
 done
 
+check_file_contains "ignores mise config when runtime management disabled" "$CHEZMOIIGNORE" 'not $caps.enableRuntimeManagement'
+check_file_contains "mise config ignore target" "$CHEZMOIIGNORE" ".config/mise"
+
 section "consistency: doctor enforce expectations"
 
 while IFS= read -r line; do


### PR DESCRIPTION
## Summary

- `private_dot_config/mise/config.toml.tmpl` を追加した。global config は最小限: global の tool version なし、`not_found_auto_install = false`(install は明示的な `mise install` のみ)。
- `.chezmoiignore` に gate を追加し、`enableRuntimeManagement=false` の profile(work-minimal)では `~/.config/mise` を管理対象外にした。
- `docs/runtime.md` を追加した。version pin は project 側 `.mise.toml` の exact pin の責務、自動 install / upgrade なし、`mise trust` / `direnv allow` は自動化しない方針を記載。`docs/update-policy.md` と整合。
- `doctor.sh` の runtime section を capability 対応にした。mise は `enableRuntimeManagement`、direnv は `enableDirenv` で gate し、無効 profile では missing 警告ではなく「disabled for profile」と表示する(report-only 維持)。
- `test-npmrc.sh` の `.chezmoiignore` 検査に mise gate の static check を追加した。

## Linked Issue

Closes #14

## Validation

- [x] `./scripts/validate-policy.sh --all` → exit 0
- [x] `./scripts/test-policy.sh` → exit 0
- [x] `./scripts/test-gitconfig.sh` → exit 0
- [x] `./scripts/test-npmrc.sh` → exit 0(mise gate の検査 2 件を含む)
- [x] `bash -n scripts/*.sh` → exit 0
- [x] `./scripts/doctor.sh work-minimal` → exit 0(runtime/direnv が「disabled for profile」表示)
- [x] `./scripts/doctor.sh personal` → exit 0
- [x] `git diff --check` → clean
- [ ] CI(validate workflow)pass

## Side Effects

- Install side effects: none
- Secret access: none
- Network changes: none
- `chezmoi apply`: no

## Residual Risk

- template render と `.chezmoiignore` gate の実機確認は Issue #9 の `chezmoi diff` で行う。
- `private_dot_config` により apply 時に `~/.config` の permission が 0700 に管理される。既存の `~/.config` が緩い permission の場合は apply 時に変更が入る(#9 の diff で確認)。
- `not_found_auto_install` は mise の setting 名変更があり得る。doctor は command presence の確認に留めているため、設定名が変わっても fail はしない。

## Notes

secret、credential、固有値は含まれていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)