### PR TITLE
Strengthen validation reliability

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Summary
 
-- 
+-
 
 ## Linked Issue
 
@@ -22,7 +22,7 @@ Add task-specific checks here.
 
 ## Residual Risk
 
-- 
+-
 
 ## Notes
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,5 +34,5 @@ jobs:
       - name: npmrc hardening tests
         run: ./scripts/test-npmrc.sh
 
-      - name: git diff check
-        run: git diff --check
+      - name: whitespace check (committed tree)
+        run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,7 @@ CLI usage error: exit 2
 
 `[warn]` は現状報告または注意喚起であり、それだけでは失敗扱いにしない。
 unknown profile / module / capability や capability enum の不正値は policy violation として fail closed する。
+`doctor.sh` / `preflight.sh` は冒頭の policy validation が失敗した場合のみ exit 1 で、それ以外は warning があっても常に exit 0(report-only)。
 
 ## validate-policy.sh
 
@@ -90,7 +91,8 @@ policy validation が失敗した場合は exit 1。
 - template に `user.useConfigOnly = true` と `transfer.credentialsInUrl = die` が含まれること。
 - 全 context(personal / work / client / sandbox / agent)の `includeIf` と include path が定義されていること。
 - template に identity 値(`name =` / `email =`、email らしき値)が含まれないこと。
-- local fixture で、known root 外では commit が失敗すること。
+- template に chezmoi のテンプレート構文が含まれないこと(fixture は raw template を git に直接渡すため)。
+- local fixture で、known root 外では commit が identity 未解決を理由に失敗すること。
 - local fixture で、`~/src/personal/` 配下では identity file の identity が解決されること。
 - credential 入り remote URL が拒否されること。
 - credential らしき remote URL(`scheme://user:password@host`)を `git_remotes_with_credentials` が検出すること。

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -6,7 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib-policy.sh"
 
 profile="${1:-personal}"
-status=0
 
 section "doctor profile: $profile"
 
@@ -206,4 +205,6 @@ for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/s
   fi
 done
 
-exit "$status"
+# doctor is report-only: warnings never change the exit code.
+# The only non-zero path is the policy validation at the top.
+exit 0

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -71,7 +71,7 @@ profile_modules() {
     $0 == "  " profile ":" { in_profile = 1; next }
     in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
     in_profile && /^    modules:/ { in_modules = 1; next }
-    in_profile && /^    capabilities:/ { in_modules = 0 }
+    in_profile && /^    [A-Za-z0-9_-]+:/ { in_modules = 0 }
     in_profile && in_modules && /^      - / {
       sub(/^      - /, "")
       print
@@ -85,7 +85,7 @@ profile_capabilities() {
     $0 == "  " profile ":" { in_profile = 1; next }
     in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
     in_profile && /^    capabilities:/ { in_caps = 1; next }
-    in_profile && in_caps && /^      [A-Za-z0-9]+:/ {
+    in_profile && in_caps && /^      [A-Za-z0-9_-]+:/ {
       key = $1
       sub(/:$/, "", key)
       print key
@@ -116,7 +116,7 @@ known_modules() {
 
 known_capabilities() {
   awk '
-    /^  [A-Za-z0-9]+:[[:space:]]*$/ {
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
       name = $1
       sub(/:$/, "", name)
       print name
@@ -128,7 +128,7 @@ capability_type() {
   local capability="$1"
   awk -v capability="$capability" '
     $0 == "  " capability ":" { in_cap = 1; next }
-    in_cap && /^  [A-Za-z0-9]+:[[:space:]]*$/ { exit }
+    in_cap && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
     in_cap && /^    type:/ { print $2; exit }
   ' "$CAPABILITIES_FILE"
 }
@@ -137,13 +137,13 @@ capability_allowed_values() {
   local capability="$1"
   awk -v capability="$capability" '
     $0 == "  " capability ":" { in_cap = 1; next }
-    in_cap && /^  [A-Za-z0-9]+:[[:space:]]*$/ { exit }
+    in_cap && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
     in_cap && /^    values:/ { in_values = 1; next }
     in_cap && in_values && /^      - / {
       sub(/^      - /, "")
       print
     }
-    in_cap && in_values && /^    [A-Za-z]+:/ { exit }
+    in_cap && in_values && /^    [A-Za-z0-9_-]+:/ { exit }
   ' "$CAPABILITIES_FILE"
 }
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -6,7 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib-policy.sh"
 
 profile="${1:-personal}"
-status=0
 
 section "preflight profile: $profile"
 
@@ -74,12 +73,9 @@ else
 fi
 
 section "source directory"
-if [[ -d "$DOTFILES_ROOT" ]]; then
-  ok "dotfiles root exists: $DOTFILES_ROOT"
-else
-  fail "dotfiles root missing: $DOTFILES_ROOT"
-  status=1
-fi
+# DOTFILES_ROOT is resolved by lib-policy.sh at source time, so it
+# always exists here; report it for the record.
+ok "dotfiles root exists: $DOTFILES_ROOT"
 
 if [[ -w "$DOTFILES_ROOT" ]]; then
   ok "dotfiles root writable"
@@ -96,4 +92,6 @@ for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/s
   fi
 done
 
-exit "$status"
+# preflight is report-only: warnings never change the exit code.
+# The only non-zero path is the policy validation at the top.
+exit 0

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -61,6 +61,17 @@ else
   ok "test passed: no email-like value in template"
 fi
 
+# The fixture checks below feed the raw template to git via
+# GIT_CONFIG_GLOBAL, which only works while it contains no template
+# directives. If templating becomes necessary, the fixtures must
+# render the template first.
+if grep -q '{{' "$GITCONFIG_TEMPLATE"; then
+  fail "test failed: template contains template directives; fixtures assume plain gitconfig"
+  status=1
+else
+  ok "test passed: template is directive-free"
+fi
+
 section "fixture checks: identity resolution"
 
 if ! command -v git >/dev/null 2>&1; then
@@ -80,6 +91,7 @@ run_git() {
   env -u EMAIL -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL \
     HOME="$fixture" \
     XDG_CONFIG_HOME="$fixture/.config" \
+    LC_ALL=C \
     GIT_CONFIG_NOSYSTEM=1 \
     GIT_CONFIG_GLOBAL="$GITCONFIG_TEMPLATE" \
     git -C "$repo" "$@"
@@ -98,8 +110,12 @@ if output="$(run_git "$fixture/outside/demo" commit --allow-empty -m test 2>&1)"
   printf '%s\n' "$output" >&2
   fail "test failed: commit succeeded outside known roots"
   status=1
+elif grep -Eqi 'no (email|name) was given|user\.useConfigOnly' <<< "$output"; then
+  ok "test passed: commit fails outside known roots (identity unresolved)"
 else
-  ok "test passed: commit fails outside known roots"
+  printf '%s\n' "$output" >&2
+  fail "test failed: commit failed outside known roots for another reason"
+  status=1
 fi
 
 run_git "$fixture/src/personal/demo" init --quiet --initial-branch=main

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -22,6 +22,20 @@ check_file_contains() {
   fi
 }
 
+# Whole-line match: substring matches (e.g. a comment that mentions the
+# entry) must not satisfy ignore-entry presence checks.
+check_file_has_line() {
+  local name="$1"
+  local file="$2"
+  local line="$3"
+  if grep -Fxq "$line" "$file"; then
+    ok "test passed: $name"
+  else
+    fail "test failed: $name (missing exact line in $file: $line)"
+    status=1
+  fi
+}
+
 section "static checks: dot_npmrc.tmpl"
 
 if [[ ! -f "$NPMRC_TEMPLATE" ]]; then
@@ -48,15 +62,15 @@ if [[ ! -f "$CHEZMOIIGNORE" ]]; then
   exit 1
 fi
 
-check_file_contains "ignores .npmrc outside enforce" "$CHEZMOIIGNORE" ".npmrc"
+check_file_has_line "ignores .npmrc outside enforce" "$CHEZMOIIGNORE" ".npmrc"
 check_file_contains "ignore gated on npmHardeningMode" "$CHEZMOIIGNORE" 'ne $caps.npmHardeningMode "enforce"'
 
-for entry in README.md AGENTS.md LICENSE docs scripts templates; do
-  check_file_contains "never applies repo file: $entry" "$CHEZMOIIGNORE" "$entry"
+for entry in README.md AGENTS.md LICENSE docs scripts templates worklog; do
+  check_file_has_line "never applies repo file: $entry" "$CHEZMOIIGNORE" "$entry"
 done
 
 check_file_contains "ignores mise config when runtime management disabled" "$CHEZMOIIGNORE" 'not $caps.enableRuntimeManagement'
-check_file_contains "mise config ignore target" "$CHEZMOIIGNORE" ".config/mise"
+check_file_has_line "mise config ignore target" "$CHEZMOIIGNORE" ".config/mise"
 
 section "consistency: doctor enforce expectations"
 

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -162,4 +162,25 @@ run_fail_contains \
   "policy validation failed for profile: personal" \
   "$fixture/scripts/validate-policy.sh" --all
 
+make_fixture
+insert_once "$fixture/.chezmoidata/profiles.yaml" "      installPackages: true" "      bad-cap: true"
+run_fail_contains \
+  "rejects unknown kebab-case capability" \
+  "unknown capability in personal: bad-cap" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+insert_once "$fixture/.chezmoidata/profiles.yaml" "      installPackages: true" "      installPackages: true"
+run_fail_contains \
+  "rejects duplicate capability" \
+  "duplicate capability in personal: installPackages" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+: > "$fixture/.chezmoidata/capabilities.schema.yaml"
+run_fail_contains \
+  "fails closed on empty capability schema" \
+  "no capabilities parsed" \
+  "$fixture/scripts/validate-policy.sh" personal
+
 ok "policy tests passed"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -19,7 +19,7 @@ EOF
 validate_profile() {
   local profile="$1"
   local status=0
-  local environment_kind module capability value type
+  local environment_kind module capability value type duplicate
 
   if ! profile_exists "$profile"; then
     fail "unknown profile: $profile"
@@ -58,6 +58,18 @@ validate_profile() {
       status=1
     fi
   done < <(profile_capabilities "$profile")
+
+  while IFS= read -r duplicate; do
+    [[ -z "$duplicate" ]] && continue
+    fail "duplicate capability in $profile: $duplicate"
+    status=1
+  done < <(profile_capabilities "$profile" | sort | uniq -d)
+
+  while IFS= read -r duplicate; do
+    [[ -z "$duplicate" ]] && continue
+    fail "duplicate module in $profile: $duplicate"
+    status=1
+  done < <(profile_modules "$profile" | sort | uniq -d)
 
   while IFS= read -r capability; do
     [[ -z "$capability" ]] && continue
@@ -132,14 +144,31 @@ trap 'rm -f "$known_modules_file" "$known_caps_file"' EXIT
 known_modules | sort > "$known_modules_file"
 known_capabilities | sort > "$known_caps_file"
 
+# Fail closed if the parsers return nothing: an empty known list would
+# otherwise validate zero items and pass vacuously.
+if [[ ! -s "$known_modules_file" ]]; then
+  fail "no modules parsed from $MODULES_FILE"
+  exit 1
+fi
+if [[ ! -s "$known_caps_file" ]]; then
+  fail "no capabilities parsed from $CAPABILITIES_FILE"
+  exit 1
+fi
+
 case "$command" in
   --all)
     status=0
+    profiles_found=0
     while IFS= read -r profile; do
       [[ -z "$profile" ]] && continue
+      profiles_found=1
       section "validating profile: $profile"
       validate_profile "$profile" || status=1
     done < <(known_profiles)
+    if [[ "$profiles_found" -eq 0 ]]; then
+      fail "no profiles parsed from $PROFILES_FILE"
+      exit 1
+    fi
     exit "$status"
     ;;
   --*)


### PR DESCRIPTION
## Summary

2026-06-11 レビューの Batch B(検証機構の信頼性)を修正。

- **CI の whitespace check を実効化**: `git diff --check` は fresh checkout では常に空で no-op だった。empty tree と HEAD の比較に変更し、commit 済み全ファイルを検査。これが検出した PR テンプレートの末尾空白 2 件も修正。
- **awk パーサーの fail-open を封鎖**: 文字種を `[A-Za-z0-9_-]+` に統一(kebab-case capability が「known からも profile からも見えず素通り」する穴を閉鎖)。パーサー出力ゼロ件で fail closed。capability / module の重複キーを検出して fail(awk は最初の値・chezmoi は最後の値を使う乖離対策)。`profile_modules` の終端条件を一般化。
- **test-npmrc の偽陽性修正**: ignore エントリの存在チェックを行全体一致(`grep -Fxq`)に変更。コメント行へのマッチで実エントリ削除を見逃す問題を解消。`worklog` エントリの検査も追加。
- **doctor / preflight の exit code 明文化**: 一度も 1 にならない `status` 機構を削除し、「policy validation 失敗以外は常に exit 0(report-only)」を script コメントと scripts/README.md に明記。credential 検出は warning のまま(`doctor && ...` を壊さない方針)。
- **test-gitconfig 強化**: known root 外の commit 失敗が identity 未解決理由であることを検査(誤った理由での偽 pass を防止)。template の directive-free を static check 化。`LC_ALL=C` で locale 依存を排除。
- 回帰テスト 3 件追加(kebab-case capability 拒否、重複キー拒否、空 schema での fail closed)。

## Linked Issue

Closes #26

## Validation

- [x] `./scripts/validate-policy.sh --all` → exit 0
- [x] `./scripts/test-policy.sh` → exit 0(新規 3 テスト含む 9 テスト pass)
- [x] `./scripts/test-gitconfig.sh` / `./scripts/test-npmrc.sh` → exit 0
- [x] `bash -n scripts/*.sh` → exit 0
- [x] `./scripts/doctor.sh work-minimal` / `./scripts/preflight.sh work-minimal` → exit 0
- [x] empty-tree `git diff --check` がローカルで pass(末尾空白修正後)
- [ ] CI pass

## Side Effects

- Install side effects: none / Secret access: none / `chezmoi apply`: no

## Residual Risk

- awk パーサーは依然として「この repo の YAML 整形規約」前提。コメント行や別インデントには対応しない(規約逸脱は fail closed 側に倒れるようになった)。本格的な YAML 対応が必要になったら yq への移行を検討(D Issue に記載予定)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)