### PR TITLE
Add shellcheck to the software catalog (#53)

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -37,6 +37,7 @@ packages:
   - { name: chezmoi, source: brew_formula }
   - { name: gh, source: brew_formula }
   - { name: mise, source: brew_formula }
+  - { name: shellcheck, source: brew_formula }
   - { name: tmux, source: brew_formula }
   - { name: yq, source: brew_formula }
   - { name: copilot-cli, source: brew_cask }

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -464,8 +464,8 @@ EOF
   done
 
   # Default inventory == the reality-seed catalog (drift-free baseline).
-  printf '%s\n' age chezmoi gh mise tmux yq > "$drift_dir/brew_formulae"
-  printf '%s\n' age chezmoi gh mise tmux yq > "$drift_dir/brew_leaves"
+  printf '%s\n' age chezmoi gh mise shellcheck tmux yq > "$drift_dir/brew_formulae"
+  printf '%s\n' age chezmoi gh mise shellcheck tmux yq > "$drift_dir/brew_leaves"
   printf '%s\n' copilot-cli iterm2 swiftbar > "$drift_dir/brew_casks"
   # npm and corepack are node-bundled; including them proves they are
   # filtered out and never reported as undeclared.

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -495,16 +495,16 @@ run_drift "catalog drift: flags an undeclared brew leaf" \
   "undeclared: librsvg (brew_formula leaf not in catalog)"
 
 setup_drift
-printf '%s\n' gh mise tmux yq > "$drift_dir/brew_formulae"
-printf '%s\n' gh mise tmux yq > "$drift_dir/brew_leaves"
+printf '%s\n' age gh mise shellcheck tmux yq > "$drift_dir/brew_formulae"
+printf '%s\n' age gh mise shellcheck tmux yq > "$drift_dir/brew_leaves"
 run_drift "catalog drift: flags a declared package that is not installed" \
   "not installed: chezmoi (brew_formula)"
 
 setup_drift
 # Declared via brew but absent from brew, while the command resolves on
 # PATH -> source drift (info), not "not installed".
-printf '%s\n' chezmoi mise tmux yq > "$drift_dir/brew_formulae"
-printf '%s\n' chezmoi mise tmux yq > "$drift_dir/brew_leaves"
+printf '%s\n' age chezmoi mise shellcheck tmux yq > "$drift_dir/brew_formulae"
+printf '%s\n' age chezmoi mise shellcheck tmux yq > "$drift_dir/brew_leaves"
 printf '#!/bin/sh\nexit 0\n' > "$drift_fakebin/gh"
 chmod +x "$drift_fakebin/gh"
 run_drift "catalog drift: source mismatch is info when the command is on PATH" \


### PR DESCRIPTION
## 概要

dev ワークフローで使う `shellcheck`(CI の `shellcheck -S warning` をローカル再現)を catalog に宣言。#53 の「catalog を育てる」運用の一環。未宣言だと doctor で undeclared drift として出るため登録する。

## 中身

- `.chezmoidata/packages.yaml`: `shellcheck`(brew_formula)を追加。
- `scripts/test-policy.sh`: drift テストの fake brew inventory に `shellcheck` を追加(catalog と一致させ「clean」テストを保つ)。

## 検証

- `shellcheck -S warning scripts/*.sh` clean、`validate-policy.sh --all` pass、`test-policy.sh` 全 pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)