### PR TITLE
policy パーサーを awk から yq に移行する(#41)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,12 +9,27 @@ on:
 permissions:
   contents: read
 
+env:
+  YQ_VERSION: 4.53.3
+  YQ_SHA256: fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       # actions/checkout v4.2.2
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # The policy scripts require mikefarah/yq v4. Download outside the
+      # checkout so a stray file never affects the working tree.
+      - name: install yq (pinned, checksum verified)
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -fsSL -o yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  yq" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 yq "$HOME/.local/bin/yq"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: bash syntax check
         run: bash -n scripts/*.sh
@@ -58,6 +73,15 @@ jobs:
           echo "${CHEZMOI_SHA256}  chezmoi.tar.gz" | sha256sum -c -
           mkdir -p "$HOME/.local/bin"
           tar -xzf chezmoi.tar.gz -C "$HOME/.local/bin" chezmoi
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: install yq (pinned, checksum verified)
+        working-directory: ${{ runner.temp }}
+        run: |
+          curl -fsSL -o yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  yq" | sha256sum -c -
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 yq "$HOME/.local/bin/yq"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: chezmoi render and managed-set tests

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -22,6 +22,10 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 - `paths:` を持たない module は現時点では情報ラベル(実装が入る時点で `paths:` を宣言する)。
 - `requires:` の capability 名・値は `validate-policy.sh` が schema と突き合わせて検証する。複数 module による同一 path の宣言は fail。
 
+## データ読み取り
+
+`.chezmoidata/*.yaml`(profiles / modules / capabilities.schema)の読み取りは shell script 側では mikefarah/yq v4 で行う(chezmoi template 側は Go template が読む)。yq が無い・別 variant の場合は `require_yq` が fail closed する。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない(injection 防止)。
+
 ## Rules
 
 - profile 名だけで副作用を許可しない。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -161,3 +161,5 @@ chezmoi が必要(CI では version pin して導入する)。
 
 他 script から source される共通 helper。
 data file path、profile/module/capability 取得、出力 helper、command availability check、Git remote credential 検出(`git_remotes_with_credentials`。remote 名のみを出力し、URL 値は出力しない)を提供する。
+
+policy data(`.chezmoidata/*.yaml`)の読み取りは mikefarah/yq v4 で行う。`require_yq` が yq の存在と variant・版を検査し、満たさなければ fail closed する(`validate-policy.sh` / `test-npmrc.sh` / `test-render.sh` が冒頭で呼ぶ。`doctor.sh` / `preflight.sh` は内部で `validate-policy.sh` を先に実行するため間接的にカバーされる)。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない。

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -30,6 +30,30 @@ fail() {
   printf '[fail] %s\n' "$*" >&2
 }
 
+# The policy parsers below require mikefarah/yq v4. Fail closed and
+# loudly on a missing binary or the unrelated Python "yq", so a wrong
+# tool never silently parses nothing and passes vacuously.
+require_yq() {
+  if ! command -v yq >/dev/null 2>&1; then
+    fail "yq not found; install mikefarah/yq v4 (brew install yq). See docs/policy-model.md"
+    return 1
+  fi
+  local version major
+  version="$(yq --version 2>/dev/null)"
+  if [[ "$version" != *mikefarah* ]]; then
+    fail "wrong yq variant: need mikefarah/yq v4, got: ${version:-unknown}"
+    return 1
+  fi
+  major="${version##*version }"
+  major="${major#v}"
+  major="${major%%.*}"
+  if [[ ! "$major" =~ ^[0-9]+$ ]] || ((major < 4)); then
+    fail "yq v4+ required, got: $version"
+    return 1
+  fi
+  return 0
+}
+
 require_data_files() {
   local missing=0
   for file in "$PROFILES_FILE" "$MODULES_FILE" "$CAPABILITIES_FILE"; do
@@ -41,109 +65,60 @@ require_data_files() {
   [[ "$missing" -eq 0 ]]
 }
 
+# Names are passed to yq via strenv(), never interpolated into the
+# expression, so a name with special characters cannot break or inject
+# into the query.
+
 profile_exists() {
   local profile="$1"
-  awk -v profile="$profile" '$0 == "  " profile ":" { found = 1 } END { exit !found }' "$PROFILES_FILE"
+  [[ "$(p="$profile" yq '.profiles // {} | has(strenv(p))' "$PROFILES_FILE" 2>/dev/null)" == "true" ]]
 }
 
 known_profiles() {
-  awk '
-    /^  [^ ].*:[[:space:]]*$/ {
-      name = $1
-      sub(/:$/, "", name)
-      print name
-    }
-  ' "$PROFILES_FILE"
+  yq '.profiles // {} | keys | .[]' "$PROFILES_FILE"
 }
 
 profile_environment_kind() {
   local profile="$1"
-  awk -v profile="$profile" '
-    $0 == "  " profile ":" { in_profile = 1; next }
-    in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
-    in_profile && /^    environmentKind:/ { print $2; exit }
-  ' "$PROFILES_FILE"
+  # environmentKind is always a string, so // "" only fires on absence.
+  p="$profile" yq '.profiles[strenv(p)].environmentKind // ""' "$PROFILES_FILE"
 }
 
 profile_modules() {
   local profile="$1"
-  awk -v profile="$profile" '
-    $0 == "  " profile ":" { in_profile = 1; next }
-    in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
-    in_profile && /^    modules:/ { in_modules = 1; next }
-    in_profile && /^    [A-Za-z0-9_-]+:/ { in_modules = 0 }
-    in_profile && in_modules && /^      - / {
-      sub(/^      - /, "")
-      print
-    }
-  ' "$PROFILES_FILE"
+  p="$profile" yq '.profiles[strenv(p)].modules[]?' "$PROFILES_FILE"
 }
 
 profile_capabilities() {
   local profile="$1"
-  awk -v profile="$profile" '
-    $0 == "  " profile ":" { in_profile = 1; next }
-    in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
-    in_profile && /^    capabilities:/ { in_caps = 1; next }
-    in_profile && /^    [A-Za-z0-9_-]+:/ { in_caps = 0 }
-    in_profile && in_caps && /^      [A-Za-z0-9_-]+:/ {
-      key = $1
-      sub(/:$/, "", key)
-      print key
-    }
-  ' "$PROFILES_FILE"
+  # // {} guards an absent capabilities map; duplicate keys are kept in
+  # the output so callers can detect them with `sort | uniq -d`.
+  p="$profile" yq '.profiles[strenv(p)].capabilities // {} | keys | .[]' "$PROFILES_FILE"
 }
 
 capability_value() {
   local profile="$1"
   local capability="$2"
-  awk -v profile="$profile" -v capability="$capability" '
-    $0 == "  " profile ":" { in_profile = 1; next }
-    in_profile && /^  [^ ].*:[[:space:]]*$/ { exit }
-    in_profile && /^    capabilities:/ { in_caps = 1; next }
-    in_profile && /^    [A-Za-z0-9_-]+:/ { in_caps = 0 }
-    in_profile && in_caps && $1 == capability ":" { print $2; exit }
-  ' "$PROFILES_FILE"
+  # select(has()) yields nothing when the key is absent while keeping a
+  # literal false value; a bare `// ""` would collapse false into "".
+  p="$profile" c="$capability" \
+    yq '.profiles[strenv(p)].capabilities // {} | select(has(strenv(c))) | .[strenv(c)]' "$PROFILES_FILE"
 }
 
 known_modules() {
-  awk '
-    /^  [^ ].*:[[:space:]]*$/ {
-      name = $1
-      sub(/:$/, "", name)
-      print name
-    }
-  ' "$MODULES_FILE"
+  yq '.modules // {} | keys | .[]' "$MODULES_FILE"
 }
 
 module_paths() {
   local module="$1"
-  awk -v module="$module" '
-    $0 == "  " module ":" { in_module = 1; next }
-    in_module && /^  [^ ].*:[[:space:]]*$/ { exit }
-    in_module && /^    paths:/ { in_paths = 1; next }
-    in_module && /^    [A-Za-z0-9_-]+:/ { in_paths = 0 }
-    in_module && in_paths && /^      - / {
-      sub(/^      - /, "")
-      print
-    }
-  ' "$MODULES_FILE"
+  m="$module" yq '.modules[strenv(m)].paths[]?' "$MODULES_FILE"
 }
 
 # Print "capability value" pairs from a module requires: section.
 module_requires() {
   local module="$1"
-  awk -v module="$module" '
-    $0 == "  " module ":" { in_module = 1; next }
-    in_module && /^  [^ ].*:[[:space:]]*$/ { exit }
-    in_module && /^    requires:/ { in_requires = 1; next }
-    in_module && /^    [A-Za-z0-9_-]+:/ { in_requires = 0 }
-    in_module && in_requires && /^      [A-Za-z0-9_-]+:/ {
-      key = $1
-      sub(/:$/, "", key)
-      print key, $2
-    }
-  ' "$MODULES_FILE"
+  m="$module" \
+    yq '.modules[strenv(m)].requires // {} | to_entries | .[] | .key + " " + (.value | tostring)' "$MODULES_FILE"
 }
 
 # A module's paths are managed for a profile when the profile lists the
@@ -152,9 +127,14 @@ module_requires() {
 module_active_for_profile() {
   local profile="$1"
   local module="$2"
-  local capability value
+  local capability value modules
 
-  profile_modules "$profile" | grep -Fxq -- "$module" || return 1
+  # Capture, then test against a here-string. A `yq | grep -q` pipe
+  # would make yq exit with SIGPIPE once grep -q closes it early, which
+  # trips callers running under `set -o pipefail` (e.g. doctor.sh).
+  modules="$(profile_modules "$profile")"
+  grep -Fxq -- "$module" <<< "$modules" || return 1
+
   while read -r capability value; do
     [[ -z "$capability" ]] && continue
     [[ "$(capability_value "$profile" "$capability")" == "$value" ]] || return 1
@@ -163,36 +143,18 @@ module_active_for_profile() {
 }
 
 known_capabilities() {
-  awk '
-    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
-      name = $1
-      sub(/:$/, "", name)
-      print name
-    }
-  ' "$CAPABILITIES_FILE"
+  yq '.capabilities // {} | keys | .[]' "$CAPABILITIES_FILE"
 }
 
 capability_type() {
   local capability="$1"
-  awk -v capability="$capability" '
-    $0 == "  " capability ":" { in_cap = 1; next }
-    in_cap && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
-    in_cap && /^    type:/ { print $2; exit }
-  ' "$CAPABILITIES_FILE"
+  # type is always a string, so // "" only fires on absence.
+  c="$capability" yq '.capabilities[strenv(c)].type // ""' "$CAPABILITIES_FILE"
 }
 
 capability_allowed_values() {
   local capability="$1"
-  awk -v capability="$capability" '
-    $0 == "  " capability ":" { in_cap = 1; next }
-    in_cap && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { exit }
-    in_cap && /^    values:/ { in_values = 1; next }
-    in_cap && in_values && /^      - / {
-      sub(/^      - /, "")
-      print
-    }
-    in_cap && in_values && /^    [A-Za-z0-9_-]+:/ { exit }
-  ' "$CAPABILITIES_FILE"
+  c="$capability" yq '.capabilities[strenv(c)].values[]?' "$CAPABILITIES_FILE"
 }
 
 capability_value_is_allowed() {

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
 
+require_yq || exit 1
+
 NPMRC_TEMPLATE="$DOTFILES_ROOT/dot_npmrc.tmpl"
 CHEZMOIIGNORE="$DOTFILES_ROOT/.chezmoiignore"
 

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -240,11 +240,25 @@ run_fail_contains \
   "unknown option: -x" \
   "$fixture/scripts/validate-policy.sh" -x
 
-# Restrict PATH so yq is not resolvable; coreutils stay available.
+# require_yq must reject a wrong yq, not just a missing one. Shadow yq
+# with a fake earlier in PATH so the test is independent of whatever yq
+# the host has (CI runners ship one in /usr/bin).
 make_fixture
+mkdir -p "$fixture/fakebin"
+printf '#!/bin/sh\necho "yq 3.4.3 (python)"\n' > "$fixture/fakebin/yq"
+chmod +x "$fixture/fakebin/yq"
 run_fail_contains \
-  "fails closed when yq is unavailable" \
-  "yq not found" \
-  env PATH=/usr/bin:/bin "$fixture/scripts/validate-policy.sh" personal
+  "fails closed on a non-mikefarah yq" \
+  "wrong yq variant" \
+  env PATH="$fixture/fakebin:$PATH" "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+mkdir -p "$fixture/fakebin"
+printf '#!/bin/sh\necho "yq (https://github.com/mikefarah/yq/) version v3.4.0"\n' > "$fixture/fakebin/yq"
+chmod +x "$fixture/fakebin/yq"
+run_fail_contains \
+  "fails closed on yq older than v4" \
+  "yq v4+ required" \
+  env PATH="$fixture/fakebin:$PATH" "$fixture/scripts/validate-policy.sh" personal
 
 ok "policy tests passed"

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -240,4 +240,11 @@ run_fail_contains \
   "unknown option: -x" \
   "$fixture/scripts/validate-policy.sh" -x
 
+# Restrict PATH so yq is not resolvable; coreutils stay available.
+make_fixture
+run_fail_contains \
+  "fails closed when yq is unavailable" \
+  "yq not found" \
+  env PATH=/usr/bin:/bin "$fixture/scripts/validate-policy.sh" personal
+
 ok "policy tests passed"

--- a/scripts/test-render.sh
+++ b/scripts/test-render.sh
@@ -10,6 +10,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
 
+require_yq || exit 1
+
 if ! command -v chezmoi >/dev/null 2>&1; then
   fail "chezmoi not found; render tests require it"
   exit 1

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -217,6 +217,7 @@ case "$command" in
     ;;
 esac
 
+require_yq || exit 1
 require_data_files || exit 1
 
 case "$command" in


### PR DESCRIPTION
## Summary

`lib-policy.sh` の YAML パーサー群を awk から mikefarah/yq v4 に移行。2-space インデント整形規約への依存を解消。YAML パーサーのみ変更し、`git_remotes_with_credentials`(git config の解析、YAML 非依存)は awk のまま。

設計は #41、Codex 設計レビューの所見も #41 に記録。設計レビューで出た論点は実機検証で全て決着:
- `off` は yq で string(go-yaml v3)→ quote 不要。
- 重複 map キーは `keys` に両方残る → `sort | uniq -d` 検出は awk と同じく機能。
- `// ""` は boolean `false` を潰す欠陥 → `select(has())` に変更で回避(false 保持・欠損は空)。

## 主な変更

- **require_yq**: yq の存在 + mikefarah variant + v4 を fail-closed で検査。`validate-policy` / `test-npmrc` / `test-render` が呼ぶ。`doctor` / `preflight` は内部で validate-policy を先に走らせるため transitive にカバー。
- **injection 安全**: profile/module/capability 名は `strenv()` 経由で渡し、式へ展開しない。
- **pipefail バグ修正**: `module_active_for_profile` を `yq | grep -q` から capture + here-string に変更。`set -o pipefail`(doctor.sh)下で grep -q が pipe を早閉じすると yq が SIGPIPE になり、membership 判定が誤って失敗していた(awk は小出力がバッファに収まり露見せず)。
- **CI**: yq(v4.53.3 pin + sha256)を validate / render 両 job に install。
- **test**: yq 不在時の fail-closed 回帰を test-policy に追加。
- docs(policy-model.md / scripts/README.md)に yq 依存を明記。

## Linked Issue

Closes #41

## Validation

- 全 suite(validate-policy --all / test-policy / test-gitconfig / test-npmrc / test-doctor / test-render)pass。`bash -n` pass(shellcheck は CI)。
- require_yq fail-closed を実機確認(PATH から yq を除外 → "yq not found" で exit 1)。
- 重複キー・`off`・`select(has())` の挙動を yq v4.53.3 で実機検証。
- flake 確認: validate-policy --all を 12 回 + suite 3 周、再失敗なし。
- perf: validate-policy --all 約 1.5s(awk からの増加は許容範囲)。
- doctor / preflight exit 0。

## Side Effects

- install: CI runner への yq 導入のみ(pin + checksum)。**host への yq 導入は本 PR の対象外**(開発機には別途 `brew install yq` 済み。yq は packages.yaml の cli/base に宣言済み)。
- secret / network / 実 home への apply: なし。

## Residual Risk

- doctor / preflight が yq 必須に格上げ(従来は self-contained)。未導入時は require_yq が明示エラーで fail closed。
- yq を多数 spawn するため awk より遅い(--all で約 1.5s)。許容範囲だが、将来重くなれば per-file 一括読みに最適化可能。
- yq variant 検査は version 文字列の "mikefarah" 一致 + major>=4。Python 版 yq は弾く。

## Next

- environmentKind cross-check の設計(capability 制約を駆動する guard)→ Codex レビュー → 本 PR の yq base 上に実装。