### PR TITLE
Software catalog: schema, parser, validation (#53 stage 1)

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -1,32 +1,47 @@
-packages:
+# Software catalog: the tools this setup intends to have, each with its
+# canonical install source. Read by scripts via mikefarah/yq v4; drift
+# against what is actually installed is reported by doctor (report-only).
+#
+# source_preference is advisory only: the order to prefer when choosing a
+# source for a new tool. Drift detection compares the catalog's declared
+# source to reality; it does not enforce this order. Cross-source
+# availability checks (is X also on a higher-preference source?) are
+# unreliable, so the order guides humans at add-time instead.
+source_preference:
   cli:
-    base:
-      - chezmoi
-      - git
-      - ripgrep
-      - fd
-      - jq
-      - yq
-    runtime:
-      - mise
-      - direnv
-    shell-extra:
-      - antidote
-      - starship
-      - fzf
-      - tmux
-    lint:
-      - shellcheck
-      - shfmt
-    github:
-      - gh
-    secrets:
-      - 1password-cli
-  cask:
-    gui-apps:
-      - 1password
-      - iterm2
-      - google-chrome
-      - raycast
-      - tailscale
-      - visual-studio-code
+    - brew_formula
+    - npm_global
+    - go_install
+    - manual
+  gui:
+    - brew_cask
+    - mas
+    - manual
+
+# Each entry:
+#   name        display name (and the default for pkg / bin).
+#   source      one of: brew_formula, brew_cask, npm_global, go_install,
+#               mas, manual.
+#   pkg         canonical install id for the source when it differs from
+#               name: npm scoped name, go package path, mas numeric app id.
+#               Required for go_install and mas (unless track_only).
+#   bin         command used to check presence when it differs from name.
+#   track_only  inventory only; never installed by tooling (also implied
+#               by source: manual).
+#
+# Drift matching uses the canonical id (pkg, defaulting to name) per
+# source. Language runtimes (node, go, uv) are mise's domain
+# (see docs/runtime.md) and are intentionally absent here.
+packages:
+  - { name: chezmoi, source: brew_formula }
+  - { name: gh, source: brew_formula }
+  - { name: mise, source: brew_formula }
+  - { name: tmux, source: brew_formula }
+  - { name: yq, source: brew_formula }
+  - { name: copilot-cli, source: brew_cask }
+  - { name: iterm2, source: brew_cask }
+  - { name: swiftbar, source: brew_cask }
+  - { name: claude-code, source: npm_global, pkg: "@anthropic-ai/claude-code", bin: claude }
+  - { name: codex, source: npm_global, pkg: "@openai/codex" }
+  - { name: goreleaser, source: go_install, pkg: "github.com/goreleaser/goreleaser/v2" }
+  - { name: tacho, source: go_install, pkg: "github.com/kosako/tachograph/cmd/tacho" }

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -24,7 +24,9 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 
 ## データ読み取り
 
-`.chezmoidata/*.yaml`(profiles / modules / capabilities.schema)の読み取りは shell script 側では mikefarah/yq v4 で行う(chezmoi template 側は Go template が読む)。yq が無い・別 variant の場合は `require_yq` が fail closed する。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない(injection 防止)。
+`.chezmoidata/*.yaml`(profiles / modules / capabilities.schema / packages)の読み取りは shell script 側では mikefarah/yq v4 で行う(chezmoi template 側は Go template が読む)。yq が無い・別 variant の場合は `require_yq` が fail closed する。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない(injection 防止)。
+
+`packages`(`.chezmoidata/packages.yaml`)は software catalog。各 entry の `source`(brew_formula / brew_cask / npm_global / go_install / mas / manual)と canonical id を宣言する。`validate-policy.sh` が source の妥当性・go_install/mas の pkg 必須・name 重複を fail closed で検査する。実機との drift(未 install / 台帳外 / source ズレ)は `doctor.sh` が report-only で報告する(install action は後続 phase)。
 
 ## Rules
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -5,6 +5,7 @@ DOTFILES_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROFILES_FILE="$DOTFILES_ROOT/.chezmoidata/profiles.yaml"
 MODULES_FILE="$DOTFILES_ROOT/.chezmoidata/modules.yaml"
 CAPABILITIES_FILE="$DOTFILES_ROOT/.chezmoidata/capabilities.schema.yaml"
+PACKAGES_FILE="$DOTFILES_ROOT/.chezmoidata/packages.yaml"
 
 ok() {
   printf '[ok] %s\n' "$*"
@@ -56,7 +57,7 @@ require_yq() {
 
 require_data_files() {
   local missing=0
-  for file in "$PROFILES_FILE" "$MODULES_FILE" "$CAPABILITIES_FILE"; do
+  for file in "$PROFILES_FILE" "$MODULES_FILE" "$CAPABILITIES_FILE" "$PACKAGES_FILE"; do
     if [[ ! -f "$file" ]]; then
       fail "missing data file: $file"
       missing=1
@@ -200,6 +201,38 @@ environment_kind_forbidden_capabilities() {
       printf '%s\n' allowSecretsAccess
       ;;
   esac
+}
+
+# Valid sources for the software catalog (packages.yaml). Validation and
+# drift detection check against this set; an unknown source is a
+# fail-closed error. See docs/policy-model.md.
+known_package_sources() {
+  printf '%s\n' \
+    brew_formula \
+    brew_cask \
+    npm_global \
+    go_install \
+    mas \
+    manual
+}
+
+# Emit one row per catalog package as pipe-joined fields:
+#   name|source|pkg|bin|track_only
+# pkg and bin are raw (empty when unset) so validation can detect a missing
+# canonical id; consumers default pkg and bin to name. A non-whitespace
+# delimiter is used on purpose: `read` collapses consecutive IFS-whitespace
+# (tab/space), which would drop empty fields, while "|" never appears in a
+# package identifier. Read it back with IFS='|'. Drift matching uses the
+# canonical id (pkg, defaulting to name) per source. This reads the data
+# file, not user input, so values are not passed through strenv.
+catalog_packages() {
+  yq '.packages[]? | [(.name // ""), (.source // ""), (.pkg // ""), (.bin // ""), ((.track_only // false) | tostring)] | join("|")' "$PACKAGES_FILE"
+}
+
+# Emit the advisory source-preference order for a category (cli / gui).
+catalog_source_preference() {
+  local category="$1"
+  c="$category" yq '.source_preference[strenv(c)][]?' "$PACKAGES_FILE"
 }
 
 # Print names of remotes whose URL embeds password-like userinfo

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -213,6 +213,34 @@ run_fail_contains \
   "module has requires but no paths: base" \
   "$fixture/scripts/validate-policy.sh" personal
 
+# Software catalog (packages.yaml) validation.
+make_fixture
+replace_once "$fixture/.chezmoidata/packages.yaml" \
+  "  - { name: chezmoi, source: brew_formula }" \
+  "  - { name: chezmoi, source: bogus_source }"
+run_fail_contains \
+  "rejects unknown package source" \
+  "unknown package source: chezmoi: bogus_source" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+replace_once "$fixture/.chezmoidata/packages.yaml" \
+  '  - { name: tacho, source: go_install, pkg: "github.com/kosako/tachograph/cmd/tacho" }' \
+  "  - { name: tacho, source: go_install }"
+run_fail_contains \
+  "rejects go_install package without a canonical pkg" \
+  "go_install package needs an explicit pkg (canonical id): tacho" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+insert_once "$fixture/.chezmoidata/packages.yaml" \
+  "  - { name: chezmoi, source: brew_formula }" \
+  "  - { name: chezmoi, source: brew_cask }"
+run_fail_contains \
+  "rejects duplicate package name" \
+  "duplicate package name: chezmoi" \
+  "$fixture/scripts/validate-policy.sh" personal
+
 # environmentKind cross-check. Every deny entry for work/client/agent
 # must actually fire: retag personal (already elevated) to work and force
 # the two caps it leaves false to true, then assert all six are flagged.

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -241,6 +241,22 @@ run_fail_contains \
   "duplicate package name: chezmoi" \
   "$fixture/scripts/validate-policy.sh" personal
 
+make_fixture
+replace_once "$fixture/.chezmoidata/packages.yaml" \
+  "  - { name: chezmoi, source: brew_formula }" \
+  "  - { name: chezmoi, source: brew_formula, track_only: tru }"
+run_fail_contains \
+  "rejects invalid track_only value" \
+  "package track_only must be true or false: chezmoi: tru" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+: > "$fixture/.chezmoidata/packages.yaml"
+run_fail_contains \
+  "fails closed on empty packages catalog" \
+  "no packages parsed" \
+  "$fixture/scripts/validate-policy.sh" personal
+
 # environmentKind cross-check. Every deny entry for work/client/agent
 # must actually fire: retag personal (already elevated) to work and force
 # the two caps it leaves false to true, then assert all six are flagged.

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -111,14 +111,28 @@ validate_modules() {
 # or app id), and names must be unique.
 validate_packages() {
   local status=0
-  local name source pkg bin track_only duplicate
+  local name source pkg bin track_only duplicate entry_ok rows
   local sources_file names_file
   sources_file="$(mktemp)"
   names_file="$(mktemp)"
   known_package_sources | sort > "$sources_file"
 
+  # Fail closed: a yq error or a missing/empty packages list must not pass
+  # vacuously (mirrors the profiles / modules / capabilities guards).
+  if ! rows="$(catalog_packages)"; then
+    fail "could not parse packages from $PACKAGES_FILE"
+    rm -f "$sources_file" "$names_file"
+    return 1
+  fi
+  if [[ -z "$rows" ]]; then
+    fail "no packages parsed from $PACKAGES_FILE"
+    rm -f "$sources_file" "$names_file"
+    return 1
+  fi
+
   while IFS='|' read -r name source pkg bin track_only; do
     [[ -z "$name$source$pkg$bin$track_only" ]] && continue
+    entry_ok=1
     if [[ -z "$name" ]]; then
       fail "package missing name (source=${source:-none})"
       status=1
@@ -135,16 +149,25 @@ validate_packages() {
       continue
     fi
     printf '%s\n' "$name" >> "$names_file"
+    case "$track_only" in
+      true | false | "") ;;
+      *)
+        fail "package track_only must be true or false: $name: $track_only"
+        status=1
+        entry_ok=0
+        ;;
+    esac
     if [[ "$track_only" != "true" && -z "$pkg" ]]; then
       case "$source" in
-        go_install|mas)
+        go_install | mas)
           fail "$source package needs an explicit pkg (canonical id): $name"
           status=1
+          entry_ok=0
           ;;
       esac
     fi
-    ok "package: $name ($source)"
-  done < <(catalog_packages)
+    [[ "$entry_ok" -eq 1 ]] && ok "package: $name ($source)"
+  done <<< "$rows"
 
   while IFS= read -r duplicate; do
     [[ -z "$duplicate" ]] && continue

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -105,6 +105,63 @@ validate_modules() {
   return "$status"
 }
 
+# The software catalog (packages.yaml) is profile-independent data, like
+# modules: every entry must name a known source, go_install / mas need an
+# explicit canonical pkg id (a bare name cannot reconstruct a module path
+# or app id), and names must be unique.
+validate_packages() {
+  local status=0
+  local name source pkg bin track_only duplicate
+  local sources_file names_file
+  sources_file="$(mktemp)"
+  names_file="$(mktemp)"
+  known_package_sources | sort > "$sources_file"
+
+  while IFS='|' read -r name source pkg bin track_only; do
+    [[ -z "$name$source$pkg$bin$track_only" ]] && continue
+    if [[ -z "$name" ]]; then
+      fail "package missing name (source=${source:-none})"
+      status=1
+      continue
+    fi
+    if [[ -z "$source" ]]; then
+      fail "package missing source: $name"
+      status=1
+      continue
+    fi
+    if ! grep -Fxq -- "$source" "$sources_file"; then
+      fail "unknown package source: $name: $source"
+      status=1
+      continue
+    fi
+    printf '%s\n' "$name" >> "$names_file"
+    if [[ "$track_only" != "true" && -z "$pkg" ]]; then
+      case "$source" in
+        go_install|mas)
+          fail "$source package needs an explicit pkg (canonical id): $name"
+          status=1
+          ;;
+      esac
+    fi
+    ok "package: $name ($source)"
+  done < <(catalog_packages)
+
+  while IFS= read -r duplicate; do
+    [[ -z "$duplicate" ]] && continue
+    fail "duplicate package name: $duplicate"
+    status=1
+  done < <(sort "$names_file" | uniq -d)
+  rm -f "$sources_file" "$names_file"
+
+  if [[ "$status" -eq 0 ]]; then
+    ok "package validation passed"
+  else
+    fail "package validation failed"
+  fi
+
+  return "$status"
+}
+
 validate_profile() {
   local profile="$1"
   local status=0
@@ -277,6 +334,8 @@ case "$command" in
     status=0
     section "validating modules"
     validate_modules || status=1
+    section "validating packages"
+    validate_packages || status=1
     profiles_found=0
     while IFS= read -r profile; do
       [[ -z "$profile" ]] && continue
@@ -298,6 +357,7 @@ case "$command" in
   *)
     status=0
     validate_modules || status=1
+    validate_packages || status=1
     validate_profile "$command" || status=1
     exit "$status"
     ;;


### PR DESCRIPTION
Part of #53 (stage 1 of 2). Stage 2 = doctor drift report.

## 概要
未参照・実機とズレた aspirational な `packages.yaml` を、source 非依存の**ソフトウェア catalog** に作り直し、消費層（yq parser）と fail-closed validation を新設。catalog は**実機現実で seed（drift=0 baseline）**。doctor の drift report と install action は後続 stage。

設計は #53 で確定、Codex 設計レビューの must/should/nit を反映（下記）。

## 変更
- **`.chezmoidata/packages.yaml`**: `source_preference`（advisory な入手元優先順位）＋ flat な `packages: [{name, source, pkg?, bin?, track_only?}]`。source は brew_formula/brew_cask/npm_global/go_install/mas/manual。実機の12ツールで seed。node/go/uv は mise 領分で除外、librsvg（孤児）は除外し後続 drift で surface。
- **`lib-policy.sh`**: `PACKAGES_FILE`（`require_data_files` に追加）、`known_package_sources`、`catalog_packages`、`catalog_source_preference`。
- **`validate-policy.sh`**: `validate_packages` — source 妥当性 / go_install・mas は pkg 必須 / name 重複を fail-closed（`validate_modules` と同型）。
- **`test-policy.sh`**: unknown source / go_install without pkg / duplicate name の 3 テスト。
- **`docs/policy-model.md`**: packages を yq 読取 data file として明記。

## Codex 設計レビュー反映
- must2（照合キー分離）: canonical id = `pkg // name`、bin = `bin // name`（claude-code≠@anthropic-ai/claude-code の誤検知回避）。
- should: go_install/mas は canonical pkg 必須 / `PACKAGES_FILE` を fail-closed data file 化 / docs 追記。
- must1（doctor の report-only）と should6（inventory 透明化）は **stage 2（doctor drift）** で対応。

## 実装上の注意（バグ回避）
`catalog_packages` は `|` 区切りで emit。`IFS=$'\t' read` は tab を IFS-whitespace として空フィールドを畳むため、空 pkg/bin が落ちて検証が誤る。非空白の `|`（package 識別子に出現しない）で空フィールドを保持。

## 検証
- validate-policy --all / test-policy / test-gitconfig / test-npmrc / test-doctor / test-render すべて PASS、bash -n / whitespace ok。
- managed set 不変（packages.yaml は managed path でない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)