### PR TITLE
Fail with a readable error on unknown profile

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,3 +1,4 @@
+{{- template "require-profile" . -}}
 {{- $caps := index .profiles .profile "capabilities" -}}
 {{/* Repo-management files are never applied to the home directory.
      chezmoi reads the source directory, not the git index, so even

--- a/.chezmoitemplates/require-profile
+++ b/.chezmoitemplates/require-profile
@@ -1,0 +1,9 @@
+{{- /* Fail fast with a readable message when .profile is missing or
+       not defined in .chezmoidata/profiles.yaml. Without this guard a
+       typo'd profile dies with "index of nil pointer". */ -}}
+{{- if not (hasKey . "profile") -}}
+{{-   fail "profile is not set; run: chezmoi init --source ~/dotfiles" -}}
+{{- end -}}
+{{- if not (hasKey .profiles .profile) -}}
+{{-   fail (printf "unknown profile %q (known: %s)" .profile (keys .profiles | sortAlpha | join ", ")) -}}
+{{- end -}}

--- a/dot_npmrc.tmpl
+++ b/dot_npmrc.tmpl
@@ -1,3 +1,4 @@
+{{- template "require-profile" . -}}
 {{- $caps := index .profiles .profile "capabilities" -}}
 {{- if eq $caps.npmHardeningMode "enforce" -}}
 # Managed by chezmoi from kosako/dotfiles (npmHardeningMode=enforce).


### PR DESCRIPTION
## Summary

- `.chezmoitemplates/require-profile` を追加し、`.profiles` を index する template(`.chezmoiignore`、`dot_npmrc.tmpl`)の先頭で呼ぶようにした。
- profile が typo の場合: `unknown profile "personl" (known: personal, work-dev, work-minimal)`(known 一覧は profiles.yaml から動的生成)。
- profile 未設定の場合: `profile is not set; run: chezmoi init --source ~/dotfiles`。
- 従来はどちらも `index of nil pointer` で原因が分からなかった。

## Linked Issue

Closes #29

## Validation

- [x] throwaway destination で typo / 未設定 / 正常の 3 ケースを確認(正常 profile の render 結果は不変: `.gitconfig` / `.npmrc` / `.config/mise/config.toml`)
- [x] `./scripts/validate-policy.sh --all` 〜 全 test script、`bash -n scripts/*.sh` → exit 0
- [ ] CI pass

## Side Effects

- なし(エラーメッセージの改善のみ)。`chezmoi apply` は throwaway destination のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)