### PR TITLE
Add guarded mise shell activation to managed zshrc (#56)

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -12,5 +12,9 @@ plugins=(git)
 # iTerm2 shell integration (no-op when the integration file is absent).
 [ -e "$HOME/.iterm2_shell_integration.zsh" ] && source "$HOME/.iterm2_shell_integration.zsh"
 
+# mise runtime activation (no-op when mise is not installed). Provides the
+# baseline runtimes from ~/.config/mise/config.toml. See docs/runtime.md.
+command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"
+
 # Local overrides win: machine-specific PATH, tool env, secrets.
 [ -r "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"


### PR DESCRIPTION
Closes #56.

## 概要
managed `dot_zshrc` に mise の shell 統合を guard 付きで追加。#54 で mise runtime module を具体化したが、shell 統合が無いと `~/.config/mise/config.toml` の baseline runtime が shell に届かず module が無効化していた。実機 brew→mise 移行の前提。

mise activation は汎用・public-safe なので、machine 固有用の `.zshrc.local` ではなく **managed `.zshrc`** が正しい置き場所。

## 変更
- `dot_zshrc`: `command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"`。mise 未導入なら no-op（oh-my-zsh / iTerm2 統合と同じ guard 思想）。`~/.zshrc.local` source の前に配置し local override が最終的に勝つ。

## 検証
- `test-render.sh` PASS（managed set 不変＝中身のみ変更、3 profile）
- `bash -n` ok、whitespace ok
- throwaway render で `.zshrc` に guard 付き mise 行が出ることを確認

## 実機
実 home への apply は本人手動（移行手順の一部）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)