### PR TITLE
doctor に orphan / AI policy / network tunnels の report section を追加する

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,6 +34,9 @@ jobs:
       - name: npmrc hardening tests
         run: ./scripts/test-npmrc.sh
 
+      - name: doctor orphan tests
+        run: ./scripts/test-doctor.sh
+
       - name: whitespace check (committed tree)
         run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -106,6 +106,7 @@ main 直 commit は例外扱いにする。
 ./scripts/test-policy.sh
 ./scripts/test-gitconfig.sh
 ./scripts/test-npmrc.sh
+./scripts/test-doctor.sh
 ./scripts/test-render.sh
 bash -n scripts/*.sh
 git diff --check

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ policy validation が失敗した場合は exit 1。
 
 ## doctor.sh
 
-導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、project root の状態を表示する。
+導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
 remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md`、Corepack の検査は `docs/supply-chain-corepack.md` に従う。
 `npmHardeningMode=enforce` の profile では、期待する npm config 値と現在値の不一致を `[warn]` で報告する(apply 前は不一致が正常)。
@@ -122,6 +122,21 @@ fixture は一時 directory に作り、実際の home や global Git config に
 - template の設定値と `doctor.sh` の enforce 期待値が一致していること。
 
 chezmoi が未導入でも実行できるよう、render はせず静的検査に留める。
+
+## test-doctor.sh
+
+fixture HOME で doctor の managed-path orphan 検出を検証する。実 home には触れない。
+
+```sh
+./scripts/test-doctor.sh
+```
+
+検証内容:
+
+- managed-by header があり現 profile で管理対象でない file が warning になること(profile 切替の残骸)。
+- 同じ file でも管理対象の profile では orphan にならないこと。
+- header のない file は orphan 扱いしないこと。
+- いずれの場合も doctor が exit 0 を維持すること(report-only)。
 
 ## test-render.sh
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -196,6 +196,76 @@ else
   ok "secret access disabled for profile"
 fi
 
+section "managed-path orphans"
+# A file that carries the managed-by header but whose path is not
+# managed for this profile is likely left over from another profile
+# (e.g. ~/.npmrc after switching personal -> work-minimal). Report
+# only; nothing is removed. Only the header line is inspected.
+orphan_count=0
+while IFS= read -r module; do
+  [[ -z "$module" ]] && continue
+  while IFS= read -r managed_path; do
+    [[ -z "$managed_path" ]] && continue
+    target="$HOME/$managed_path"
+    candidates=()
+    if [[ -f "$target" ]]; then
+      candidates=("$target")
+    elif [[ -d "$target" ]]; then
+      while IFS= read -r found_file; do
+        candidates+=("$found_file")
+      done < <(find "$target" -maxdepth 3 -type f 2>/dev/null)
+    fi
+    [[ "${#candidates[@]}" -eq 0 ]] && continue
+    for candidate in "${candidates[@]}"; do
+      grep -q "Managed by chezmoi" "$candidate" 2>/dev/null || continue
+      if module_active_for_profile "$profile" "$module"; then
+        item "managed and active: $candidate"
+      else
+        orphan_count=$((orphan_count + 1))
+        warn "managed-by header but not managed for profile $profile: $candidate (orphan from another profile?)"
+      fi
+    done
+  done < <(module_paths "$module")
+done < <(known_modules)
+if [[ "$orphan_count" -eq 0 ]]; then
+  ok "no managed-path orphans"
+fi
+
+section "AI policy"
+if [[ "$(capability_value "$profile" enableAiPolicy)" == "true" ]]; then
+  ok "enableAiPolicy=true (policy docs + report-only checks; see docs/ai-policy.md)"
+  item "boundary today: directory convention + Git identity separation + policy docs"
+  if [[ -d "$HOME/src/agent" ]]; then
+    ok "agent project root exists: $HOME/src/agent"
+  else
+    warn "agent project root missing: $HOME/src/agent"
+  fi
+else
+  ok "AI policy checks disabled for profile"
+fi
+if [[ "$(capability_value "$profile" enableAiTools)" == "true" ]]; then
+  warn "enableAiTools=true but the ai-tools module is not implemented yet (nothing is managed)"
+else
+  ok "AI tool install/sync not managed (enableAiTools=false)"
+fi
+
+section "network tunnels"
+allow_tunnels="$(capability_value "$profile" allowNetworkTunnels)"
+ok "allowNetworkTunnels=$allow_tunnels"
+tunnel_tools_found=0
+for tunnel_tool in tailscale cloudflared ngrok zerotier-cli; do
+  command -v "$tunnel_tool" >/dev/null 2>&1 || continue
+  tunnel_tools_found=$((tunnel_tools_found + 1))
+  if [[ "$allow_tunnels" == "true" ]]; then
+    item "tunnel tool present: $tunnel_tool"
+  else
+    warn "tunnel tool present but allowNetworkTunnels=false: $tunnel_tool (not removed automatically)"
+  fi
+done
+if [[ "$tunnel_tools_found" -eq 0 ]]; then
+  ok "no tunnel tools found"
+fi
+
 section "project roots"
 for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/sandbox" "$HOME/src/agent"; do
   if [[ -d "$dir" ]]; then

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -146,6 +146,22 @@ module_requires() {
   ' "$MODULES_FILE"
 }
 
+# A module's paths are managed for a profile when the profile lists the
+# module and every requires: condition matches the profile's value.
+# Mirrors the .chezmoiignore generation logic.
+module_active_for_profile() {
+  local profile="$1"
+  local module="$2"
+  local capability value
+
+  profile_modules "$profile" | grep -Fxq -- "$module" || return 1
+  while read -r capability value; do
+    [[ -z "$capability" ]] && continue
+    [[ "$(capability_value "$profile" "$capability")" == "$value" ]] || return 1
+  done < <(module_requires "$module")
+  return 0
+}
+
 known_capabilities() {
   awk '
     /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify the doctor orphan detection with a fixture HOME. doctor stays
+# report-only: both runs must exit 0; only the warnings differ.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+status=0
+fixture_home="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-doctor-test.XXXXXX")"
+trap 'rm -rf "$fixture_home"' EXIT
+
+# A leftover enforce-mode .npmrc, as after switching personal -> work-minimal.
+printf '# Managed by chezmoi from kosako/dotfiles (npmHardeningMode=enforce).\nignore-scripts=true\n' \
+  > "$fixture_home/.npmrc"
+
+orphan_marker="orphan from another profile"
+
+# work-minimal does not manage .npmrc (npmHardeningMode=report): orphan.
+if ! output="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" work-minimal 2>&1)"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: doctor must stay exit 0 for work-minimal"
+  status=1
+fi
+if grep -F "$orphan_marker" <<< "$output" | grep -Fq ".npmrc"; then
+  ok "test passed: orphan .npmrc reported for work-minimal"
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: orphan .npmrc not reported for work-minimal"
+  status=1
+fi
+
+# personal manages .npmrc (npmHardeningMode=enforce): not an orphan.
+if ! output="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: doctor must stay exit 0 for personal"
+  status=1
+fi
+if grep -Fq "$orphan_marker" <<< "$output"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: personal must not report the fixture .npmrc as orphan"
+  status=1
+else
+  ok "test passed: no orphan reported for personal"
+fi
+
+# A file without the managed-by header is never an orphan.
+printf 'registry-noise=1\n' > "$fixture_home/.npmrc"
+if HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" work-minimal 2>&1 | grep -Fq "$orphan_marker"; then
+  fail "test failed: headerless file must not be reported as orphan"
+  status=1
+else
+  ok "test passed: headerless file ignored"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "doctor tests passed"
+fi
+exit "$status"


### PR DESCRIPTION
## Summary

中間レビュー 2026-06-12 の「profile 切替の orphan が doctor から見えない」「AI 境界・tunnels の capability に消費者がいない」への対応。すべて report-only(exit 0 維持)。

- **managed-path orphans**: modules.yaml の `paths:` 宣言(#35)を候補に、「managed-by header があるのに現 profile で管理対象でない」file を warning(例: personal→work-minimal 切替後の `~/.npmrc`)。判定は policy データのみで行い chezmoi の init 状態に依存しない。header 行の有無だけを見て、削除はしない。
- **AI policy**: `enableAiPolicy=true` が docs/ai-environment-boundary.md の約束どおり report-only check を駆動。`enableAiTools=true` なら「ai-tools module 未実装」と warning(正直さの維持)。
- **network tunnels**: `allowNetworkTunnels` と tunnel tool(tailscale / cloudflared / ngrok / zerotier-cli)の存在を report。false なのに存在すれば warning。
- `scripts/test-doctor.sh` 新設(fixture HOME、orphan の positive / negative / headerless)、CI に追加。

## Linked Issue

Closes #38

## Validation

- `bash -n scripts/*.sh` pass(shellcheck は CI に委任)
- `./scripts/test-doctor.sh` pass(新規 3 件)
- `./scripts/test-policy.sh` / `test-npmrc.sh` / `test-gitconfig.sh` / `test-render.sh` / `validate-policy.sh --all` pass
- 実機確認: `doctor.sh personal` で `~/.gitconfig` が managed and active、orphan なし、tailscale が present として report、exit 0。`doctor.sh work-minimal` も exit 0

## Side Effects

- install / secret / network / apply: なし(検査のみ。file は header 行の grep のみ)

## Residual Risk

- orphan 検出は「managed-by header の有無」に依存する。header のない手書き file は検出対象外(意図どおり: 管理外 file には触れない)。
- tunnel tool の一覧は代表 4 種の固定リスト。増やす場合は doctor の編集が必要。
- environmentKind cross-check は検査対象が未定義のため対象外のまま(中間レビューの残項目)。

## Next

- Phase 7 前の前提整備はこれで完了。次は #15(zsh)/ #16(VS Code)/ #17(SSH)だが、棚卸しと好みの判断が要るため本人と一緒に進める