### PR TITLE
Add catalog drift report to doctor (#53 stage 1)

### DIFF
--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -26,7 +26,15 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 
 `.chezmoidata/*.yaml`(profiles / modules / capabilities.schema / packages)の読み取りは shell script 側では mikefarah/yq v4 で行う(chezmoi template 側は Go template が読む)。yq が無い・別 variant の場合は `require_yq` が fail closed する。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない(injection 防止)。
 
-`packages`(`.chezmoidata/packages.yaml`)は software catalog。各 entry の `source`(brew_formula / brew_cask / npm_global / go_install / mas / manual)と canonical id を宣言する。`validate-policy.sh` が source の妥当性・go_install/mas の pkg 必須・name 重複を fail closed で検査する。実機との drift(未 install / 台帳外 / source ズレ)は `doctor.sh` が report-only で報告する(install action は後続 phase)。
+`packages`(`.chezmoidata/packages.yaml`)は software catalog。各 entry の `source`(brew_formula / brew_cask / npm_global / go_install / mas / manual)と canonical id を宣言する。`validate-policy.sh` が source の妥当性・go_install/mas の pkg 必須・name 重複を fail closed で検査する。
+
+実機との drift は `doctor.sh` の `software catalog` section(`report_catalog_drift`)が **report-only**(常に exit 0、欠けている package manager は skip)で報告する。検出は 3 種:
+
+- **未 install**(宣言済みだが入っていない)→ `warn`。
+- **台帳外**(undeclared / sprawl: 入っているが catalog に無い)→ `warn`。brew は `brew leaves`(top-level のみ。依存は拾わない)、npm は node 同梱の `npm` / `corepack` を除外(runtime の領分、node/go/uv と同じ扱い)、mas は App Store の無関係アプリが大量に誤検知されるため undeclared は出さない(宣言済み mas entry の presence のみ確認)。
+- **source ズレ**(宣言 source の inventory には無いが `command` が PATH 上に在る = 別 source で入っている疑い)→ `info`。manager 横断の名前照合(脆い)はやらず、PATH 上の存在という堅い信号だけを使う。
+
+照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。install action は後続 phase。
 
 ## Rules
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -154,6 +154,12 @@ else
   fi
 fi
 
+section "software catalog (report-only)"
+# Drift between packages.yaml and what is actually installed. report_catalog_drift
+# is report-only (always returns 0) and skips any missing package manager;
+# the only fail path in doctor stays the policy validation at the top.
+report_catalog_drift || true
+
 section "runtime and shell"
 if [[ "$(capability_value "$profile" enableRuntimeManagement)" == "true" ]]; then
   command_status mise || true

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -287,7 +287,7 @@ report_catalog_drift() {
   # Inventories (read-only). A failing probe leaves the list empty via
   # `|| true`; per-source availability flags gate whether absence means
   # "not installed" or "manager not present, skip".
-  local have_brew=0 have_npm=0 have_mas=0 gobin=""
+  local have_brew=0 have_npm=0 have_go=0 have_mas=0 gobin=""
   if command -v brew >/dev/null 2>&1; then
     have_brew=1
     brew list --formula -1 2>/dev/null | sort > "$brew_formulae" || true
@@ -300,15 +300,18 @@ report_catalog_drift() {
       | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null \
       | grep -vxE 'npm|corepack' | sort > "$npm_globals" || true
   fi
+  # A go-built binary persists in GOPATH/bin even if `go` is later removed,
+  # but treating go like the other managers (absent -> skip, not "not
+  # installed") keeps the contract uniform and avoids guessing GOPATH when
+  # go cannot tell us where it is.
   if command -v go >/dev/null 2>&1; then
+    have_go=1
     gobin="$(go env GOBIN 2>/dev/null || true)"
     [[ -z "$gobin" ]] && gobin="$(go env GOPATH 2>/dev/null || true)/bin"
-  else
-    gobin="${GOPATH:-$HOME/go}/bin"
-  fi
-  if [[ -n "$gobin" && -d "$gobin" ]]; then
-    find "$gobin" -maxdepth 1 -type f -perm -u+x -exec basename {} \; 2>/dev/null \
-      | sort > "$go_bins" || true
+    if [[ -n "$gobin" && -d "$gobin" ]]; then
+      find "$gobin" -maxdepth 1 -type f -perm -u+x -exec basename {} \; 2>/dev/null \
+        | sort > "$go_bins" || true
+    fi
   fi
   if command -v mas >/dev/null 2>&1; then
     have_mas=1
@@ -328,7 +331,11 @@ report_catalog_drift() {
   else
     item "npm: not found (npm_global sources skipped)"
   fi
-  item "go bin: ${gobin:-unknown}"
+  if [[ "$have_go" -eq 1 ]]; then
+    item "go bin: ${gobin:-unknown}"
+  else
+    item "go: not found (go_install sources skipped)"
+  fi
   if [[ "$have_mas" -eq 1 ]]; then
     item "mas: $(command -v mas)"
   else
@@ -400,7 +407,9 @@ report_catalog_drift() {
         fi
         ;;
       go_install)
-        if grep -Fxq -- "$bincmd" "$go_bins"; then
+        if [[ "$have_go" -eq 0 ]]; then
+          item "skip $name: go not available"
+        elif grep -Fxq -- "$bincmd" "$go_bins"; then
           ok "installed: $name (go_install)"
         elif command -v "$bincmd" >/dev/null 2>&1; then
           info "source drift: $name declared go_install, absent from go bin; '$bincmd' on PATH (installed elsewhere?)"
@@ -453,13 +462,15 @@ report_catalog_drift() {
       }
     done < "$npm_globals"
   fi
-  while IFS= read -r b; do
-    [[ -z "$b" ]] && continue
-    grep -Fxq -- "$b" "$decl_go_bins" || {
-      warn "undeclared: $b (go binary not in catalog)"
-      drift_count=$((drift_count + 1))
-    }
-  done < "$go_bins"
+  if [[ "$have_go" -eq 1 ]]; then
+    while IFS= read -r b; do
+      [[ -z "$b" ]] && continue
+      grep -Fxq -- "$b" "$decl_go_bins" || {
+        warn "undeclared: $b (go binary not in catalog)"
+        drift_count=$((drift_count + 1))
+      }
+    done < "$go_bins"
+  fi
 
   if [[ "$drift_count" -eq 0 ]]; then
     ok "no catalog drift"

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -235,6 +235,240 @@ catalog_source_preference() {
   c="$category" yq '.source_preference[strenv(c)][]?' "$PACKAGES_FILE"
 }
 
+# Report drift between the declared catalog (packages.yaml) and what is
+# actually installed, per source. Report-only: every path returns 0 so a
+# caller under `set -e` (doctor.sh) keeps its exit code, and all probes are
+# read-only with a missing package manager skipped rather than failed.
+#
+# Three drift kinds (see docs/policy-model.md):
+#   - declared but not installed          -> warn (suggest installing)
+#   - installed but not declared (sprawl) -> warn (undeclared)
+#   - declared source vs reality mismatch -> info (declared in source S,
+#                                            absent from S, yet the command
+#                                            resolves on PATH)
+#
+# Matching uses the canonical installed id (pkg, defaulting to name) per
+# source, never a cross-manager name table: the catalog design rejected
+# cross-source availability checks as unreliable. The source-mismatch
+# signal is deliberately weak ("not in S's inventory but on PATH") because
+# it never guesses which other manager owns the tool. Undeclared detection
+# uses `brew leaves` (top-level installs) so dependencies are not flagged,
+# excludes node-bundled npm globals (npm, corepack: runtime domain, like
+# node/go/uv), and is skipped for mas (the App Store carries many apps
+# unrelated to the dev catalog; flagging them all would be noise).
+report_catalog_drift() {
+  if ! require_yq; then
+    warn "yq unavailable; skipping catalog drift"
+    return 0
+  fi
+  if [[ ! -f "$PACKAGES_FILE" ]]; then
+    warn "catalog missing: $PACKAGES_FILE; skipping drift"
+    return 0
+  fi
+
+  local rows
+  if ! rows="$(catalog_packages)" || [[ -z "$rows" ]]; then
+    warn "could not read catalog packages; skipping drift"
+    return 0
+  fi
+
+  local brew_formulae brew_leaves brew_casks npm_globals go_bins mas_ids
+  local decl_brew_formula decl_brew_cask decl_npm decl_go_bins
+  brew_formulae="$(mktemp)"; brew_leaves="$(mktemp)"; brew_casks="$(mktemp)"
+  npm_globals="$(mktemp)"; go_bins="$(mktemp)"; mas_ids="$(mktemp)"
+  decl_brew_formula="$(mktemp)"; decl_brew_cask="$(mktemp)"
+  decl_npm="$(mktemp)"; decl_go_bins="$(mktemp)"
+  local drift_tmp=(
+    "$brew_formulae" "$brew_leaves" "$brew_casks" "$npm_globals" "$go_bins"
+    "$mas_ids" "$decl_brew_formula" "$decl_brew_cask" "$decl_npm"
+    "$decl_go_bins"
+  )
+
+  # Inventories (read-only). A failing probe leaves the list empty via
+  # `|| true`; per-source availability flags gate whether absence means
+  # "not installed" or "manager not present, skip".
+  local have_brew=0 have_npm=0 have_mas=0 gobin=""
+  if command -v brew >/dev/null 2>&1; then
+    have_brew=1
+    brew list --formula -1 2>/dev/null | sort > "$brew_formulae" || true
+    brew leaves 2>/dev/null | sort > "$brew_leaves" || true
+    brew list --cask -1 2>/dev/null | sort > "$brew_casks" || true
+  fi
+  if command -v npm >/dev/null 2>&1; then
+    have_npm=1
+    npm ls -g --depth=0 --json 2>/dev/null \
+      | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null \
+      | grep -vxE 'npm|corepack' | sort > "$npm_globals" || true
+  fi
+  if command -v go >/dev/null 2>&1; then
+    gobin="$(go env GOBIN 2>/dev/null || true)"
+    [[ -z "$gobin" ]] && gobin="$(go env GOPATH 2>/dev/null || true)/bin"
+  else
+    gobin="${GOPATH:-$HOME/go}/bin"
+  fi
+  if [[ -n "$gobin" && -d "$gobin" ]]; then
+    find "$gobin" -maxdepth 1 -type f -perm -u+x -exec basename {} \; 2>/dev/null \
+      | sort > "$go_bins" || true
+  fi
+  if command -v mas >/dev/null 2>&1; then
+    have_mas=1
+    mas list 2>/dev/null | awk '{print $1}' | sort > "$mas_ids" || true
+  fi
+
+  # Report which inventories were inspected. npm's global root differs by
+  # active node (mise-managed vs system); naming it avoids misreading a
+  # shim-shadowed inventory (same root cause as the mise shims problem).
+  if [[ "$have_brew" -eq 1 ]]; then
+    item "brew: $(command -v brew)"
+  else
+    item "brew: not found (brew sources skipped)"
+  fi
+  if [[ "$have_npm" -eq 1 ]]; then
+    item "npm: $(command -v npm) (global root: $(npm root -g 2>/dev/null || echo unknown))"
+  else
+    item "npm: not found (npm_global sources skipped)"
+  fi
+  item "go bin: ${gobin:-unknown}"
+  if [[ "$have_mas" -eq 1 ]]; then
+    item "mas: $(command -v mas)"
+  else
+    item "mas: not found (mas sources skipped)"
+  fi
+
+  local drift_count=0
+  local name source pkg bin track_only canonical bincmd
+  while IFS='|' read -r name source pkg bin track_only; do
+    [[ -z "$name$source" ]] && continue
+    canonical="${pkg:-$name}"
+    bincmd="${bin:-$name}"
+
+    # Accumulate declared sets (track-only included: a declared track-only
+    # entry must not later surface as undeclared sprawl).
+    case "$source" in
+      brew_formula) printf '%s\n' "$canonical" >> "$decl_brew_formula" ;;
+      brew_cask) printf '%s\n' "$canonical" >> "$decl_brew_cask" ;;
+      npm_global) printf '%s\n' "$canonical" >> "$decl_npm" ;;
+      go_install) printf '%s\n' "$bincmd" >> "$decl_go_bins" ;;
+    esac
+
+    # track-only / manual entries are inventory only; never installed by
+    # tooling, so they produce no "not installed" drift.
+    if [[ "$track_only" == "true" || "$source" == "manual" ]]; then
+      if command -v "$bincmd" >/dev/null 2>&1; then
+        item "track-only present: $name ($source)"
+      else
+        item "track-only, not present: $name ($source)"
+      fi
+      continue
+    fi
+
+    case "$source" in
+      brew_formula)
+        if [[ "$have_brew" -eq 0 ]]; then
+          item "skip $name: brew not available"
+        elif grep -Fxq -- "$canonical" "$brew_formulae"; then
+          ok "installed: $name (brew_formula)"
+        elif command -v "$bincmd" >/dev/null 2>&1; then
+          info "source drift: $name declared brew_formula, absent from brew; '$bincmd' on PATH (installed elsewhere?)"
+          drift_count=$((drift_count + 1))
+        else
+          warn "not installed: $name (brew_formula)"
+          drift_count=$((drift_count + 1))
+        fi
+        ;;
+      brew_cask)
+        if [[ "$have_brew" -eq 0 ]]; then
+          item "skip $name: brew not available"
+        elif grep -Fxq -- "$canonical" "$brew_casks"; then
+          ok "installed: $name (brew_cask)"
+        else
+          warn "not installed: $name (brew_cask)"
+          drift_count=$((drift_count + 1))
+        fi
+        ;;
+      npm_global)
+        if [[ "$have_npm" -eq 0 ]]; then
+          item "skip $name: npm not available"
+        elif grep -Fxq -- "$canonical" "$npm_globals"; then
+          ok "installed: $name (npm_global)"
+        elif command -v "$bincmd" >/dev/null 2>&1; then
+          info "source drift: $name declared npm_global, absent from npm -g; '$bincmd' on PATH (installed elsewhere?)"
+          drift_count=$((drift_count + 1))
+        else
+          warn "not installed: $name (npm_global)"
+          drift_count=$((drift_count + 1))
+        fi
+        ;;
+      go_install)
+        if grep -Fxq -- "$bincmd" "$go_bins"; then
+          ok "installed: $name (go_install)"
+        elif command -v "$bincmd" >/dev/null 2>&1; then
+          info "source drift: $name declared go_install, absent from go bin; '$bincmd' on PATH (installed elsewhere?)"
+          drift_count=$((drift_count + 1))
+        else
+          warn "not installed: $name (go_install)"
+          drift_count=$((drift_count + 1))
+        fi
+        ;;
+      mas)
+        if [[ "$have_mas" -eq 0 ]]; then
+          item "skip $name: mas not available"
+        elif grep -Fxq -- "$canonical" "$mas_ids"; then
+          ok "installed: $name (mas)"
+        else
+          warn "not installed: $name (mas)"
+          drift_count=$((drift_count + 1))
+        fi
+        ;;
+      *)
+        # validate-policy rejects unknown sources; defensive skip here.
+        item "skip $name: unhandled source $source"
+        ;;
+    esac
+  done <<< "$rows"
+
+  # Undeclared (sprawl): installed top-level items absent from the catalog.
+  if [[ "$have_brew" -eq 1 ]]; then
+    while IFS= read -r f; do
+      [[ -z "$f" ]] && continue
+      grep -Fxq -- "$f" "$decl_brew_formula" || {
+        warn "undeclared: $f (brew_formula leaf not in catalog)"
+        drift_count=$((drift_count + 1))
+      }
+    done < "$brew_leaves"
+    while IFS= read -r c; do
+      [[ -z "$c" ]] && continue
+      grep -Fxq -- "$c" "$decl_brew_cask" || {
+        warn "undeclared: $c (brew_cask not in catalog)"
+        drift_count=$((drift_count + 1))
+      }
+    done < "$brew_casks"
+  fi
+  if [[ "$have_npm" -eq 1 ]]; then
+    while IFS= read -r n; do
+      [[ -z "$n" ]] && continue
+      grep -Fxq -- "$n" "$decl_npm" || {
+        warn "undeclared: $n (npm global not in catalog)"
+        drift_count=$((drift_count + 1))
+      }
+    done < "$npm_globals"
+  fi
+  while IFS= read -r b; do
+    [[ -z "$b" ]] && continue
+    grep -Fxq -- "$b" "$decl_go_bins" || {
+      warn "undeclared: $b (go binary not in catalog)"
+      drift_count=$((drift_count + 1))
+    }
+  done < "$go_bins"
+
+  if [[ "$drift_count" -eq 0 ]]; then
+    ok "no catalog drift"
+  fi
+
+  rm -f "${drift_tmp[@]}"
+  return 0
+}
+
 # Print names of remotes whose URL embeds password-like userinfo
 # (scheme://user:password@host). URL values are never printed.
 git_remotes_with_credentials() {

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -348,4 +348,108 @@ run_fail_contains \
   "yq v4+ required" \
   env PATH="$fixture/fakebin:$PATH" "$fixture/scripts/validate-policy.sh" personal
 
+# ---- Software catalog drift (report_catalog_drift) ----
+# report_catalog_drift probes real package managers, so tests run it against
+# fake brew / npm / go on a minimal PATH (only the fakes, a symlinked yq,
+# and coreutils). This keeps the inventory fully controlled and independent
+# of whatever is installed on the host or CI runner. Every assertion also
+# proves the report-only contract: run_ok_contains requires exit 0, so the
+# drift cases confirm drift never changes the exit code.
+
+# Globals set by setup_drift: drift_dir (fake inventory + go bin),
+# drift_fakebin (fake managers + yq symlink). Reuses `fixture` from
+# make_fixture for the sourced lib-policy.sh and packages.yaml.
+setup_drift() {
+  make_fixture
+  drift_dir="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-drift.XXXXXX")"
+  tmp_roots+=("$drift_dir")
+  drift_fakebin="$drift_dir/bin"
+  mkdir -p "$drift_fakebin" "$drift_dir/go/bin"
+
+  cat > "$drift_fakebin/brew" <<'EOF'
+#!/bin/sh
+case "$*" in
+  "list --formula"*) cat "$DRIFT_DIR/brew_formulae" 2>/dev/null ;;
+  "leaves"*) cat "$DRIFT_DIR/brew_leaves" 2>/dev/null ;;
+  "list --cask"*) cat "$DRIFT_DIR/brew_casks" 2>/dev/null ;;
+esac
+exit 0
+EOF
+  cat > "$drift_fakebin/npm" <<'EOF'
+#!/bin/sh
+case "$*" in
+  "ls -g"*) cat "$DRIFT_DIR/npm.json" 2>/dev/null ;;
+  "root -g") echo "$DRIFT_DIR/npm-global" ;;
+esac
+exit 0
+EOF
+  cat > "$drift_fakebin/go" <<'EOF'
+#!/bin/sh
+if [ "$1" = "env" ] && [ "$2" = "GOBIN" ]; then echo ""; exit 0; fi
+if [ "$1" = "env" ] && [ "$2" = "GOPATH" ]; then echo "$FAKE_GOPATH"; exit 0; fi
+exit 0
+EOF
+  chmod +x "$drift_fakebin/brew" "$drift_fakebin/npm" "$drift_fakebin/go"
+  # yq is the one real tool the function needs; symlink it so the minimal
+  # PATH can still satisfy require_yq without pulling in the host's bin dir.
+  ln -s "$(command -v yq)" "$drift_fakebin/yq"
+
+  # Default inventory == the reality-seed catalog (drift-free baseline).
+  printf '%s\n' chezmoi gh mise tmux yq > "$drift_dir/brew_formulae"
+  printf '%s\n' chezmoi gh mise tmux yq > "$drift_dir/brew_leaves"
+  printf '%s\n' copilot-cli iterm2 swiftbar > "$drift_dir/brew_casks"
+  # npm and corepack are node-bundled; including them proves they are
+  # filtered out and never reported as undeclared.
+  printf '%s' '{"dependencies":{"@anthropic-ai/claude-code":{},"@openai/codex":{},"npm":{},"corepack":{}}}' \
+    > "$drift_dir/npm.json"
+  touch "$drift_dir/go/bin/goreleaser" "$drift_dir/go/bin/tacho"
+  chmod +x "$drift_dir/go/bin/goreleaser" "$drift_dir/go/bin/tacho"
+}
+
+run_drift() {
+  local name="$1"
+  local expected="$2"
+  run_ok_contains "$name" "$expected" \
+    env "PATH=$drift_fakebin:/usr/bin:/bin" \
+        "DRIFT_DIR=$drift_dir" \
+        "FAKE_GOPATH=$drift_dir/go" \
+        "LIBPOLICY=$fixture/scripts/lib-policy.sh" \
+        bash -c 'set -euo pipefail; source "$LIBPOLICY"; report_catalog_drift'
+}
+
+setup_drift
+run_drift "catalog drift: clean when reality matches the catalog" "no catalog drift"
+
+setup_drift
+printf 'librsvg\n' >> "$drift_dir/brew_leaves"
+run_drift "catalog drift: flags an undeclared brew leaf" \
+  "undeclared: librsvg (brew_formula leaf not in catalog)"
+
+setup_drift
+printf '%s\n' gh mise tmux yq > "$drift_dir/brew_formulae"
+printf '%s\n' gh mise tmux yq > "$drift_dir/brew_leaves"
+run_drift "catalog drift: flags a declared package that is not installed" \
+  "not installed: chezmoi (brew_formula)"
+
+setup_drift
+# Declared via brew but absent from brew, while the command resolves on
+# PATH -> source drift (info), not "not installed".
+printf '%s\n' chezmoi mise tmux yq > "$drift_dir/brew_formulae"
+printf '%s\n' chezmoi mise tmux yq > "$drift_dir/brew_leaves"
+printf '#!/bin/sh\nexit 0\n' > "$drift_fakebin/gh"
+chmod +x "$drift_fakebin/gh"
+run_drift "catalog drift: source mismatch is info when the command is on PATH" \
+  "source drift: gh declared brew_formula"
+
+setup_drift
+touch "$drift_dir/go/bin/stray-tool"
+chmod +x "$drift_dir/go/bin/stray-tool"
+run_drift "catalog drift: flags an undeclared go binary" \
+  "undeclared: stray-tool (go binary not in catalog)"
+
+setup_drift
+rm -f "$drift_fakebin/brew"
+run_drift "catalog drift: skips a missing package manager (report-only)" \
+  "brew: not found (brew sources skipped)"
+
 ok "policy tests passed"

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -452,4 +452,11 @@ rm -f "$drift_fakebin/brew"
 run_drift "catalog drift: skips a missing package manager (report-only)" \
   "brew: not found (brew sources skipped)"
 
+setup_drift
+# go absent must be a skip, not "not installed": a go-built binary can linger
+# in GOPATH/bin without go, but the contract treats an absent manager as skip.
+rm -f "$drift_fakebin/go"
+run_drift "catalog drift: skips go_install when go is absent" \
+  "skip goreleaser: go not available"
+
 ok "policy tests passed"

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -390,9 +390,16 @@ if [ "$1" = "env" ] && [ "$2" = "GOPATH" ]; then echo "$FAKE_GOPATH"; exit 0; fi
 exit 0
 EOF
   chmod +x "$drift_fakebin/brew" "$drift_fakebin/npm" "$drift_fakebin/go"
-  # yq is the one real tool the function needs; symlink it so the minimal
-  # PATH can still satisfy require_yq without pulling in the host's bin dir.
-  ln -s "$(command -v yq)" "$drift_fakebin/yq"
+  # Make the fake bin fully self-contained so report_catalog_drift runs with
+  # PATH=$drift_fakebin only. A minimal PATH that still included /usr/bin
+  # would leak host tools: GitHub's ubuntu runner ships a real `go` in
+  # /usr/bin, which would defeat the go-absent test. Symlinking the few real
+  # tools the function needs keeps manager presence controlled by the fakes
+  # alone (and host-independent).
+  local tool
+  for tool in bash sh cat dirname mktemp sort grep find basename awk rm yq; do
+    ln -s "$(command -v "$tool")" "$drift_fakebin/$tool"
+  done
 
   # Default inventory == the reality-seed catalog (drift-free baseline).
   printf '%s\n' chezmoi gh mise tmux yq > "$drift_dir/brew_formulae"
@@ -410,7 +417,7 @@ run_drift() {
   local name="$1"
   local expected="$2"
   run_ok_contains "$name" "$expected" \
-    env "PATH=$drift_fakebin:/usr/bin:/bin" \
+    env "PATH=$drift_fakebin" \
         "DRIFT_DIR=$drift_dir" \
         "FAKE_GOPATH=$drift_dir/go" \
         "LIBPOLICY=$fixture/scripts/lib-policy.sh" \


### PR DESCRIPTION
## 概要

issue #53 **第1段(宣言レイヤ)の残り**。`doctor.sh` に software catalog の drift report section を追加し、第1段を完結させる。stage 1 前半(PR #58)で入れた schema / parser / validation の上に、実機との drift を report-only で可視化する消費層を載せる。

## 中身

- `lib-policy.sh` に `report_catalog_drift` を追加(doctor の新 section が呼ぶ)。**report-only**: 全パス `return 0`、package manager 不在は skip。doctor の非ゼロ経路は冒頭の policy validation のみのまま。
- drift 3 種:
  - **未 install**(宣言済みだが未導入)→ `warn`
  - **台帳外**(undeclared sprawl)→ `warn`。brew は `brew leaves`(top-level のみ)、npm は node 同梱の `npm`/`corepack` 除外、mas は App Store の無関係アプリ過検知を避け undeclared を出さない。
  - **source ズレ**(宣言 source の inventory に無いが `command` が PATH 上に在る)→ `info`。manager 横断の名前照合(脆い)は避け、PATH 存在という堅い信号のみ。
- 照合は source ごとの canonical id(`pkg // name`)。inventory は read-only で取得し、どこを見たか(`npm root -g` 等)を report(mise shims 問題対策)。
- `docs/policy-model.md` に検出仕様を明記。

## Codex 設計レビュー(#53 コメント)反映

- must1: doctor の exit 0 維持(catalog section は fail-closed を伝播しない)。
- must2: 表示=`name` / canonical=`pkg//name` / 実行確認=`bin//name` の分離。
- should6: 検査した npm global root を report。

## テスト

`test-policy.sh` に `report_catalog_drift` のテストを追加。fake brew/npm/go を最小 PATH で動かし、inventory を完全制御(host/CI 非依存)。clean / undeclared / 未install / source ズレ / go undeclared / manager 不在 をカバー。drift ケースは exit 0 維持も同時に検証。

## 検証(ローカル)

- `shellcheck -S warning scripts/*.sh` clean
- `test-policy.sh` / `test-gitconfig.sh` / `test-npmrc.sh` / `test-doctor.sh` / `test-render.sh` 全 pass
- `doctor.sh personal` 実機: seed と drift なし一致(唯一 `librsvg` を undeclared として surface = 設計通りの孤児ライブラリ)、exit 0

## 残(第2段)

install action(capability gate + 手動起動)。本 PR には含めない。

Closes は付けず #53 は第2段まで open のまま。

🤖 Generated with [Claude Code](https://claude.com/claude-code)