### PR TITLE
#9 前の小バッチ: CI render 検証、パーサー終端、init 既定値の削除ほか

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,5 +1,9 @@
-{{- $profile := promptStringOnce . "profile" "Profile (personal, work-minimal, work-dev)" "personal" -}}
-sourceDir = {{ joinPath .chezmoi.homeDir "dotfiles" | quote }}
+{{- /* No default on purpose: a profile must be chosen explicitly.
+       Valid profiles live in .chezmoidata/profiles.yaml; a typo fails
+       at render time via .chezmoitemplates/require-profile.
+       Non-interactive init: chezmoi init --promptString profile=<name> */ -}}
+{{- $profile := promptStringOnce . "profile" "profile" -}}
+sourceDir = {{ .chezmoi.sourceDir | quote }}
 
 [data]
 profile = {{ $profile | quote }}

--- a/.chezmoidata/capabilities.schema.yaml
+++ b/.chezmoidata/capabilities.schema.yaml
@@ -1,54 +1,39 @@
 capabilities:
   installPackages:
     type: boolean
-    default: false
   installGuiApps:
     type: boolean
-    default: false
   enableMacOSDefaults:
     type: boolean
-    default: false
   enable1PasswordSSH:
     type: boolean
-    default: false
   enableGitSigning:
     type: boolean
-    default: false
   enableDirenv:
     type: boolean
-    default: false
   enableRuntimeManagement:
     type: boolean
-    default: false
   enableVsCodeSettings:
     type: boolean
-    default: false
   enableVsCodeExtensions:
     type: boolean
-    default: false
   npmHardeningMode:
     type: enum
-    default: report
     values:
       - off
       - report
       - enforce
   corepackMode:
     type: enum
-    default: report
     values:
       - off
       - report
       - enable
   allowNetworkTunnels:
     type: boolean
-    default: false
   allowSecretsAccess:
     type: boolean
-    default: false
   enableAiTools:
     type: boolean
-    default: false
   enableAiPolicy:
     type: boolean
-    default: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,3 +36,26 @@ jobs:
 
       - name: whitespace check (committed tree)
         run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD
+
+  render:
+    runs-on: ubuntu-latest
+    env:
+      CHEZMOI_VERSION: 2.70.5
+      CHEZMOI_SHA256: 6a76a0ac3718f0d45b34b4b57067f9556f8f6042e3da710a3c496838362aca14
+    steps:
+      # actions/checkout v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # Download outside the checkout: a stray file in the source
+      # directory would show up as an unexpected managed target.
+      - name: install chezmoi (pinned, checksum verified)
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -fsSL -o chezmoi.tar.gz "https://github.com/twpayne/chezmoi/releases/download/v${CHEZMOI_VERSION}/chezmoi_${CHEZMOI_VERSION}_linux_amd64.tar.gz"
+          echo "${CHEZMOI_SHA256}  chezmoi.tar.gz" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"
+          tar -xzf chezmoi.tar.gz -C "$HOME/.local/bin" chezmoi
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: chezmoi render and managed-set tests
+        run: ./scripts/test-render.sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mac用ポータブル開発環境を管理する `chezmoi` repository。
 基本モデル:
 
 ```text
-base + modules + profiles + machine + policy + capabilities
+base + modules + profiles + policy + capabilities
 ```
 
 - `profile`: ユーザーが選びやすい用途別プリセット。
@@ -21,6 +21,8 @@ base + modules + profiles + machine + policy + capabilities
 - `policy`: 何を許可し、何を禁止するかの判断基準。
 
 `profile` は権限そのものではない。実際に何を許可するかは `capabilities` で判定する。
+
+AI agent 境界は、現時点では directory convention(`~/src/agent`)と Git identity 分離、docs の方針記述([docs/ai-environment-boundary.md](docs/ai-environment-boundary.md))で構成されており、`enableAiPolicy` capability を消費する実装はまだない。
 
 ## プロジェクトの置き場所
 
@@ -74,8 +76,14 @@ base + modules + profiles + machine + policy + capabilities
 chezmoi init --source ~/dotfiles
 ```
 
-init は profile(personal / work-minimal / work-dev)などを prompt で聞く。
+init は profile を prompt で聞く。デフォルトはないため、`personal` / `work-minimal` / `work-dev` のいずれかを明示的に入力する。typo は render 時に known profile 一覧つきのエラーで fail する。
 回答は `~/.config/chezmoi/chezmoi.toml` に保存され、repo には入らない。
+
+非対話で profile を指定する場合:
+
+```sh
+chezmoi init --source ~/dotfiles --promptString profile=personal
+```
 
 次に差分を確認する。
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -106,9 +106,12 @@ main 直 commit は例外扱いにする。
 ./scripts/test-policy.sh
 ./scripts/test-gitconfig.sh
 ./scripts/test-npmrc.sh
+./scripts/test-render.sh
 bash -n scripts/*.sh
 git diff --check
 ```
+
+`test-render.sh` は chezmoi を必要とする(CI では version pin して導入する)。
 
 `preflight` / `doctor` を変更した場合:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -120,6 +120,25 @@ fixture は一時 directory に作り、実際の home や global Git config に
 
 chezmoi が未導入でも実行できるよう、render はせず静的検査に留める。
 
+## test-render.sh
+
+chezmoi で各 profile を throwaway destination に render(apply)し、managed target 一覧を期待値と比較する。実 home には触れない。
+
+```sh
+./scripts/test-render.sh
+```
+
+検証内容:
+
+- 全 profile が template エラーなしで apply できること。
+- 各 profile の managed target 一覧が期待値と一致すること(profile を追加・変更したら期待値の更新が必要)。
+- typo profile が known profile 一覧つきのエラーで fail すること。
+- profile 未設定が init 誘導メッセージで fail すること。
+- 非対話 init(`--promptString profile=<name>`)が動くこと。
+- profile 無回答の init が fail すること(default を持たない)。
+
+chezmoi が必要(CI では version pin して導入する)。
+
 ## lib-policy.sh
 
 他 script から source される共通 helper。

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -85,6 +85,7 @@ profile_capabilities() {
     $0 == "  " profile ":" { in_profile = 1; next }
     in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
     in_profile && /^    capabilities:/ { in_caps = 1; next }
+    in_profile && /^    [A-Za-z0-9_-]+:/ { in_caps = 0 }
     in_profile && in_caps && /^      [A-Za-z0-9_-]+:/ {
       key = $1
       sub(/:$/, "", key)
@@ -100,6 +101,7 @@ capability_value() {
     $0 == "  " profile ":" { in_profile = 1; next }
     in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
     in_profile && /^    capabilities:/ { in_caps = 1; next }
+    in_profile && /^    [A-Za-z0-9_-]+:/ { in_caps = 0 }
     in_profile && in_caps && $1 == capability ":" { print $2; exit }
   ' "$PROFILES_FILE"
 }

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -185,6 +185,20 @@ run_fail_contains \
   "$fixture/scripts/validate-policy.sh" personal
 
 make_fixture
+insert_once "$fixture/.chezmoidata/profiles.yaml" "      enableAiPolicy: true" "    extraSection:"
+insert_once "$fixture/.chezmoidata/profiles.yaml" "    extraSection:" "      sneakyKey: true"
+run_ok \
+  "ignores sections after capabilities" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+: > "$fixture/.chezmoidata/profiles.yaml"
+run_fail_contains \
+  "fails closed on empty profiles for --list-profiles" \
+  "no profiles parsed" \
+  "$fixture/scripts/validate-policy.sh" --list-profiles
+
+make_fixture
 : > "$fixture/.chezmoidata/capabilities.schema.yaml"
 run_fail_contains \
   "fails closed on empty capability schema" \

--- a/scripts/test-render.sh
+++ b/scripts/test-render.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Render every profile into a throwaway destination and assert the
+# managed target set. This is the apply-shaped safety net: template
+# errors and unexpected managed targets fail here before any real
+# `chezmoi apply`. It never touches the real home directory.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  fail "chezmoi not found; render tests require it"
+  exit 1
+fi
+
+status=0
+tmp_roots=()
+
+cleanup() {
+  local dir
+  if [[ "${#tmp_roots[@]}" -eq 0 ]]; then
+    return 0
+  fi
+  for dir in "${tmp_roots[@]}"; do
+    rm -rf "$dir"
+  done
+}
+trap cleanup EXIT
+
+make_root() {
+  root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-render-test.XXXXXX")"
+  tmp_roots+=("$root")
+  mkdir -p "$root/home"
+}
+
+write_config() {
+  local profile="$1"
+  printf '[data]\nprofile = "%s"\n' "$profile" > "$root/chezmoi.toml"
+}
+
+throwaway_chezmoi() {
+  chezmoi --config "$root/chezmoi.toml" \
+    --source "$DOTFILES_ROOT" --destination "$root/home" "$@"
+}
+
+# Every profile must have an expected managed set here. Adding or
+# changing a profile without updating this list fails the test.
+expected_managed() {
+  local profile="$1"
+  case "$profile" in
+    personal)
+      printf '%s\n' .config .config/mise .config/mise/config.toml .gitconfig .npmrc
+      ;;
+    work-minimal)
+      printf '%s\n' .config .gitconfig
+      ;;
+    work-dev)
+      printf '%s\n' .config .config/mise .config/mise/config.toml .gitconfig
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+section "render and managed set per profile"
+
+profiles_found=0
+while IFS= read -r profile; do
+  [[ -z "$profile" ]] && continue
+  profiles_found=1
+
+  if ! expected="$(expected_managed "$profile")"; then
+    fail "no expected managed set for profile: $profile (update test-render.sh)"
+    status=1
+    continue
+  fi
+
+  make_root
+  write_config "$profile"
+
+  if ! output="$(throwaway_chezmoi apply 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    fail "test failed: apply renders for $profile"
+    status=1
+    continue
+  fi
+  ok "test passed: apply renders for $profile"
+
+  managed="$(throwaway_chezmoi managed | sort)"
+  if diff_output="$(diff <(printf '%s\n' "$expected") <(printf '%s\n' "$managed"))"; then
+    ok "test passed: managed set matches for $profile"
+  else
+    printf '%s\n' "$diff_output" >&2
+    fail "test failed: managed set mismatch for $profile"
+    status=1
+  fi
+done < <(known_profiles)
+
+if [[ "$profiles_found" -eq 0 ]]; then
+  fail "no profiles parsed from $PROFILES_FILE"
+  exit 1
+fi
+
+section "fail-closed render guards"
+
+make_root
+write_config "no-such-profile"
+if output="$(throwaway_chezmoi managed 2>&1)"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: typo profile must not render"
+  status=1
+elif grep -Fq 'unknown profile "no-such-profile"' <<< "$output"; then
+  ok "test passed: typo profile fails with known-profile message"
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: typo profile fails without the expected message"
+  status=1
+fi
+
+make_root
+: > "$root/chezmoi.toml"
+if output="$(throwaway_chezmoi managed 2>&1)"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: missing profile must not render"
+  status=1
+elif grep -Fq 'profile is not set' <<< "$output"; then
+  ok "test passed: missing profile fails with init guidance"
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: missing profile fails without the expected message"
+  status=1
+fi
+
+section "non-interactive init"
+
+make_root
+if output="$(env HOME="$root/home" XDG_CONFIG_HOME="$root/config" XDG_DATA_HOME="$root/data" \
+  chezmoi init --source "$DOTFILES_ROOT" --promptString profile=work-minimal 2>&1)"; then
+  config_file="$root/config/chezmoi/chezmoi.toml"
+  if grep -Fxq 'profile = "work-minimal"' "$config_file"; then
+    ok "test passed: non-interactive init writes the chosen profile"
+  else
+    fail "test failed: init config does not contain the chosen profile"
+    status=1
+  fi
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: non-interactive init with --promptString"
+  status=1
+fi
+
+# No default profile on purpose: init without an answer must fail
+# instead of silently picking one.
+make_root
+if output="$(env HOME="$root/home" XDG_CONFIG_HOME="$root/config" XDG_DATA_HOME="$root/data" \
+  chezmoi init --source "$DOTFILES_ROOT" --no-tty </dev/null 2>&1)"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: init without a profile answer must fail (default has been reintroduced?)"
+  status=1
+else
+  ok "test passed: init without a profile answer fails"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "render tests passed"
+fi
+exit "$status"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -41,7 +41,7 @@ validate_profile() {
 
   while IFS= read -r module; do
     [[ -z "$module" ]] && continue
-    if grep -Fxq "$module" "$known_modules_file"; then
+    if grep -Fxq -- "$module" "$known_modules_file"; then
       ok "module allowed: $module"
     else
       fail "unknown module in $profile: $module"
@@ -51,7 +51,7 @@ validate_profile() {
 
   while IFS= read -r capability; do
     [[ -z "$capability" ]] && continue
-    if grep -Fxq "$capability" "$known_caps_file"; then
+    if grep -Fxq -- "$capability" "$known_caps_file"; then
       ok "capability allowed: $capability"
     else
       fail "unknown capability in $profile: $capability"
@@ -132,7 +132,13 @@ require_data_files || exit 1
 
 case "$command" in
   --list-profiles)
-    known_profiles
+    profiles="$(known_profiles)"
+    # Fail closed: an empty parse must not look like "no profiles, all fine".
+    if [[ -z "$profiles" ]]; then
+      fail "no profiles parsed from $PROFILES_FILE"
+      exit 1
+    fi
+    printf '%s\n' "$profiles"
     exit 0
     ;;
 esac


### PR DESCRIPTION
## Summary

中間レビュー 2026-06-12 で挙がった「#9(初回 apply)前の小修正」をまとめて実施。2026-06-12 の本人判断(init default は削除、zsh 前検証は CI managed-set 代替)を反映。

- `scripts/test-render.sh` 新設: 全 profile を throwaway destination に apply し managed 一覧を期待値と比較。typo profile / profile 未設定 / default なし init の fail-closed も検証。CI に chezmoi(v2.70.5 pin、sha256 検証)で実行する `render` job を追加。
- `lib-policy.sh`: `profile_capabilities` / `capability_value` の in_caps 終端を一般化(#26 の `profile_modules` と同じ)。回帰テスト付き。
- `.chezmoi.toml.tmpl`: default profile を削除(明示入力必須)、prompt キーを `profile` に短縮(非対話 init: `--promptString profile=<name>`)、`sourceDir` を `{{ .chezmoi.sourceDir }}` に。
- `capabilities.schema.yaml`: 読まれていない `default:` を削除。
- README: 基本モデル式から `machine` を削除、init 手順(対話/非対話)を更新、AI 境界の現状 1 文を追加。
- `validate-policy.sh`: `--list-profiles` の空データ fail-closed、grep `--`。

## Linked Issue

Closes #33

## Validation

local(macOS、chezmoi v2.70.5):

- `bash -n scripts/*.sh` pass
- `./scripts/validate-policy.sh --all` pass
- `./scripts/test-policy.sh` pass(新規 2 件含む)
- `./scripts/test-gitconfig.sh` / `./scripts/test-npmrc.sh` pass
- `./scripts/test-render.sh` pass(3 profile render + fail 3 ケース + 非対話 init)
- mutation 確認: 旧 `lib-policy.sh` に対して新回帰テストが fail することを確認
- 非対話 init の生成 config を実機確認(`sourceDir = "/Users/kosako/dotfiles"`、profile 反映)

shellcheck は local 未導入のため CI に委任。

## Side Effects

- install: なし(CI runner への chezmoi 導入のみ。version pin + checksum 検証、tarball は checkout 外に download)
- secret / network / 実 home への apply: なし(render は throwaway destination のみ)

## Residual Risk

- test-render.sh の期待 managed 一覧は手書きのため、profile 変更時に更新が必要(不一致は fail するので silent drift はしない)。
- 既存の `~/.config/chezmoi/chezmoi.toml` を持つ環境では init 済みのため default 削除の影響なし。新規 init は明示入力が必要になる(意図どおり)。
- init 無回答 fail テストはエラーメッセージではなく exit code のみを見る(chezmoi の文言変化に依存しないため)。

## Next

- #9: 初回 apply(target を `~/.gitconfig` に絞る、手動の identity file 配置含む)
- #28: paths 駆動案で実装(別 Issue 化予定)