### PR TITLE
Add new-machine bootstrap procedure to private-backup docs (#60)

### DIFF
--- a/docs/private-backup.md
+++ b/docs/private-backup.md
@@ -84,6 +84,39 @@ private-backup.sh restore --in PATH (--identity PATH | --identity-command CMD) \
   home-relative 検証 / symlink 親ディレクトリ経由の書き込み拒否 / verify 済みアーカイブのみ復元)。
   冒頭で `require_secrets_access` を通す。
 
+## 新マシン bootstrap 手順(復元チェーン)
+
+復号に必要な信頼の起点は age identity 鍵で、それは 1Password にある。そして 1Password へ
+アクセスする手段(`op` の設定・sign-in 材料)を **backup の中身に依存させない**。逆順だと
+「backup を復号するには identity が要る → identity は 1Password → 1Password access は backup
+の中」で循環する。よって新マシンでは下記を**手で用意してから** restore する。**順序を守る**:
+
+1. **公開 dotfiles を入れる**: chezmoi + yq を入れ `chezmoi init`([README](../README.md) の
+   Quickstart)。これは public 設定だけで、private 設定(本機能の対象)は含まれない。
+2. **age を入れる**: `brew install age`。catalog の宣言レイヤ(#53)に載るが install action は
+   手動起動なので、ここでは手で入れる。verify / restore が age に依存する。
+3. **1Password を用意する(信頼の起点・手動)**: 1Password app と `op` CLI を入れ、sign-in する。
+   **backup から復元しない** —— backup を復号する identity がまだ無いため。op の設定 / sign-in
+   材料を「backup にだけ置く」ことは禁止([docs/secrets.md](secrets.md):復元チェーンの循環回避)。
+4. **age identity を 1Password から取り出す**: identity は `op read` で**参照**する(値を
+   ディスクに落とさない)。dotfiles はこの fetch を実行せず、利用者の手元操作に閉じる(secrets.md)。
+5. **restore する**: まず dry-run で差分を確認し、問題なければ `--apply`。
+
+```sh
+# identity をディスクに置かず op 経由で age に渡す(op:// は placeholder。実 vault/item 名は repo に書かない)
+./scripts/private-backup.sh restore --in /path/to/archive.age \
+  --identity-command 'op read op://Personal/dotfiles-age-identity/identity'
+
+# 差分を確認したら --apply を付けて反映(既存ファイルは timestamp 退避 dir へ move)
+./scripts/private-backup.sh restore --in /path/to/archive.age \
+  --identity-command 'op read op://Personal/dotfiles-age-identity/identity' --apply
+```
+
+restore は `allowSecretsAccess=true` の profile でのみ実行できる(work / client / agent では拒否)。
+復元後に**新しい backup を作る**には公開鍵(recipient)が要る ——
+`~/.config/dotfiles/private-backup.recipient` を置くか `--recipient` で渡す(公開鍵なので
+secret ではないが repo にはコミットしない)。
+
 ## 安全境界(後続スクリプトが守る規約)
 
 - backup / restore は **手動起動のみ**・`chezmoi apply` 非結合。

--- a/docs/private-backup.md
+++ b/docs/private-backup.md
@@ -97,7 +97,8 @@ private-backup.sh restore --in PATH (--identity PATH | --identity-command CMD) \
    手動起動なので、ここでは手で入れる。verify / restore が age に依存する。
 3. **1Password を用意する(信頼の起点・手動)**: 1Password app と `op` CLI を入れ、sign-in する。
    **backup から復元しない** —— backup を復号する identity がまだ無いため。op の設定 / sign-in
-   材料を「backup にだけ置く」ことは禁止([docs/secrets.md](secrets.md):復元チェーンの循環回避)。
+   材料を「backup にだけ置く」ことは禁止([docs/secrets.md](secrets.md) の責務範囲・対象外:
+   実 fetch は利用者側で、dotfiles は secret 素材を保持しない)。
 4. **age identity を 1Password から取り出す**: identity は `op read` で**参照**する(値を
    ディスクに落とさない)。dotfiles はこの fetch を実行せず、利用者の手元操作に閉じる(secrets.md)。
 5. **restore する**: まず dry-run で差分を確認し、問題なければ `--apply`。


### PR DESCRIPTION
## 概要

#60 の完了条件で唯一未了だった docs 項目(**復元チェーンと新マシン bootstrap 手順**)を `docs/private-backup.md` に追記する。実装は全段 merge 済みで、残りはこの docs だけだった。

## 内容

- `## 新マシン bootstrap 手順(復元チェーン)` セクションを追加。
- 復号の信頼の起点(age identity)は 1Password にあり、**1Password access 自体を backup の中身に依存させない**。逆順だと循環する(backup 復号には identity → identity は 1Password → 1Password access が backup の中)。
- 手順の順序を固定: chezmoi init(public のみ)→ `age` 手動 install → 1Password 手動用意(信頼の起点)→ `op read` で identity 参照 → restore(dry-run → `--apply`)。
- フラグ・パス・recipient 既定値は `scripts/private-backup.sh` の実挙動に一致。`op://` は placeholder。`docs/secrets.md` の fetch 境界と整合。

## レビュー

docs-only・最小追記。コードは Claude が書いたので相互レビューは Codex 側。