### PR TITLE
Document distribution vs monitoring coordination layers (#73)

### DIFF
--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -84,6 +84,13 @@ AI skills / agents project は、`dotfiles` の policy を前提に動く。poli
 - AI skills / agents project は `dotfiles` の capability を前提条件として参照してよい。
 - AI skills / agents project が install、network tunnel、secret access を必要とする場合は、`dotfiles` 側の capability と approval policy に従う。
 
+連携は 2 層に分かれる。混同しない:
+
+- **配布層**(AI skills / agents project → AI tool home): skill / instruction を `~/.claude` / `~/.codex` などへ配置するのは AI skills / agents project 側の責務(build / sync)。`dotfiles` はこの配布物を管理せず、tool home の asset を作らない。配布の正本は当該 project 側の docs。
+- **監視層**(`dotfiles` → AI skills / agents project): `dotfiles` の `doctor` が presence と、opt-in 時に status の health を read-only で覗くだけ(上の箇条書き)。書き込み・clone・sync はしない。
+
+監視層の status 読み取りは既定で off(`enableAgentToolsStatus: false`)。実運用で有効化する手順(presence path の整合・opt-in・status の実態確認)は Issue #73 で検討する。
+
 推奨する置き場所:
 
 ```text


### PR DESCRIPTION
## 概要

今回の連携整理で判明した **配布層 / 監視層の 2 層区別**が境界 doc に明文化されていなかったので、`docs/ai-environment-boundary.md` の「連携ルール」に追記する。**docs 整備のみ**(#73 のコード宿題 = path 整合・opt-in・status 実態確認には触れない)。

## 内容(確定事実のみ)

- **配布層**(AI skills/agents project → tool home): skill/instruction の配置は当該 project の責務。dotfiles は配布物を管理しない。
- **監視層**(dotfiles doctor → status): presence + opt-in status を read-only で覗くだけ。書き込み・clone・sync はしない。
- 監視層 status 読み取りが既定 off(`enableAgentToolsStatus: false`)である確定事実を明記。
- 実運用での有効化手順(未決定)は本文に焼かず **Issue #73 へのポインタ**に留める。

## レビュー

docs-only・最小 1 ブロック追記。Claude が書いたので相互レビューは Codex 側。#73 は close しない(コード宿題が残る)。