### PR TITLE
Concretize mise runtime module with global baseline (#54)

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,14 +1,34 @@
 # Runtime
 
-`runtime` module の方針。mise で runtime(node、python など)を管理する。
+`runtime` module の方針。mise で言語 runtime(node、go、python など)を管理する。
+
+## global baseline と project pin の責務分界
+
+global の mise config(`~/.config/mise/config.toml`)と project の `.mise.toml` は役割が違う。
+
+- **global(baseline)**: project の外でも動く必要があるグローバル CLI のための *最小 baseline runtime* だけを宣言する。具体例: npm global tool(例 `@anthropic-ai/claude-code` / `@openai/codex`)は node を、`go install` 由来の tool(例 `goreleaser`)は go を、どの project にいなくても要求する。これらが動く下地を出すのが global の役割。
+  - baseline は `lts` / major 線で宣言する(例: `node = "lts"`、`go = "1.26"`)。**再現性のための exact pin ではない**。
+- **project(override)**: 各 project の `.mise.toml` が **exact version** で pin し、global baseline を override する(例: `templates/project/python/.mise.toml`)。再現性の責務は project 側にある。
+
+この分界は意図的な決定(2026-06-18、#54)。以前は「global に tool version を置かない」方針だったが、global CLI(npm global / go install 由来)が project 外でも runtime を要するため、global に最小 baseline を置く形へ改めた。global は「再現性 pin の置き場」ではなく「グローバルツールの稼働基盤」と位置づける。
+
+## uv の扱い
+
+- `uv` は **Python の tool/package manager(tool)** であって、言語 runtime の管理ではない。グローバル CLI として使うため mise の tool として供給する。
+- **Python runtime の pin は別 scope**。global mise config に python を baseline 宣言しない(必要になったら別途方針を決める)。
 
 ## 方針
 
-- global の mise config(`~/.config/mise/config.toml`)は最小限に保ち、global に tool version を置かない。
-- version pin は project 側の `.mise.toml` の責務。exact version で pin する(例: `templates/project/python/.mise.toml`)。
-- runtime の自動 install はしない。`not_found_auto_install = false` を設定し、install は明示的な `mise install` で行う。
+- runtime の自動 install はしない。`not_found_auto_install = false` を設定し、install は明示的な `mise install` で行う。baseline を宣言しても、shim 呼び出しで勝手に runtime を取りに行かない。
 - `mise trust` / `direnv allow` は自動化しない。
 - `enableRuntimeManagement=false` の profile では、mise config を chezmoi 管理対象外にする。この gate は `runtime` module の `paths:` / `requires:` 宣言(`.chezmoidata/modules.yaml`)から `.chezmoiignore` に生成される。
+
+## config 管理と実 install の境界
+
+`enableRuntimeManagement` が制御するのは **mise config file の chezmoi 管理**であって、runtime を実際に install することではない。
+
+- `work-dev` は `enableRuntimeManagement=true`(config 管理は可)だが `installPackages=false`。実際の `mise install`(runtime を取得する install 操作)は **本人の明示手動操作に限定**し、repo が work 環境で自動実行することはしない。
+- environmentKind の制約上、work / client / agent では install 系 capability が false 必須(`docs/policy-model.md`)。mise config を管理することと runtime を install することは別レイヤだと理解する。
 
 ## capability との対応
 
@@ -17,10 +37,26 @@
 
 ## update policy との関係
 
-runtime の upgrade は project 側の pin 変更として明示的に行う。global での自動 upgrade はしない(`docs/update-policy.md`)。
+runtime の upgrade は project 側の pin 変更、または global baseline 線の明示的な変更として行う。global での自動 upgrade はしない(`docs/update-policy.md`)。
+
+## 移行手順(brew → mise)
+
+既に node / go / uv を Homebrew で入れている環境を mise 供給へ移す手順。**実 home への操作は本人が明示的に行う**(repo は勝手に install / uninstall しない)。npm global package は node の prefix 配下に入るため、node 供給元を切り替えると **見えなくなる**。先に入れ直すこと。
+
+1. **mise 導入**: `brew install mise`(`packages.yaml` の `cli.runtime` に宣言済み)。shell 統合(`mise activate`)を有効化。
+2. **baseline runtime を install**: `mise install`(global config の `node` / `go` / `uv` を取得)。`not_found_auto_install=false` なのでこの明示実行が必要。
+3. **PATH 確認**: 新しい shell で `command -v node npm go uv` が mise 配下(`$HOME/.local/share/mise/...` の shim)を指すことを確認。
+4. **global npm tool の入れ直し**: mise の node 配下に `@anthropic-ai/claude-code` / `@openai/codex` を入れ直す。`npm root -g` が mise 配下になっていることを確認する。
+5. **go tool**: `$HOME/go/bin` 配下の tool(`goreleaser` 等)は go バイナリと独立なので PATH に残るが、必要なら mise の go で再ビルドする。
+6. **検証**: `command -v node npm go uv claude codex` がすべて解決し、`npm root -g` が mise 配下を指すことを確認してから次へ。
+7. **brew から撤去**: 検証が済んだら `brew uninstall node go uv`。node/go/uv に依存する他 formula が無いことを `brew uses --installed node go uv` で事前確認する。
+
+### rollback
+
+撤去前に問題が出たら `brew uninstall` を行わなければよい(mise と brew の runtime が共存している状態に戻すだけ)。撤去後に戻すなら `brew install node go uv` で再導入する。
 
 ## 対象外
 
-- mise 自体の install(package install は後続 phase)。
 - runtime の自動 install / upgrade。
 - project ごとの version 強制。
+- Python runtime の pin(uv は tool として扱う。runtime pin は別 scope)。

--- a/private_dot_config/mise/config.toml.tmpl
+++ b/private_dot_config/mise/config.toml.tmpl
@@ -1,7 +1,14 @@
 # Managed by chezmoi from kosako/dotfiles.
-# Global mise config stays minimal: no global tool versions.
-# Pin runtimes per project in .mise.toml with exact versions.
-# See docs/runtime.md.
+# Global mise config: baseline runtimes for global tooling only.
+#
+# Scope split (see docs/runtime.md):
+#   - global (this file): the minimal baseline runtimes that global CLIs
+#     (npm-global / go-installed tools) need to run outside any project.
+#     Declared as lts / major lines, NOT reproducibility pins.
+#   - project (.mise.toml): pins exact versions and overrides the baseline.
+#
+# uv is a Python tool manager (a tool), not Python runtime management;
+# Python runtime pinning is a separate scope and is not declared here.
 
 [settings]
 # Do not auto-install missing runtimes when a shim is invoked.
@@ -9,4 +16,9 @@
 not_found_auto_install = false
 
 [tools]
-# Intentionally empty. Global tool versions are not managed here.
+# Baseline runtimes for global tooling. Projects override with exact
+# versions in their own .mise.toml.
+node = "lts"
+go = "1.26"
+# uv: Python tool manager (tool), provided so global `uv` works.
+uv = "latest"

--- a/templates/project/python/.mise.toml
+++ b/templates/project/python/.mise.toml
@@ -1,4 +1,4 @@
-# Pin runtimes per project with exact versions.
-# See ~/dotfiles/docs/runtime.md (global mise config stays minimal).
+# Pin runtimes per project with exact versions. The project .mise.toml
+# overrides the global baseline (lts / major lines). See docs/runtime.md.
 [tools]
 python = "3.13.5"


### PR DESCRIPTION
Closes #54.

## 概要
mise runtime module を「宣言止まり」から具体化し、runtime 方針を改訂する。global tooling(npm-global / go-installed CLI)が動く baseline runtime を global に置き、exact pin の責務は project 側に残す。#53(software catalog)の precursor。

設計は #54 で確定（A=major/LTS baseline、B=mise 単独移行、C/D/E）。Codex 設計レビューの must（runtime.md 現文言との矛盾）を本 PR で対応。

## 変更
- **docs/runtime.md**: 「global に tool version を置かない」を撤回し、**global baseline ↔ project exact pin の責務分界**を明文化（must 対応、2026-06-18 の意識的なルール改訂）。加えて:
  - uv は Python tool manager(tool)であり Python runtime 管理ではない／runtime pin は別 scope（should）
  - config 管理と実 install の境界（work-dev は config 管理可だが installPackages=false、`mise install` は本人手動限定・repo が work で自動実行しない）（should）
  - brew→mise 移行手順＋検証ステップ（brew uninstall 前に `command -v node npm go uv claude codex` と `npm root -g` が mise 配下を確認、`brew uses --installed` で依存確認）、$HOME 抽象化（should/nit）
- **private_dot_config/mise/config.toml.tmpl**: baseline `node="lts"` / `go="1.26"` / `uv="latest"` を宣言。`not_found_auto_install=false` 維持。
- **templates/project/python/.mise.toml**: 新方針に合わせコメント更新。

mise 自体は `packages.yaml` の `cli.runtime` に宣言済み。**managed set は不変**（config.toml は personal/work-dev で既に管理対象）、中身だけ変更。

## 検証
- `validate-policy.sh --all` PASS（3 profile）
- `test-render.sh` PASS（managed set 一致＋実 render、fail-closed guards）
- `test-doctor.sh` PASS、`bash -n` ok、whitespace ok
- throwaway render で mise config に baseline が出ることを確認

## 実機（本 PR では行わない）
実 home への mise 導入・brew uninstall は docs の手順に沿って**本人が手動**で実施。

🤖 Generated with [Claude Code](https://claude.com/claude-code)