### PR TITLE
Add private-backup runtime secrets gate (#60, stage 1)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,6 +52,9 @@ jobs:
       - name: doctor orphan tests
         run: ./scripts/test-doctor.sh
 
+      - name: private-backup secrets-gate tests
+        run: ./scripts/test-secrets-gate.sh
+
       - name: whitespace check (committed tree)
         run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -141,6 +141,28 @@ fixture HOME で doctor の managed-path orphan 検出を検証する。実 home
 - contract version 不一致 / status.sh 欠如 / agent-tools 不在でも warning のみで exit 0 になること。
 - いずれの場合も doctor が exit 0 を維持すること(report-only)。
 
+## test-secrets-gate.sh
+
+private-backup の runtime gate(issue #60)を検証する。backup / restore は host の
+**実 profile** が `allowSecretsAccess=true` のときだけ実行できる。gate は fail-closed で、
+profile を解決できない・未知の profile・`true` 以外の値はすべて拒否する。
+
+```sh
+./scripts/test-secrets-gate.sh
+```
+
+検証内容:
+
+- `profile_allows_secrets_access` が `allowSecretsAccess=true` の profile(personal)だけ許可し、
+  `false` の profile(work-minimal / work-dev)と未知 profile を拒否すること(vacuously true にしない)。
+- chezmoi が見つからないとき `resolve_runtime_profile` / `require_secrets_access` が fail-closed で
+  拒否すること(default profile に倒さない)。
+- chezmoi が profile を解決できる環境では、gate の判定が実 profile の純検査と一致すること
+  (より緩くならない。chezmoi 不在の CI では skip)。
+
+実 profile は `chezmoi data` から取得し、CLI 引数では渡さない(呼び出し側が gate を
+より緩い profile に誘導できないようにするため)。
+
 ## test-render.sh
 
 chezmoi で各 profile を throwaway destination に render(apply)し、managed target 一覧を期待値と比較する。実 home には触れない。

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -514,9 +514,14 @@ resolve_runtime_profile() {
   if ! command -v chezmoi >/dev/null 2>&1; then
     return 1
   fi
-  local profile
-  profile="$(chezmoi data --format=json 2>/dev/null \
-    | yq -p json '.profile // ""' 2>/dev/null)" || return 1
+  # Capture `chezmoi data` separately rather than piping it straight into
+  # yq: a `chezmoi data | yq` pipeline reports only yq's exit status, so a
+  # `chezmoi data` that fails yet still prints parseable JSON would be
+  # masked by a successful yq and slip through. The gate must not depend
+  # on the caller having `set -o pipefail`, so check chezmoi's status first.
+  local data profile
+  data="$(chezmoi data --format=json 2>/dev/null)" || return 1
+  profile="$(printf '%s\n' "$data" | yq -p json '.profile // ""' 2>/dev/null)" || return 1
   [[ -n "$profile" && "$profile" != "null" ]] || return 1
   printf '%s\n' "$profile"
 }

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -502,6 +502,60 @@ backup_paths() {
   yq '.backup_paths[]? | [(.type // ""), (.category // ""), (.path // "")] | join("|")' "$BACKUP_PATHS_FILE"
 }
 
+# Resolve the machine's actual profile from the live chezmoi config,
+# fail-closed. Prints the profile name on success; on any failure
+# (chezmoi absent, config unreadable, empty/null profile) prints nothing
+# and returns non-zero. The private-backup runtime gate (issue #60) must
+# never fall back to a default profile: an environment whose profile
+# cannot be proven must refuse, not silently assume personal. This reads
+# the real config (`chezmoi data`), not a CLI argument, so a caller cannot
+# talk the gate into a more permissive profile than the host actually has.
+resolve_runtime_profile() {
+  if ! command -v chezmoi >/dev/null 2>&1; then
+    return 1
+  fi
+  local profile
+  profile="$(chezmoi data --format=json 2>/dev/null \
+    | yq -p json '.profile // ""' 2>/dev/null)" || return 1
+  [[ -n "$profile" && "$profile" != "null" ]] || return 1
+  printf '%s\n' "$profile"
+}
+
+# Pure capability check for a named profile (no chezmoi dependency, so it
+# is unit-testable). Returns 0 only when the profile is defined and its
+# allowSecretsAccess capability is literally true. A missing profile, a
+# missing capability, or any non-true value (false / absent) returns 1.
+profile_allows_secrets_access() {
+  local profile="$1"
+  profile_exists "$profile" || return 1
+  [[ "$(capability_value "$profile" allowSecretsAccess)" == "true" ]]
+}
+
+# Runtime gate for the private-backup tooling (issue #60). The archive may
+# contain secrets, so backup / restore may run only where the host's real
+# profile grants allowSecretsAccess (personal today; work / client / agent
+# / sandbox are forbidden by policy). Fail-closed at every step: an
+# unresolvable profile, an unknown profile, or allowSecretsAccess != true
+# all refuse with exit-worthy non-zero. Prints a one-line reason; never
+# prints secrets or paths.
+require_secrets_access() {
+  local profile
+  if ! profile="$(resolve_runtime_profile)"; then
+    fail "cannot resolve the machine profile from chezmoi config; refusing (private-backup needs allowSecretsAccess=true). Run: chezmoi init --source ~/dotfiles"
+    return 1
+  fi
+  if ! profile_exists "$profile"; then
+    fail "machine profile '$profile' is not defined in profiles.yaml; refusing private-backup"
+    return 1
+  fi
+  if ! profile_allows_secrets_access "$profile"; then
+    fail "profile '$profile' does not grant secret access (allowSecretsAccess != true); private-backup refuses to run here"
+    return 1
+  fi
+  ok "secret access granted for profile '$profile'"
+  return 0
+}
+
 # Print names of remotes whose URL embeds password-like userinfo
 # (scheme://user:password@host). URL values are never printed.
 git_remotes_with_credentials() {

--- a/scripts/test-secrets-gate.sh
+++ b/scripts/test-secrets-gate.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify the private-backup runtime gate (issue #60): backup / restore may
+# run only where the host's real profile grants allowSecretsAccess. The
+# gate must be fail-closed — an unresolvable or unknown profile, or any
+# non-true value, refuses. The pure capability checks run without chezmoi
+# so this test is deterministic in CI (the validate job has no chezmoi).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+status=0
+
+pass() { ok "test passed: $*"; }
+miss() {
+  fail "test failed: $*"
+  status=1
+}
+
+# 1. profile_allows_secrets_access: only allowSecretsAccess=true profiles
+#    pass. personal grants it; work-minimal / work-dev do not.
+if profile_allows_secrets_access personal; then
+  pass "personal grants secret access"
+else
+  miss "personal should grant secret access"
+fi
+for denied in work-minimal work-dev; do
+  if profile_allows_secrets_access "$denied"; then
+    miss "$denied must not grant secret access"
+  else
+    pass "$denied denied secret access"
+  fi
+done
+
+# 2. An unknown profile must not pass (fail-closed, never vacuously true).
+if profile_allows_secrets_access no-such-profile; then
+  miss "unknown profile must be denied"
+else
+  pass "unknown profile denied"
+fi
+
+# 3. resolve_runtime_profile / require_secrets_access fail closed when
+#    chezmoi cannot be found. Run in a subshell with an empty PATH so
+#    `command -v chezmoi` resolves to nothing; the gate must refuse before
+#    ever assuming a default profile. `fail`/`ok` use shell builtins, so
+#    the empty PATH does not break the gate's own output.
+# shellcheck disable=SC2123 # emptying PATH is the point: simulate chezmoi absence
+if ( PATH=""; resolve_runtime_profile >/dev/null 2>&1 ); then
+  miss "resolve_runtime_profile must fail with chezmoi absent"
+else
+  pass "resolve_runtime_profile fails closed without chezmoi"
+fi
+# shellcheck disable=SC2123 # emptying PATH is the point: simulate chezmoi absence
+if ( PATH=""; require_secrets_access >/dev/null 2>&1 ); then
+  miss "require_secrets_access must refuse with chezmoi absent"
+else
+  pass "require_secrets_access refuses without chezmoi"
+fi
+
+# 4. Consistency with the live host, only when chezmoi can resolve a
+#    profile (skipped in CI). The gate's verdict must match the pure check
+#    for whatever profile the machine actually runs — never more permissive.
+if resolved="$(resolve_runtime_profile 2>/dev/null)"; then
+  if require_secrets_access >/dev/null 2>&1; then
+    if profile_allows_secrets_access "$resolved"; then
+      pass "gate agrees with profile '$resolved' (granted)"
+    else
+      miss "gate granted access but profile '$resolved' should be denied"
+    fi
+  else
+    if profile_allows_secrets_access "$resolved"; then
+      miss "gate refused but profile '$resolved' should be granted"
+    else
+      pass "gate agrees with profile '$resolved' (denied)"
+    fi
+  fi
+else
+  item "chezmoi did not resolve a profile; skipping live consistency check"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "secrets-gate tests passed"
+fi
+exit "$status"

--- a/scripts/test-secrets-gate.sh
+++ b/scripts/test-secrets-gate.sh
@@ -75,19 +75,28 @@ SH
   chmod +x "$fixture_bin/chezmoi"
 }
 with_fixture() { ( PATH="$fixture_bin:$PATH"; "$@" >/dev/null 2>&1 ); }
+# The must case must be exercised with pipefail OFF: this test file runs
+# under `set -o pipefail`, which a subshell inherits, and under pipefail a
+# `chezmoi(fail) | yq(ok)` pipeline already reports non-zero — so the old
+# buggy pipeline would pass this test too. Turning pipefail off makes the
+# test fail against the old code and pass only with the exit-status check,
+# pinning that the gate does not depend on the caller having pipefail.
+with_fixture_no_pipefail() {
+  ( set +o pipefail; PATH="$fixture_bin:$PATH"; "$@" >/dev/null 2>&1 )
+}
 
 # 4a. The must case: chezmoi prints a valid profile but exits non-zero.
 #     The gate must fail closed, not trust the masked payload.
 fake_chezmoi '{"profile":"personal"}' 3
-if with_fixture resolve_runtime_profile; then
-  miss "resolve must fail closed when chezmoi exits non-zero (even with valid JSON)"
+if with_fixture_no_pipefail resolve_runtime_profile; then
+  miss "resolve must fail closed when chezmoi exits non-zero (even with valid JSON, no pipefail)"
 else
-  pass "resolve fails closed on chezmoi non-zero exit despite valid JSON"
+  pass "resolve fails closed on chezmoi non-zero exit despite valid JSON (no pipefail)"
 fi
-if with_fixture require_secrets_access; then
-  miss "gate must refuse when chezmoi exits non-zero"
+if with_fixture_no_pipefail require_secrets_access; then
+  miss "gate must refuse when chezmoi exits non-zero (no pipefail)"
 else
-  pass "gate refuses on chezmoi non-zero exit"
+  pass "gate refuses on chezmoi non-zero exit (no pipefail)"
 fi
 
 # 4b. Healthy chezmoi resolving an allowed profile -> granted.

--- a/scripts/test-secrets-gate.sh
+++ b/scripts/test-secrets-gate.sh
@@ -59,7 +59,63 @@ else
   pass "require_secrets_access refuses without chezmoi"
 fi
 
-# 4. Consistency with the live host, only when chezmoi can resolve a
+# 4. Fixture chezmoi on PATH: drive resolve_runtime_profile / the gate
+#    deterministically (no real chezmoi needed, so this is stable in CI).
+#    A fake `chezmoi` echoes a chosen `chezmoi data` payload and exit code;
+#    real yq stays resolvable because the fixture dir is only prepended.
+fixture_bin="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-gate-test.XXXXXX")"
+trap 'rm -rf "$fixture_bin"' EXIT
+fake_chezmoi() {
+  # $1 = stdout payload, $2 = exit code
+  cat > "$fixture_bin/chezmoi" <<SH
+#!/bin/sh
+printf '%s\n' '$1'
+exit $2
+SH
+  chmod +x "$fixture_bin/chezmoi"
+}
+with_fixture() { ( PATH="$fixture_bin:$PATH"; "$@" >/dev/null 2>&1 ); }
+
+# 4a. The must case: chezmoi prints a valid profile but exits non-zero.
+#     The gate must fail closed, not trust the masked payload.
+fake_chezmoi '{"profile":"personal"}' 3
+if with_fixture resolve_runtime_profile; then
+  miss "resolve must fail closed when chezmoi exits non-zero (even with valid JSON)"
+else
+  pass "resolve fails closed on chezmoi non-zero exit despite valid JSON"
+fi
+if with_fixture require_secrets_access; then
+  miss "gate must refuse when chezmoi exits non-zero"
+else
+  pass "gate refuses on chezmoi non-zero exit"
+fi
+
+# 4b. Healthy chezmoi resolving an allowed profile -> granted.
+fake_chezmoi '{"profile":"personal"}' 0
+if with_fixture require_secrets_access; then
+  pass "gate grants for resolved personal profile"
+else
+  miss "gate should grant for resolved personal profile"
+fi
+
+# 4c. Healthy chezmoi resolving a denied profile -> refused.
+fake_chezmoi '{"profile":"work-minimal"}' 0
+if with_fixture require_secrets_access; then
+  miss "gate must refuse for resolved work-minimal profile"
+else
+  pass "gate refuses for resolved work-minimal profile"
+fi
+
+# 4d. Healthy chezmoi but no profile key -> fail closed (empty profile).
+fake_chezmoi '{}' 0
+if with_fixture resolve_runtime_profile; then
+  miss "resolve must fail closed on empty profile"
+else
+  pass "resolve fails closed on empty profile"
+fi
+rm -f "$fixture_bin/chezmoi"
+
+# 5. Consistency with the live host, only when chezmoi can resolve a
 #    profile (skipped in CI). The gate's verdict must match the pure check
 #    for whatever profile the machine actually runs — never more permissive.
 if resolved="$(resolve_runtime_profile 2>/dev/null)"; then


### PR DESCRIPTION
## 何を

#60 第1段の後半に向けた土台。private-backup の backup / restore(後続 PR)は archive に secret を取り込みうるので、**host の実 profile が `allowSecretsAccess=true` のときだけ**実行できる必要がある。両スクリプトが共有する fail-closed な runtime gate を `lib-policy.sh` に追加する。

## 内容

- `resolve_runtime_profile`: 実 profile を **live な chezmoi config (`chezmoi data`) から取得**。CLI 引数では渡さない(呼び出し側が gate を緩い profile に誘導できない)。chezmoi 不在 / config 読めない / profile 空 は fail-closed。
- `profile_allows_secrets_access`: chezmoi 非依存の純検査(単体テスト可)。`allowSecretsAccess=true` のみ許可。profile/capability 欠如で vacuously true にしない。
- `require_secrets_access`: 上記2つを合成。失敗時は理由を1行で出す(secret / path は出さない)。

## テスト

`scripts/test-secrets-gate.sh`:
- deny path(work-minimal / work-dev / 未知 profile / chezmoi 不在)を **chezmoi なしで**検証。
- profile を解決できる環境では gate 判定が純検査と一致(より緩くならない)。chezmoi 不在の CI では skip。

CI(`validate` job)に追加、README にセクション追記。

## 確認した検証

- `bash -n` / `shellcheck -S warning` / `validate-policy.sh --all` / `test-policy.sh` / `test-secrets-gate.sh` / whitespace check すべて green(ローカル)。

## スコープ外(後続 PR)

- backup スクリプト本体 + machine-neutral manifest + age 暗号化 + verify
- doctor の report-only section + docs 更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)