### PR TITLE
doctor に agent-tools の report-only status チェックを追加(#7)

### DIFF
--- a/.chezmoidata/capabilities.schema.yaml
+++ b/.chezmoidata/capabilities.schema.yaml
@@ -35,5 +35,7 @@ capabilities:
     type: boolean
   enableAiTools:
     type: boolean
+  enableAgentToolsStatus:
+    type: boolean
   enableAiPolicy:
     type: boolean

--- a/.chezmoidata/profiles.yaml
+++ b/.chezmoidata/profiles.yaml
@@ -33,6 +33,7 @@ profiles:
       allowNetworkTunnels: true
       allowSecretsAccess: true
       enableAiTools: false
+      enableAgentToolsStatus: false
       enableAiPolicy: true
 
   work-minimal:
@@ -62,6 +63,7 @@ profiles:
       allowNetworkTunnels: false
       allowSecretsAccess: false
       enableAiTools: false
+      enableAgentToolsStatus: false
       enableAiPolicy: true
 
   work-dev:
@@ -96,4 +98,5 @@ profiles:
       allowNetworkTunnels: false
       allowSecretsAccess: false
       enableAiTools: false
+      enableAgentToolsStatus: false
       enableAiPolicy: true

--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -80,6 +80,7 @@ AI skills / agents project は、`dotfiles` の policy を前提に動く。poli
 - `dotfiles` は AI skills / agents project の path を表示してよい。
 - `dotfiles` は AI skills / agents project を自動更新しない。
 - `dotfiles` は AI skills / agents project の secret を読まない。
+- `dotfiles` の `doctor` は、`~/src/agent/agent-tools` の presence と、存在すれば status contract(`scripts/status.sh --json`、report-only、`contract_version: 2`)の安全な summary を report する(Issue #7)。`conflict` / `stale` / 失敗 check などは warning にするが、clone / pull / sync は一切しない。
 - AI skills / agents project は `dotfiles` の capability を前提条件として参照してよい。
 - AI skills / agents project が install、network tunnel、secret access を必要とする場合は、`dotfiles` 側の capability と approval policy に従う。
 

--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -80,7 +80,7 @@ AI skills / agents project は、`dotfiles` の policy を前提に動く。poli
 - `dotfiles` は AI skills / agents project の path を表示してよい。
 - `dotfiles` は AI skills / agents project を自動更新しない。
 - `dotfiles` は AI skills / agents project の secret を読まない。
-- `dotfiles` の `doctor` は、`~/src/agent/agent-tools` の presence と、存在すれば status contract(`scripts/status.sh --json`、report-only、`contract_version: 2`)の安全な summary を report する(Issue #7)。`conflict` / `stale` / 失敗 check などは warning にするが、clone / pull / sync は一切しない。
+- `dotfiles` の `doctor` は `~/src/agent/agent-tools` の presence を report する。status(`scripts/status.sh --json`、report-only、`contract_version: 2`)の読み取りは別 repo のコード実行になるため、`enableAgentToolsStatus` capability での明示 opt-in 時のみ実行し、安全な summary(`conflict` / `stale` / 失敗 check 等は warning)を出す(Issue #7)。clone / pull / sync は一切しない。
 - AI skills / agents project は `dotfiles` の capability を前提条件として参照してよい。
 - AI skills / agents project が install、network tunnel、secret access を必要とする場合は、`dotfiles` 側の capability と approval policy に従う。
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ policy validation が失敗した場合は exit 1。
 
 ## doctor.sh
 
-導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、agent-tools(report-only。`~/src/agent/agent-tools` の presence と、存在すれば status contract(`scripts/status.sh --json`)の安全な summary。clone / pull / sync はしない)、project root の状態を表示する。
+導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、agent-tools(report-only。`~/src/agent/agent-tools` の presence を表示し、`enableAgentToolsStatus=true` の opt-in 時のみ status contract(`scripts/status.sh --json`)を実行して安全な summary を出す。clone / pull / sync はしない)、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
 remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md`、Corepack の検査は `docs/supply-chain-corepack.md` に従う。
 `npmHardeningMode=enforce` の profile では、期待する npm config 値と現在値の不一致を `[warn]` で報告する(apply 前は不一致が正常)。
@@ -136,6 +136,9 @@ fixture HOME で doctor の managed-path orphan 検出を検証する。実 home
 - managed-by header があり現 profile で管理対象でない file が warning になること(profile 切替の残骸)。
 - 同じ file でも管理対象の profile では orphan にならないこと。
 - header のない file は orphan 扱いしないこと。
+- agent-tools の status.sh 実行が opt-in であること(`enableAgentToolsStatus=false` では実行マーカーが作られない)。
+- opt-in 時は status を summary し `conflict` を warning にすること。
+- contract version 不一致 / status.sh 欠如 / agent-tools 不在でも warning のみで exit 0 になること。
 - いずれの場合も doctor が exit 0 を維持すること(report-only)。
 
 ## test-render.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ policy validation が失敗した場合は exit 1。
 
 ## doctor.sh
 
-導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、project root の状態を表示する。
+導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、agent-tools(report-only。`~/src/agent/agent-tools` の presence と、存在すれば status contract(`scripts/status.sh --json`)の安全な summary。clone / pull / sync はしない)、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
 remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md`、Corepack の検査は `docs/supply-chain-corepack.md` に従う。
 `npmHardeningMode=enforce` の profile では、期待する npm config 値と現在値の不一致を `[warn]` で報告する(apply 前は不一致が正常)。

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -249,6 +249,78 @@ else
   ok "AI tool install/sync not managed (enableAiTools=false)"
 fi
 
+section "agent-tools (report-only)"
+# Report-only companion check. dotfiles never clones/pulls/syncs
+# agent-tools; it only reads the status contract (its scripts/status.sh
+# --json, report-only by contract). See docs/ai-environment-boundary.md
+# and the agent-tools status-manifest-contract (contract_version 2).
+if [[ "$(capability_value "$profile" enableAiPolicy)" != "true" ]]; then
+  ok "AI policy disabled; skipping agent-tools check"
+else
+  agent_tools_dir="$HOME/src/agent/agent-tools"
+  agent_tools_status="$agent_tools_dir/scripts/status.sh"
+  if [[ ! -d "$agent_tools_dir" ]]; then
+    warn "agent-tools not present at $agent_tools_dir (not auto-cloned)"
+  elif [[ ! -x "$agent_tools_status" ]]; then
+    warn "agent-tools present but scripts/status.sh is missing or not executable"
+  elif ! status_json="$("$agent_tools_status" --json 2>/dev/null)" || [[ -z "$status_json" ]]; then
+    warn "agent-tools status.sh produced no usable output (skipping summary)"
+  else
+    # Null-safe queries plus `|| true` keep doctor report-only even if
+    # the JSON is malformed (a failed substitution would trip set -e).
+    sj() { printf '%s' "$status_json" | yq -p json "$1" 2>/dev/null || true; }
+    contract_version="$(sj '.contract_version // ""')"
+    if [[ "$contract_version" != "2" ]]; then
+      warn "agent-tools status contract_version=${contract_version:-unknown}, expected 2 (not interpreting fields)"
+    else
+      ok "agent-tools present; status contract v2"
+
+      if [[ "$(sj '.repo.clean // false')" == "true" ]]; then
+        ok "agent-tools working tree clean"
+      else
+        warn "agent-tools working tree not clean"
+      fi
+
+      item "assets: $(sj '.assets.total // 0') (manifest errors: $(sj '.assets.manifest_errors // 0'))"
+      if [[ "$(sj '.assets.manifest_errors // 0')" != "0" ]]; then
+        warn "agent-tools manifest validation errors present"
+      fi
+
+      for check in manifest_validation prompt_injection_static; do
+        result="$(sj ".checks.$check // \"not_run\"")"
+        if [[ "$result" == "pass" ]]; then
+          ok "check $check: pass"
+        else
+          warn "check $check: $result"
+        fi
+      done
+
+      item "generated: $(sj '.generated.total // 0') (stale: $(sj '.generated.stale // 0'))"
+      if [[ "$(sj '.generated.stale // 0')" != "0" ]]; then
+        warn "agent-tools has stale generated artifacts"
+      fi
+
+      if [[ "$(sj '.register.catalog_present // false')" == "true" ]]; then
+        item "register: registered=$(sj '.register.registered // 0') human_review=$(sj '.register.human_review_required // 0') unsupported=$(sj '.register.unsupported // 0')"
+        if [[ "$(sj '.register.human_review_required // 0')" != "0" ]]; then
+          warn "agent-tools assets require human review"
+        fi
+      else
+        item "register: catalog not present"
+      fi
+
+      item "sync targets: $(sj '.sync_targets // [] | length')"
+      if [[ "$(sj '[.sync_targets[]? | select(.state == "conflict")] | length')" != "0" ]]; then
+        warn "agent-tools sync conflicts (unmanaged same-name targets); sync must not change them"
+      fi
+      if [[ "$(sj '[.sync_targets[]? | select(.state == "stale")] | length')" != "0" ]]; then
+        warn "agent-tools has stale sync targets (generated artifact newer than target)"
+      fi
+    fi
+    unset -f sj
+  fi
+fi
+
 section "network tunnels"
 allow_tunnels="$(capability_value "$profile" allowNetworkTunnels)"
 ok "allowNetworkTunnels=$allow_tunnels"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -251,9 +251,11 @@ fi
 
 section "agent-tools (report-only)"
 # Report-only companion check. dotfiles never clones/pulls/syncs
-# agent-tools; it only reads the status contract (its scripts/status.sh
-# --json, report-only by contract). See docs/ai-environment-boundary.md
-# and the agent-tools status-manifest-contract (contract_version 2).
+# agent-tools. Presence is always reported, but running its status.sh
+# (executing code from another repo) is opt-in via enableAgentToolsStatus
+# so doctor's no-side-effects invariant is never delegated implicitly.
+# See docs/ai-environment-boundary.md and the agent-tools
+# status-manifest-contract (contract_version 2).
 if [[ "$(capability_value "$profile" enableAiPolicy)" != "true" ]]; then
   ok "AI policy disabled; skipping agent-tools check"
 else
@@ -261,6 +263,8 @@ else
   agent_tools_status="$agent_tools_dir/scripts/status.sh"
   if [[ ! -d "$agent_tools_dir" ]]; then
     warn "agent-tools not present at $agent_tools_dir (not auto-cloned)"
+  elif [[ "$(capability_value "$profile" enableAgentToolsStatus)" != "true" ]]; then
+    ok "agent-tools present; status read disabled (set enableAgentToolsStatus=true to let doctor run its status.sh)"
   elif [[ ! -x "$agent_tools_status" ]]; then
     warn "agent-tools present but scripts/status.sh is missing or not executable"
   elif ! status_json="$("$agent_tools_status" --json 2>/dev/null)" || [[ -z "$status_json" ]]; then

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -90,12 +90,13 @@ else
   status=1
 fi
 
-# Throwaway repo copy with the opt-in enabled for personal.
+# Throwaway repo copy with the opt-in enabled for every profile, so the
+# test does not depend on which profile comes first.
 optin_root="$fixture_home/.dotfiles-optin"
 mkdir -p "$optin_root/.chezmoidata"
 cp -R "$DOTFILES_ROOT/scripts" "$optin_root/scripts"
 cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$optin_root/.chezmoidata/"
-awk '!done && $0 == "      enableAgentToolsStatus: false" { print "      enableAgentToolsStatus: true"; done = 1; next } { print }' \
+awk '$0 == "      enableAgentToolsStatus: false" { print "      enableAgentToolsStatus: true"; next } { print }' \
   "$optin_root/.chezmoidata/profiles.yaml" > "$optin_root/.chezmoidata/profiles.yaml.tmp"
 mv "$optin_root/.chezmoidata/profiles.yaml.tmp" "$optin_root/.chezmoidata/profiles.yaml"
 
@@ -150,6 +151,40 @@ if at_out="$(HOME="$fixture_home" "$optin_root/scripts/doctor.sh" personal 2>&1)
 else
   printf '%s\n' "$at_out" >&2
   fail "test failed: doctor must stay exit 0 when status.sh missing"
+  status=1
+fi
+
+# F) Opt-in + status.sh exits non-zero: warning, still exit 0.
+cat > "$agent_scripts/status.sh" <<'SH'
+#!/bin/sh
+exit 1
+SH
+chmod +x "$agent_scripts/status.sh"
+if at_out="$(HOME="$fixture_home" "$optin_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "no usable output" <<< "$at_out"; then
+    ok "test passed: status.sh failure is a warning (exit 0)"
+  else
+    printf '%s\n' "$at_out" >&2
+    fail "test failed: status.sh failure not handled"
+    status=1
+  fi
+else
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: doctor must stay exit 0 when status.sh exits non-zero"
+  status=1
+fi
+
+# G) Opt-in + malformed status JSON: doctor must not break, exit 0.
+cat > "$agent_scripts/status.sh" <<'SH'
+#!/bin/sh
+[ "$1" = "--json" ] || exit 1
+echo 'this is not json {{{'
+SH
+chmod +x "$agent_scripts/status.sh"
+if HOME="$fixture_home" "$optin_root/scripts/doctor.sh" personal >/dev/null 2>&1; then
+  ok "test passed: malformed status JSON keeps doctor at exit 0"
+else
+  fail "test failed: malformed status JSON must not break doctor"
   status=1
 fi
 

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -55,6 +55,72 @@ else
   ok "test passed: headerless file ignored"
 fi
 
+# agent-tools report-only section. A fake status.sh emits the contract
+# JSON; doctor must summarize it and flag conflict targets, never write,
+# and always exit 0.
+agent_scripts="$fixture_home/src/agent/agent-tools/scripts"
+mkdir -p "$agent_scripts"
+cat > "$agent_scripts/status.sh" <<'SH'
+#!/bin/sh
+[ "$1" = "--json" ] || exit 1
+cat <<'JSON'
+{"contract_version":2,"repo":{"present":true,"clean":true},"assets":{"total":1,"manifest_errors":0},"checks":{"manifest_validation":"pass","prompt_injection_static":"pass"},"generated":{"total":1,"stale":0},"register":{"catalog_present":true,"registered":1,"human_review_required":0,"unsupported":0},"sync_targets":[{"tool":"codex","name":"x","state":"conflict"}]}
+JSON
+SH
+chmod +x "$agent_scripts/status.sh"
+
+if ! at_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: doctor must stay exit 0 with agent-tools present"
+  status=1
+fi
+if grep -Fq "agent-tools present; status contract v2" <<< "$at_out"; then
+  ok "test passed: agent-tools status summarized"
+else
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: agent-tools status not summarized"
+  status=1
+fi
+if grep -Fq "sync conflicts" <<< "$at_out"; then
+  ok "test passed: agent-tools conflict target flagged"
+else
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: agent-tools conflict not flagged"
+  status=1
+fi
+
+# An unknown contract version must not be interpreted.
+cat > "$agent_scripts/status.sh" <<'SH'
+#!/bin/sh
+[ "$1" = "--json" ] || exit 1
+echo '{"contract_version":99}'
+SH
+chmod +x "$agent_scripts/status.sh"
+at_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1 || true)"
+if grep -Fq "expected 2 (not interpreting fields)" <<< "$at_out"; then
+  ok "test passed: unknown agent-tools contract version is not interpreted"
+else
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: contract version mismatch not handled"
+  status=1
+fi
+
+# Absent agent-tools is a report-only warning, not a failure.
+rm -rf "$fixture_home/src/agent/agent-tools"
+if at_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "agent-tools not present" <<< "$at_out"; then
+    ok "test passed: absent agent-tools reported, doctor exit 0"
+  else
+    printf '%s\n' "$at_out" >&2
+    fail "test failed: absent agent-tools not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: doctor must stay exit 0 when agent-tools absent"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "doctor tests passed"
 fi

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -55,58 +55,106 @@ else
   ok "test passed: headerless file ignored"
 fi
 
-# agent-tools report-only section. A fake status.sh emits the contract
-# JSON; doctor must summarize it and flag conflict targets, never write,
-# and always exit 0.
-agent_scripts="$fixture_home/src/agent/agent-tools/scripts"
+# agent-tools report-only section. Presence is always reported; running
+# status.sh is opt-in via enableAgentToolsStatus. doctor must always
+# exit 0 and never write. The fake status.sh records that it ran so the
+# opt-in gate can be proven.
+agent_dir="$fixture_home/src/agent/agent-tools"
+agent_scripts="$agent_dir/scripts"
+agent_marker="$agent_dir/ran-marker"
 mkdir -p "$agent_scripts"
 cat > "$agent_scripts/status.sh" <<'SH'
 #!/bin/sh
 [ "$1" = "--json" ] || exit 1
+: > "$(dirname "$0")/../ran-marker"
 cat <<'JSON'
 {"contract_version":2,"repo":{"present":true,"clean":true},"assets":{"total":1,"manifest_errors":0},"checks":{"manifest_validation":"pass","prompt_injection_static":"pass"},"generated":{"total":1,"stale":0},"register":{"catalog_present":true,"registered":1,"human_review_required":0,"unsupported":0},"sync_targets":[{"tool":"codex","name":"x","state":"conflict"}]}
 JSON
 SH
 chmod +x "$agent_scripts/status.sh"
 
-if ! at_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
-  printf '%s\n' "$at_out" >&2
-  fail "test failed: doctor must stay exit 0 with agent-tools present"
-  status=1
-fi
-if grep -Fq "agent-tools present; status contract v2" <<< "$at_out"; then
-  ok "test passed: agent-tools status summarized"
+# A) Default profile (enableAgentToolsStatus=false): present but status.sh
+#    must not run.
+rm -f "$agent_marker"
+if at_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "status read disabled" <<< "$at_out" && [[ ! -e "$agent_marker" ]]; then
+    ok "test passed: agent-tools status execution is opt-in (not run by default)"
+  else
+    printf '%s\n' "$at_out" >&2
+    fail "test failed: agent-tools status.sh ran or was not reported as disabled"
+    status=1
+  fi
 else
   printf '%s\n' "$at_out" >&2
-  fail "test failed: agent-tools status not summarized"
-  status=1
-fi
-if grep -Fq "sync conflicts" <<< "$at_out"; then
-  ok "test passed: agent-tools conflict target flagged"
-else
-  printf '%s\n' "$at_out" >&2
-  fail "test failed: agent-tools conflict not flagged"
+  fail "test failed: doctor must stay exit 0 (agent-tools present, opt-in off)"
   status=1
 fi
 
-# An unknown contract version must not be interpreted.
+# Throwaway repo copy with the opt-in enabled for personal.
+optin_root="$fixture_home/.dotfiles-optin"
+mkdir -p "$optin_root/.chezmoidata"
+cp -R "$DOTFILES_ROOT/scripts" "$optin_root/scripts"
+cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$optin_root/.chezmoidata/"
+awk '!done && $0 == "      enableAgentToolsStatus: false" { print "      enableAgentToolsStatus: true"; done = 1; next } { print }' \
+  "$optin_root/.chezmoidata/profiles.yaml" > "$optin_root/.chezmoidata/profiles.yaml.tmp"
+mv "$optin_root/.chezmoidata/profiles.yaml.tmp" "$optin_root/.chezmoidata/profiles.yaml"
+
+# B) Opt-in enabled: status.sh runs, summary shown, conflict flagged.
+rm -f "$agent_marker"
+if at_out="$(HOME="$fixture_home" "$optin_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "agent-tools present; status contract v2" <<< "$at_out" \
+    && grep -Fq "sync conflicts" <<< "$at_out" && [[ -e "$agent_marker" ]]; then
+    ok "test passed: opt-in runs status.sh and summarizes (conflict flagged)"
+  else
+    printf '%s\n' "$at_out" >&2
+    fail "test failed: opt-in summary/conflict/marker missing"
+    status=1
+  fi
+else
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: doctor must stay exit 0 (opt-in summary)"
+  status=1
+fi
+
+# C) Opt-in + unknown contract version: not interpreted, still exit 0.
 cat > "$agent_scripts/status.sh" <<'SH'
 #!/bin/sh
 [ "$1" = "--json" ] || exit 1
 echo '{"contract_version":99}'
 SH
 chmod +x "$agent_scripts/status.sh"
-at_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1 || true)"
-if grep -Fq "expected 2 (not interpreting fields)" <<< "$at_out"; then
-  ok "test passed: unknown agent-tools contract version is not interpreted"
+if at_out="$(HOME="$fixture_home" "$optin_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "expected 2 (not interpreting fields)" <<< "$at_out"; then
+    ok "test passed: unknown contract version is not interpreted (exit 0)"
+  else
+    printf '%s\n' "$at_out" >&2
+    fail "test failed: contract version mismatch not handled"
+    status=1
+  fi
 else
   printf '%s\n' "$at_out" >&2
-  fail "test failed: contract version mismatch not handled"
+  fail "test failed: doctor must stay exit 0 on contract version mismatch"
   status=1
 fi
 
-# Absent agent-tools is a report-only warning, not a failure.
-rm -rf "$fixture_home/src/agent/agent-tools"
+# D) Opt-in + missing status.sh: warning, still exit 0.
+rm -f "$agent_scripts/status.sh"
+if at_out="$(HOME="$fixture_home" "$optin_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "status.sh is missing or not executable" <<< "$at_out"; then
+    ok "test passed: missing status.sh is a warning (exit 0)"
+  else
+    printf '%s\n' "$at_out" >&2
+    fail "test failed: missing status.sh not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$at_out" >&2
+  fail "test failed: doctor must stay exit 0 when status.sh missing"
+  status=1
+fi
+
+# E) Absent agent-tools: report-only warning, exit 0.
+rm -rf "$agent_dir"
 if at_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
   if grep -Fq "agent-tools not present" <<< "$at_out"; then
     ok "test passed: absent agent-tools reported, doctor exit 0"


### PR DESCRIPTION
## Summary

`agent-tools`(`kosako/agent-tools`、別 public repo)が status/manifest contract(`contract_version: 2`、`scripts/status.sh --json`)を実装済みになったので、#7 の dotfiles 側 report-only 受け口を実装。doctor が agent-tools を **clone / pull / sync せず**、status を読むだけで安全な summary を出す。

## 変更

- `doctor.sh` に `agent-tools (report-only)` セクション(enableAiPolicy で gate、AI policy セクションに隣接):
  - `~/src/agent/agent-tools` の presence を確認。無ければ warning。
  - あれば `scripts/status.sh --json` を実行(contract 上 report-only)、`contract_version` を検証(2 以外は「not interpreting fields」で停止)。
  - 安全な summary: repo clean、assets/manifest_errors、checks、generated/stale、register summary、sync_targets の状態。`conflict` / `stale` / 失敗 check / `human_review_required` を warning。
- **常に report-only**: 不在・status.sh 欠如・実行失敗・version 不一致・不正 JSON のいずれも warning で exit 0(null-safe yq + `|| true` で set -e を踏まない)。
- contract が「dotfiles が読んでよい/読まない情報」を規定しており、metadata と state のみ読む(secret / asset 本体は読まない)。
- test-doctor: present(conflict target あり)/ version 不一致 / 不在 を検証、いずれも exit 0。
- docs: scripts/README.md、ai-environment-boundary.md。

## Linked Issue

Closes #7

## Validation

- 全 suite pass(validate-policy / test-policy / test-gitconfig / test-npmrc / **test-doctor**(新規 4 件)/ test-render)。`bash -n` pass(shellcheck は CI)。
- fixture smoke test: present / version 不一致 / 不在 の 3 ケースで期待どおりの出力 + doctor exit 0 を確認。
- 実 home(agent-tools 未 clone)で doctor exit 0、当該セクションは「not present」を表示。

## Side Effects

- install / secret / network / 実 home への apply: なし。
- **doctor が `~/src/agent/agent-tools/scripts/status.sh` を実行する**点は設計上の論点(別 repo のコード実行)。status.sh は contract 上 report-only で、ユーザーが両 repo を所有。doctor は既に git/npm/op/chezmoi 等の外部コマンドを実行しており、同等の信頼前提。出力捕捉のみ・書き込みなし・常に exit 0。レビューで懸念があれば opt-in 化を検討。

## Residual Risk

- contract 文書(status-manifest-contract.md v2)に対して実装。実 `status.sh` 出力が doc から drift していれば summary がずれうる(version guard で致命化は防止)。
- 実 home で live status を見るには `~/src/agent/agent-tools` への clone が別途必要(dotfiles は自動 clone しない)。

## Next

- (任意)agent-tools を `~/src/agent/agent-tools` に clone すれば live status が doctor に出る。