### PR TITLE
environmentKind を capability 制約の guard にする(#43)

### DIFF
--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -30,10 +30,25 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 
 - profile 名だけで副作用を許可しない。
 - unknown profile / module / capability は fail closed。
-- destructive な操作は work / client でデフォルト無効。
+- destructive な操作は work / client / agent でデフォルト無効(environmentKind の制約として `validate-policy.sh` が hard fail で強制。下記参照)。
 - secret access、network tunnel、AI tools は personal でも明示的に扱う。
 - boolean で足りない capability は enum にする。
 - `report` は検査のみ、`enforce` / `enable` は実際の適用を意味する。
+
+## environmentKind の制約
+
+environmentKind は飾りラベルではなく、capability の不変条件を駆動する。`validate-policy.sh` が各 profile を検証するとき、environmentKind が禁止する boolean capability が `true` だと **hard fail**(report-only の warning ではない)する。「work 環境なのに `installPackages=true`」のような矛盾を CI で止めるための invariant(2026-06-14 決定)。
+
+| environmentKind | false 必須の capability |
+| --- | --- |
+| work / client / agent | installPackages, installGuiApps, enableMacOSDefaults, allowSecretsAccess, allowNetworkTunnels, enableAiTools |
+| sandbox | allowSecretsAccess |
+| personal | (制約なし) |
+
+- 表は `scripts/lib-policy.sh` の `environment_kind_forbidden_capabilities` が持つ。
+- `personal` は明示許可前提なので無制約。`agent` は profile がまだ無いが、最小権限を明示するため先行定義してある(agent profile 追加時に即発効)。
+- enum capability(`npmHardeningMode` など)への制約は今回の対象外(必要なら別 follow-up)。
+- 将来 work 等で禁止 capability を正当に許したくなった場合は、warning で迂回せず、この表自体を見直す。
 
 ## Capability Modes
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -178,6 +178,30 @@ is_allowed_environment_kind() {
   esac
 }
 
+# Boolean capabilities that must be false for a given environmentKind.
+# Encodes the policy that work / client / agent environments do not carry
+# elevated permissions (install, system mutation, secrets, network, AI
+# tooling) by default, and that sandbox forbids secret access. personal
+# is unconstrained; enum capabilities are out of scope here. See
+# docs/policy-model.md. agent has no profile yet; the row is defined so
+# the constraint takes effect the moment an agent profile is added.
+environment_kind_forbidden_capabilities() {
+  case "$1" in
+    work | client | agent)
+      printf '%s\n' \
+        installPackages \
+        installGuiApps \
+        enableMacOSDefaults \
+        allowSecretsAccess \
+        allowNetworkTunnels \
+        enableAiTools
+      ;;
+    sandbox)
+      printf '%s\n' allowSecretsAccess
+      ;;
+  esac
+}
+
 # Print names of remotes whose URL embeds password-like userinfo
 # (scheme://user:password@host). URL values are never printed.
 git_remotes_with_credentials() {

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -213,6 +213,37 @@ run_fail_contains \
   "module has requires but no paths: base" \
   "$fixture/scripts/validate-policy.sh" personal
 
+# environmentKind cross-check: a forbidden capability set true must fail.
+make_fixture
+replace_once "$fixture/.chezmoidata/profiles.yaml" "      installPackages: false" "      installPackages: true"
+run_fail_contains \
+  "work environmentKind forbids installPackages=true" \
+  "environmentKind work forbids installPackages=true" \
+  "$fixture/scripts/validate-policy.sh" work-minimal
+
+# client / sandbox / agent have no profile yet; retag personal (which has
+# elevated capabilities) to prove each row's constraint fires.
+make_fixture
+replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: client"
+run_fail_contains \
+  "client environmentKind forbids elevated capabilities" \
+  "environmentKind client forbids" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: sandbox"
+run_fail_contains \
+  "sandbox environmentKind forbids allowSecretsAccess" \
+  "environmentKind sandbox forbids allowSecretsAccess=true" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: agent"
+run_fail_contains \
+  "agent environmentKind forbids elevated capabilities" \
+  "environmentKind agent forbids" \
+  "$fixture/scripts/validate-policy.sh" personal
+
 make_fixture
 insert_once "$fixture/.chezmoidata/profiles.yaml" "      enableAiPolicy: true" "    extraSection:"
 insert_once "$fixture/.chezmoidata/profiles.yaml" "    extraSection:" "      sneakyKey: true"

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -213,13 +213,25 @@ run_fail_contains \
   "module has requires but no paths: base" \
   "$fixture/scripts/validate-policy.sh" personal
 
-# environmentKind cross-check: a forbidden capability set true must fail.
+# environmentKind cross-check. Every deny entry for work/client/agent
+# must actually fire: retag personal (already elevated) to work and force
+# the two caps it leaves false to true, then assert all six are flagged.
 make_fixture
-replace_once "$fixture/.chezmoidata/profiles.yaml" "      installPackages: false" "      installPackages: true"
-run_fail_contains \
-  "work environmentKind forbids installPackages=true" \
-  "environmentKind work forbids installPackages=true" \
-  "$fixture/scripts/validate-policy.sh" work-minimal
+replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: work"
+replace_once "$fixture/.chezmoidata/profiles.yaml" "      enableMacOSDefaults: false" "      enableMacOSDefaults: true"
+replace_once "$fixture/.chezmoidata/profiles.yaml" "      enableAiTools: false" "      enableAiTools: true"
+ek_output="$("$fixture/scripts/validate-policy.sh" personal 2>&1 || true)"
+ek_missing=""
+for cap in installPackages installGuiApps enableMacOSDefaults allowSecretsAccess allowNetworkTunnels enableAiTools; do
+  grep -Fq "environmentKind work forbids $cap=true" <<< "$ek_output" || ek_missing="$ek_missing $cap"
+done
+if [[ -z "$ek_missing" ]]; then
+  ok "test passed: every work deny capability is enforced"
+else
+  printf '%s\n' "$ek_output" >&2
+  fail "test failed: work deny not enforced for:$ek_missing"
+  exit 1
+fi
 
 # client / sandbox / agent have no profile yet; retag personal (which has
 # elevated capabilities) to prove each row's constraint fires.

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -108,7 +108,7 @@ validate_modules() {
 validate_profile() {
   local profile="$1"
   local status=0
-  local environment_kind module capability value type duplicate
+  local environment_kind module capability value type duplicate forbidden ek_violations
 
   if ! profile_exists "$profile"; then
     fail "unknown profile: $profile"
@@ -193,6 +193,23 @@ validate_profile() {
         ;;
     esac
   done < "$known_caps_file"
+
+  # environmentKind cross-check: capabilities the environmentKind forbids
+  # must be false. This makes the work/client/agent/sandbox restrictions a
+  # hard invariant rather than a convention (see docs/policy-model.md).
+  ek_violations=0
+  while IFS= read -r forbidden; do
+    [[ -z "$forbidden" ]] && continue
+    value="$(capability_value "$profile" "$forbidden")"
+    if [[ "$value" == "true" ]]; then
+      fail "environmentKind $environment_kind forbids $forbidden=true (profile $profile)"
+      status=1
+      ek_violations=$((ek_violations + 1))
+    fi
+  done < <(environment_kind_forbidden_capabilities "$environment_kind")
+  if [[ "$ek_violations" -eq 0 ]]; then
+    ok "environmentKind constraints satisfied: $environment_kind"
+  fi
 
   if [[ "$status" -eq 0 ]]; then
     ok "policy validation passed for profile: $profile"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -197,18 +197,22 @@ validate_profile() {
   # environmentKind cross-check: capabilities the environmentKind forbids
   # must be false. This makes the work/client/agent/sandbox restrictions a
   # hard invariant rather than a convention (see docs/policy-model.md).
-  ek_violations=0
-  while IFS= read -r forbidden; do
-    [[ -z "$forbidden" ]] && continue
-    value="$(capability_value "$profile" "$forbidden")"
-    if [[ "$value" == "true" ]]; then
-      fail "environmentKind $environment_kind forbids $forbidden=true (profile $profile)"
-      status=1
-      ek_violations=$((ek_violations + 1))
+  # Only meaningful for a valid kind; an unknown/missing environmentKind
+  # has already failed above, and must not print "satisfied".
+  if is_allowed_environment_kind "$environment_kind"; then
+    ek_violations=0
+    while IFS= read -r forbidden; do
+      [[ -z "$forbidden" ]] && continue
+      value="$(capability_value "$profile" "$forbidden")"
+      if [[ "$value" == "true" ]]; then
+        fail "environmentKind $environment_kind forbids $forbidden=true (profile $profile)"
+        status=1
+        ek_violations=$((ek_violations + 1))
+      fi
+    done < <(environment_kind_forbidden_capabilities "$environment_kind")
+    if [[ "$ek_violations" -eq 0 ]]; then
+      ok "environmentKind constraints satisfied: $environment_kind"
     fi
-  done < <(environment_kind_forbidden_capabilities "$environment_kind")
-  if [[ "$ek_violations" -eq 0 ]]; then
-    ok "environmentKind constraints satisfied: $environment_kind"
   fi
 
   if [[ "$status" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

environmentKind が tag のみで何も駆動しない問題(中間レビュー指摘)を解消。`validate-policy.sh` が各 profile を cross-check し、**environmentKind が禁止する boolean capability が true なら hard fail** する(doctor warning ではない)。「work 環境なのに installPackages=true」を CI で止める invariant。設計は #41 と同様 設計 → Codex 設計レビュー(GO)→ 実装の順。

## 変更

- `lib-policy.sh` の `environment_kind_forbidden_capabilities` が deny 表を持つ:
  - work / client / agent: installPackages / installGuiApps / enableMacOSDefaults / allowSecretsAccess / allowNetworkTunnels / enableAiTools を false 必須
  - sandbox: allowSecretsAccess を false 必須
  - personal: 無制約
- `validate-policy.sh` の profile 検証に cross-check ブロックを追加(違反は status=1)。
- enum capability への制約は対象外(別 follow-up)。
- docs/policy-model.md に表と hard-fail 方針を明記、Rules の該当行も更新。

設計レビューでの Codex 指摘を反映済み: enableAiTools を deny に追加、agent 行を先行定義(profile 未存在でも将来即発効)、client/sandbox/agent も回帰テスト対象に。

## Linked Issue

Closes #43

## Validation

- 全 suite pass(`validate-policy --all` / `test-policy`(新規 4 件含む)/ `test-gitconfig` / `test-npmrc` / `test-doctor` / `test-render`)。`bash -n` pass(shellcheck は CI)。
- 現行 3 profile は制約を満たす(`environmentKind constraints satisfied` を確認)。
- 回帰: work に installPackages=true を入れると fail、personal を client/sandbox/agent に retag すると各 deny が発火することを確認。
- flake 確認(validate-policy --all ×5)、doctor / preflight exit 0。

## Side Effects

- install / secret / network / 実 home への apply: なし(検証ロジックと docs のみ)。

## Residual Risk

- hard fail のため、将来 work 等で禁止 capability を正当に許す場合は deny 表の見直しが必要(意図的な摩擦)。
- agent / client / sandbox profile は未存在。制約は表に先行定義済みで、profile 追加時に即発効する。

## Next

- enum capability への制約(npmHardeningMode 等)を入れるかは別 follow-up。
- #15 / #16 / #17(zsh / VS Code / SSH)は既存ファイル棚卸しが要るため本人と。