### PR TITLE
Clean up minor review findings

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,8 +1,5 @@
 {{- $profile := promptStringOnce . "profile" "Profile (personal, work-minimal, work-dev)" "personal" -}}
-[data]
-profile = {{ $profile | quote }}
 sourceDir = {{ joinPath .chezmoi.homeDir "dotfiles" | quote }}
 
-[data.onepassword]
-vault = {{ promptStringOnce . "opVault" "1Password vault" "Private" | quote }}
-item = {{ promptStringOnce . "opItem" "1Password item for development environment" "Dev Environment" | quote }}
+[data]
+profile = {{ $profile | quote }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,13 +75,6 @@ Notion dotfiles project page
 
 ## コミット前チェック
 
-最低限、変更内容に応じて以下を実行する。
-
-```sh
-./scripts/validate-policy.sh personal
-./scripts/validate-policy.sh work-minimal
-./scripts/validate-policy.sh work-dev
-bash -n scripts/lib-policy.sh scripts/validate-policy.sh scripts/preflight.sh scripts/doctor.sh
-```
+検証コマンドは `docs/github-workflow.md` の「最低限の validation」に従う。CI(`.github/workflows/validate.yml`)も同じ内容を実行するため、コマンド一覧はそちらを single source of truth とし、ここには重複して書かない。
 
 `doctor` / `preflight` は環境依存の warning が出ることがある。policy violation と report-only warning を混同しない。

--- a/docs/supply-chain-corepack.md
+++ b/docs/supply-chain-corepack.md
@@ -28,7 +28,7 @@ corepack enable
 ```
 
 - pin は project 側の責務。dotfiles は global に package manager を強制しない。
-- project templates(Phase 6)に `packageManager` の例を含める予定。
+- exact pin の例は `templates/project/node/package.json` にある。
 - range 指定や hash なしの曖昧な pin は避け、exact version を使う。
 
 ## update policy との関係

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -32,7 +32,7 @@ insert_once() {
   local insert="$3"
   local tmp="$file.tmp"
 
-  awk -v target="$target" -v insert="$insert" '
+  if ! awk -v target="$target" -v insert="$insert" '
     {
       print
       if ($0 == target && !done) {
@@ -41,7 +41,11 @@ insert_once() {
       }
     }
     END { if (!done) exit 1 }
-  ' "$file" > "$tmp"
+  ' "$file" > "$tmp"; then
+    rm -f "$tmp"
+    fail "insert_once: target line not found in $file: $target"
+    return 1
+  fi
   mv "$tmp" "$file"
 }
 
@@ -51,7 +55,7 @@ replace_once() {
   local replacement="$3"
   local tmp="$file.tmp"
 
-  awk -v target="$target" -v replacement="$replacement" '
+  if ! awk -v target="$target" -v replacement="$replacement" '
     $0 == target && !done {
       print replacement
       done = 1
@@ -59,7 +63,11 @@ replace_once() {
     }
     { print }
     END { if (!done) exit 1 }
-  ' "$file" > "$tmp"
+  ' "$file" > "$tmp"; then
+    rm -f "$tmp"
+    fail "replace_once: target line not found in $file: $target"
+    return 1
+  fi
   mv "$tmp" "$file"
 }
 
@@ -182,5 +190,11 @@ run_fail_contains \
   "fails closed on empty capability schema" \
   "no capabilities parsed" \
   "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+run_fail_contains \
+  "rejects single-dash option as usage error" \
+  "unknown option: -x" \
+  "$fixture/scripts/validate-policy.sh" -x
 
 ok "policy tests passed"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -171,7 +171,7 @@ case "$command" in
     fi
     exit "$status"
     ;;
-  --*)
+  -*)
     fail "unknown option: $command"
     usage >&2
     exit 2


### PR DESCRIPTION
## Summary

Issue #30 のうち機械的な 5 項目(1, 2, 3, 4, 6)を修正。

- **AGENTS.md**: コミット前チェックを docs/github-workflow.md への参照に一本化(既に乖離していた重複リストを削除)。
- **`.chezmoi.toml.tmpl`**: 未使用の 1Password prompt 2 つを削除(参照する template / script が存在しない。ssh-1password module 実装時に再追加)。`sourceDir` を `[data]` 配下(機能していなかった)から top-level に移動し、`--source` なしの chezmoi 実行でも source が固定されるようにした。
- **docs/supply-chain-corepack.md**: `packageManager` 例の「予定」記載を実装済みの記述に更新。
- **`validate-policy.sh`**: 単一ダッシュのオプションを usage error(exit 2)として扱うよう修正 + 回帰テスト。
- **`test-policy.sh`**: `insert_once` / `replace_once` が対象行を見つけられない場合に診断メッセージを出して fail するようにした(従来は set -e で無言死 + .tmp 残骸)。

**残り(判断待ちで Issue は open のまま)**: 5(enum `off` の quote / rename)、7(`dot_gitconfig.tmpl` の rename)、8(`~/.config` 0700 の扱い)、9(yq 移行の将来検討)。

## Linked Issue

Refs #30(close しない)

## Validation

- [x] 全 validation + 新回帰テスト → exit 0(`validate-policy.sh -x` が exit 2 になることを直接確認)
- [x] throwaway destination で personal profile の render 確認(target 不変: `.gitconfig` / `.npmrc` / `.config/mise/config.toml`)
- [ ] CI pass

## Side Effects

- `.chezmoi.toml.tmpl` の変更により、既存の chezmoi config がある環境では次回実行時に「config file template has changed, run chezmoi init」の警告が出る(#9 実施時にどのみち init するため影響なし)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)