### PR TITLE
検証計画と local-override 規約を docs に昇格する

### DIFF
--- a/docs/local-overrides.md
+++ b/docs/local-overrides.md
@@ -1,0 +1,48 @@
+# Local Overrides
+
+managed な設定 file と、host 固有の local 上書きの境界規約。
+Phase 7 以降の zsh(#15)、VS Code(#16)、SSH(#17)はこの規約に従って実装する。
+
+## 共通原則
+
+- local override file は chezmoi の管理対象にしない。repo にも commit しない。
+- secret、会社・クライアント固有の値、host 固有の調整は local override file 側にのみ置く。
+- managed file は local override file が存在しなくても壊れないように書く。
+- doctor は local override file の存在を report-only で表示してよいが、中身は読まない。
+- 命名は managed file に `.local` を付ける(`~/.zshrc.local`、`~/.ssh/config.local`)。
+
+## zsh: local-wins(末尾 source)
+
+managed な `~/.zshrc` は末尾で local file を source する。
+
+```sh
+[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"
+```
+
+zsh は後に評価された設定が勝つため、末尾 source は **local-wins** になる。
+shell 設定は利便性の調整が主目的で、host 側の事情(会社の PATH、ツールの hook)が
+managed 側の既定値を上書きできる必要があるため、これを意図とする。
+
+## SSH: managed-wins(末尾 Include)
+
+managed な `~/.ssh/config` は末尾に local file を Include する。
+
+```text
+Include config.local
+```
+
+ssh_config は **first-match-wins** のため、末尾 Include は managed 設定が優先される
+**managed-wins** になる。SSH は安全境界(どの host にどの鍵・agent を使うか)であり、
+local file が managed の安全設定を上書きできてはならないため、zsh とは逆の勝ち方を意図とする。
+
+local 側は managed が定義していない Host を追加する用途に限る。
+
+## VS Code
+
+VS Code の settings は JSON 単一 file のため source / Include に相当する仕組みがない。
+扱い(managed file に一本化するか、機械 merge を導入するか)は #16 の実装時に決める。
+
+## 決定記録
+
+- 2026-06-13: 本規約を確定(中間レビュー 2026-06-12 の提案に基づく)。zsh = 末尾 source で
+  local-wins、SSH = 末尾 Include で managed-wins。

--- a/docs/validation-plan.md
+++ b/docs/validation-plan.md
@@ -1,0 +1,45 @@
+# Validation Plan
+
+この repository の検証レイヤーと、検証戦略に関する決定の記録。
+検証メモや試行錯誤は Notion(検証戦略ページ)に置き、確定した計画だけをここに置く。
+
+## 検証レイヤー
+
+```text
+1. 静的検証 + テスト   CI が PR ごとに実行(.github/workflows/validate.yml が single source)
+2. render 検証         test-render.sh: 全 profile を throwaway destination に apply し
+                       managed target 一覧を期待値と比較(CI の render job)
+3. 実 host への適用    target を絞った chezmoi apply(diff 全文確認後)
+```
+
+検証コマンドの一覧は `docs/github-workflow.md` の「最低限の validation」を参照する。
+
+## 新しい file 種別を managed にするときの標準手順
+
+1. module の `paths:` / `requires:` を `.chezmoidata/modules.yaml` に宣言する(`docs/policy-model.md`)。
+2. throwaway destination で apply し、`scripts/test-render.sh` の期待 managed 一覧を更新する。
+3. 実 host では `chezmoi diff` の全出力を確認してから、target を絞って apply する。
+4. 適用後に `./scripts/doctor.sh <profile>` を確認する。
+
+## 決定記録
+
+### 2026-06-12: VM 検証を経ず host 直行に下方修正
+
+当初計画(Notion 検証戦略)は clean / existing VM での apply 検証を経て host に適用する段階方式だった。
+実際には以下の組み合わせで VM 検証を代替し、host へ直行する方式に変更した。
+
+- throwaway destination での apply 検証(実 home に触れない)
+- CI の render / managed-set 検証(`test-render.sh`)
+- 実 host では target を絞った apply(初回は `~/.gitconfig` のみ。Issue #9)
+
+### 2026-06-12: 初回 apply は personal の target 絞りで実施
+
+当初案は「副作用が最小の work-minimal を最初に apply する」だったが、この host の主用途が
+personal であるため、personal profile で target を `~/.gitconfig` に絞って初回 apply を実施した(Issue #9)。
+profile 指定だけでは適用範囲は絞れないため、初回適用は必ず target 指定で行う。
+
+### 2026-06-12: zsh 移行前の検証は CI render 検証の拡張で行う
+
+login shell を壊しうる zsh 移行(Issue #15)の前提検証は、VM 検証の復活ではなく
+CI の render / managed-set 検証の拡張で行う(本人決定)。あわせて `docs/local-overrides.md` の
+規約に従い、既存 `~/.zshrc` の棚卸しを移行前に行う。


### PR DESCRIPTION
## Summary

中間レビュー 2026-06-12 の「検証戦略の乖離」「Phase 7 前に local-override 規約を確定」への対応。docs のみ。

- `docs/validation-plan.md` 新設: 実際に使っている検証レイヤー(静的 + CI / render・managed-set / target 絞り apply)、新 file 種別を managed にする標準手順、2026-06-12 の決定 3 件を日付きで記録(VM 段階の廃止、personal target 絞りでの初回 apply、zsh 前検証は CI render 拡張)。
- `docs/local-overrides.md` 新設: zsh は末尾 source で local-wins、SSH は末尾 Include で managed-wins(first-match-wins)。勝ち方が逆になる理由を明記。VS Code は #16 で決める。

## Linked Issue

Closes #36

## Validation

- docs のみの変更。`git diff --check` pass。CI 全 job に委任。

## Side Effects

- install / secret / network / apply: なし

## Residual Risk

- 規約は #15 / #17 実装時に実地で検証される。実装で齟齬が出たら本 docs を日付きで更新する。

## Next

- doctor に orphan / AI policy / tunnels section を追加(Phase 7 前の残り)
- merge 後に Notion 検証戦略ページへ昇格済みの旨を追記