### PR TITLE
Add private-backup report-only section to doctor (#60, stage 1)

### DIFF
--- a/docs/private-backup.md
+++ b/docs/private-backup.md
@@ -68,12 +68,13 @@ private-backup.sh verify --in PATH (--identity PATH | --identity-command CMD)
 
 ## 段階
 
-- **第1段**: リスト schema + parser + validate + `age` を catalog に追加(宣言レイヤ)。
+- **第1段(完了)**: リスト schema + parser + validate + `age` を catalog に追加(宣言レイヤ)。
   runtime secrets gate。backup(machine-neutral manifest + age identity 暗号化 +
-  指定先書き出し + local 補足同梱)+ verify。← ここまで実装済み。残り = doctor の
-  report-only section。
-- **後続**: restore(dry-run 既定 / `--apply` / 既存は timestamp 退避 / 0700 temp /
-  symlink・path traversal 防御)。
+  指定先書き出し + local 補足同梱)+ verify。doctor の report-only section
+  (public baseline の解決 + marker からバックアップ有無/最終日時。local 補足は存在のみ・
+  中身は読まない)。
+- **第2段(後続)**: restore(dry-run 既定 / `--apply` / 既存は timestamp 退避 / 0700 temp /
+  symlink・path traversal 防御)。冒頭で `require_secrets_access` を通す。
 
 ## 安全境界(後続スクリプトが守る規約)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ policy validation が失敗した場合は exit 1。
 
 ## doctor.sh
 
-導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、agent-tools(report-only。`~/src/agent/agent-tools` の presence を表示し、`enableAgentToolsStatus=true` の opt-in 時のみ status contract(`scripts/status.sh --json`)を実行して安全な summary を出す。clone / pull / sync はしない)、project root の状態を表示する。
+導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、agent-tools(report-only。`~/src/agent/agent-tools` の presence を表示し、`enableAgentToolsStatus=true` の opt-in 時のみ status contract(`scripts/status.sh --json`)を実行して安全な summary を出す。clone / pull / sync はしない)、private-backup(report-only。public baseline の各 target の存在と marker からのバックアップ有無/最終日時を表示。local 補足は **存在のみ**で中身・件数は出さない。アーカイブや captured file の中身は読まない)、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
 remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md`、Corepack の検査は `docs/supply-chain-corepack.md` に従う。
 `npmHardeningMode=enforce` の profile では、期待する npm config 値と現在値の不一致を `[warn]` で報告する(apply 前は不一致が正常)。
@@ -139,6 +139,8 @@ fixture HOME で doctor の managed-path orphan 検出を検証する。実 home
 - agent-tools の status.sh 実行が opt-in であること(`enableAgentToolsStatus=false` では実行マーカーが作られない)。
 - opt-in 時は status を summary し `conflict` を warning にすること。
 - contract version 不一致 / status.sh 欠如 / agent-tools 不在でも warning のみで exit 0 になること。
+- private-backup section: marker 不在で「no backup recorded」、marker ありで最終成功時刻 /
+  archive / 件数を表示すること。local 補足は **存在のみ**で中身(secret らしき行)を漏らさないこと。
 - いずれの場合も doctor が exit 0 を維持すること(report-only)。
 
 ## private-backup.sh

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -209,7 +209,14 @@ section "private-backup (report-only)"
 # read, per docs/local-overrides.md. The state marker (repo-external)
 # gives backup presence and last-success time. doctor never reads any
 # captured file, the archive, or the supplement's contents.
-if [[ -f "$BACKUP_PATHS_FILE" ]]; then
+if [[ ! -f "$BACKUP_PATHS_FILE" ]]; then
+  warn "backup catalog missing: $BACKUP_PATHS_FILE"
+elif ! baseline_rows="$(backup_paths 2>/dev/null)"; then
+  # Capture first so a yq/parse failure becomes a warning instead of a
+  # healthy-looking "0/0 present" (a failed process substitution would not
+  # fail the while loop).
+  warn "could not read backup catalog; skipping baseline resolution"
+else
   baseline_present=0
   baseline_total=0
   while IFS='|' read -r _bp_type _bp_category bp_path; do
@@ -221,10 +228,8 @@ if [[ -f "$BACKUP_PATHS_FILE" ]]; then
     else
       item "baseline absent: $bp_path"
     fi
-  done < <(backup_paths 2>/dev/null)
+  done <<< "$baseline_rows"
   ok "baseline targets: $baseline_present/$baseline_total present"
-else
-  warn "backup catalog missing: $BACKUP_PATHS_FILE"
 fi
 
 # Local supplement: existence only. Do not parse, count, or read it.
@@ -236,14 +241,21 @@ else
 fi
 
 # State marker: presence + last success + basename + count, nothing else.
+# The marker is repo-external and could be stale or hand-edited, so treat
+# its fields as untrusted: drop non-printable chars, basename the archive,
+# and require a numeric count — anything odd is shown as "unknown" rather
+# than echoed verbatim to the terminal.
 backup_marker="$HOME/.local/state/dotfiles/private-backup.json"
 if [[ -f "$backup_marker" ]]; then
-  bm() { yq -p=json -o=tsv "$1" "$backup_marker" 2>/dev/null || true; }
+  bm() { yq -p=json -o=tsv "$1" "$backup_marker" 2>/dev/null | tr -dc '[:print:]' || true; }
   marker_last="$(bm '.last_success // ""')"
-  marker_archive="$(bm '.archive // ""')"
+  marker_archive_raw="$(bm '.archive // ""')"
   marker_count="$(bm '.file_count // ""')"
+  marker_archive="unknown"
+  [[ -n "$marker_archive_raw" ]] && marker_archive="$(basename "$marker_archive_raw")"
+  [[ "$marker_count" =~ ^[0-9]+$ ]] || marker_count="unknown"
   if [[ -n "$marker_last" ]]; then
-    ok "last backup: $marker_last (archive: ${marker_archive:-unknown}, files: ${marker_count:-unknown})"
+    ok "last backup: $marker_last (archive: $marker_archive, files: $marker_count)"
   else
     warn "backup marker present but unreadable"
   fi

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -202,6 +202,56 @@ else
   ok "secret access disabled for profile"
 fi
 
+section "private-backup (report-only)"
+# Report-only and contents-blind (issue #60). Resolve the PUBLIC baseline
+# (backup-paths.yaml) and show whether each target exists; the local
+# supplement is reported by EXISTENCE ONLY — never parsed, counted, or
+# read, per docs/local-overrides.md. The state marker (repo-external)
+# gives backup presence and last-success time. doctor never reads any
+# captured file, the archive, or the supplement's contents.
+if [[ -f "$BACKUP_PATHS_FILE" ]]; then
+  baseline_present=0
+  baseline_total=0
+  while IFS='|' read -r _bp_type _bp_category bp_path; do
+    [[ -z "$bp_path" ]] && continue
+    baseline_total=$((baseline_total + 1))
+    if [[ -e "$HOME/$bp_path" ]]; then
+      item "baseline present: $bp_path"
+      baseline_present=$((baseline_present + 1))
+    else
+      item "baseline absent: $bp_path"
+    fi
+  done < <(backup_paths 2>/dev/null)
+  ok "baseline targets: $baseline_present/$baseline_total present"
+else
+  warn "backup catalog missing: $BACKUP_PATHS_FILE"
+fi
+
+# Local supplement: existence only. Do not parse, count, or read it.
+backup_supplement="$HOME/.config/dotfiles/backup-paths.local"
+if [[ -f "$backup_supplement" ]]; then
+  item "local supplement present (contents not inspected)"
+else
+  item "local supplement absent"
+fi
+
+# State marker: presence + last success + basename + count, nothing else.
+backup_marker="$HOME/.local/state/dotfiles/private-backup.json"
+if [[ -f "$backup_marker" ]]; then
+  bm() { yq -p=json -o=tsv "$1" "$backup_marker" 2>/dev/null || true; }
+  marker_last="$(bm '.last_success // ""')"
+  marker_archive="$(bm '.archive // ""')"
+  marker_count="$(bm '.file_count // ""')"
+  if [[ -n "$marker_last" ]]; then
+    ok "last backup: $marker_last (archive: ${marker_archive:-unknown}, files: ${marker_count:-unknown})"
+  else
+    warn "backup marker present but unreadable"
+  fi
+  unset -f bm
+else
+  warn "no backup recorded yet (run private-backup.sh backup)"
+fi
+
 section "managed-path orphans"
 # A file that carries the managed-by header but whose path is not
 # managed for this profile is likely left over from another profile

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -263,6 +263,24 @@ else
   status=1
 fi
 
+# K) A malformed/null marker must not break doctor: report "unreadable"
+#    and stay exit 0 (guards the set -euo pipefail paths in the section).
+printf 'this is not valid json {{{\n' \
+  > "$fixture_home/.local/state/dotfiles/private-backup.json"
+if pb_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "backup marker present but unreadable" <<< "$pb_out"; then
+    ok "test passed: malformed backup marker reported unreadable (exit 0)"
+  else
+    printf '%s\n' "$pb_out" >&2
+    fail "test failed: malformed backup marker not handled"
+    status=1
+  fi
+else
+  printf '%s\n' "$pb_out" >&2
+  fail "test failed: doctor must stay exit 0 on a malformed backup marker"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "doctor tests passed"
 fi

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -204,6 +204,65 @@ else
   status=1
 fi
 
+# private-backup report-only section (issue #60). doctor must report
+# backup presence and the local supplement's EXISTENCE ONLY, never parse
+# or read the supplement, and always stay exit 0.
+
+# H) No marker yet: doctor reports "no backup recorded" and stays exit 0.
+if pb_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "no backup recorded yet" <<< "$pb_out"; then
+    ok "test passed: missing backup marker reported (exit 0)"
+  else
+    printf '%s\n' "$pb_out" >&2
+    fail "test failed: missing backup marker not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$pb_out" >&2
+  fail "test failed: doctor must stay exit 0 with no backup marker"
+  status=1
+fi
+
+# I) With a marker, doctor surfaces the last-success time / archive / count.
+mkdir -p "$fixture_home/.local/state/dotfiles"
+printf '{"schema_version":1,"last_success":"2026-06-19T00:00:00Z","archive":"backup.age","file_count":2}\n' \
+  > "$fixture_home/.local/state/dotfiles/private-backup.json"
+if pb_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "last backup: 2026-06-19T00:00:00Z" <<< "$pb_out" \
+    && grep -Fq "backup.age" <<< "$pb_out"; then
+    ok "test passed: backup marker last-success reported"
+  else
+    printf '%s\n' "$pb_out" >&2
+    fail "test failed: backup marker details not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$pb_out" >&2
+  fail "test failed: doctor must stay exit 0 with a backup marker"
+  status=1
+fi
+
+# J) The local supplement is reported by existence only — never parsed or
+#    its contents/count shown. A supplement with a recognisable secret-ish
+#    line must not have that line (or an entry count) appear in output.
+mkdir -p "$fixture_home/.config/dotfiles"
+printf 'backup_paths:\n  - { path: .secret-canary-zzz, type: file }\n' \
+  > "$fixture_home/.config/dotfiles/backup-paths.local"
+if pb_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "local supplement present" <<< "$pb_out" \
+    && ! grep -Fq "secret-canary-zzz" <<< "$pb_out"; then
+    ok "test passed: local supplement reported by existence only (contents not leaked)"
+  else
+    printf '%s\n' "$pb_out" >&2
+    fail "test failed: local supplement contents leaked or not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$pb_out" >&2
+  fail "test failed: doctor must stay exit 0 with a local supplement"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "doctor tests passed"
 fi


### PR DESCRIPTION
## 何を

#60 **第1段の最後**。doctor に private-backup の健康診断 section を追加(report-only・中身ブラインド)。これで第1段(gate / backup / verify / doctor)が揃う。

## 内容(`scripts/doctor.sh`)

- **public baseline 解決**: `backup-paths.yaml` の各 target が HOME に存在するか表示 + `n/total present` サマリ。
- **local 補足**: **存在のみ**表示。parse / 件数 / 中身は一切出さない(`docs/local-overrides.md` の規約)。
- **marker**(repo 外): バックアップ有無 + 最終成功時刻 + archive basename + 件数のみ。
- captured file / アーカイブ / 補足の**中身は読まない**。常に exit 0(失敗は doctor 冒頭の policy validation のみ)。

## テスト(`scripts/test-doctor.sh`)

- marker 不在 → 「no backup recorded」、exit 0。
- marker あり → 最終成功時刻 / archive / 件数を表示。
- local 補足に canary 行を仕込み、**存在のみ報告**で canary が出力に出ないこと(中身を漏らさない)。

## 確認した検証

ローカルで全 suite(`validate --all` / `test-policy` / `test-secrets-gate` / `test-private-backup` / `test-doctor`)+ shellcheck + whitespace green。

## これで #60 第1段は完了

残りは第2段 = restore(dry-run 既定 / `--apply` / timestamp 退避 / 0700 temp / symlink・traversal 防御)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)