### PR TITLE
Add Codex config.toml to the encrypted backup catalog (#78)

### DIFF
--- a/.chezmoidata/backup-paths.yaml
+++ b/.chezmoidata/backup-paths.yaml
@@ -20,3 +20,8 @@
 backup_paths:
   - { path: .zshrc.local, type: file, category: shell }
   - { path: .ssh/config.local, type: file, category: ssh }
+  # Codex harness config. Contains a mix of public-safe settings and
+  # machine/secret-bearing values (project paths incl. ~/work, status_line,
+  # mcp env), so it is never committed; the encrypted archive carries it.
+  # auth.json is intentionally excluded (1Password is the secret SoR). #78
+  - { path: .codex/config.toml, type: file, category: ai-tools }


### PR DESCRIPTION
## 概要

Codex の `~/.codex/config.toml` を **#60 の暗号化バックアップ**の退避対象に追加する(grill で確定した X 案)。

精査の結果、`config.toml` は public-safe な決めと**機密・固有・動的値が 1 ファイルに混在**(`[projects.*]` の `~/work` パス、`status_line` の秘匿物の疑い、`[mcp_servers.*.env]` 絶対パス、`[hooks.state.*]` の hash 等)。Claude settings(#75)のような 2 層分離が無く public repo に載せられないため、public 管理ではなく暗号化アーカイブで丸ごと退避する。

## 変更

- **`.chezmoidata/backup-paths.yaml`**(public baseline)に `.codex/config.toml`(type: file, category: ai-tools)を 1 エントリ追加。パスは public-safe、中身は age 暗号化アーカイブが運ぶ(#60 は「アーカイブは secret を含みうる前提」)。
- `#60` の `backup` / `verify` / `restore` がそのまま捕捉・復元(スクリプト変更なし)。

## 設計判断

- **`auth.json` は除外**: #60 方針(secret の system-of-record は 1Password、backup を secret 倉庫にしない)に従い、新マシンは Codex 再ログインで取得。
- `keybindings.json` 等は今回対象外。`~/.codex/AGENTS.md` は agent-tools 配布物なので dotfiles 対象外。

## 検証

- `validate-policy.sh`: `backup path: .codex/config.toml` 通過。
- 全7テストスイート PASS。

## レビュー

Claude が書いたので相互レビューは Codex 側。public-safety(パスが public-safe か、auth 除外の妥当性)と #60 機構との整合を重点に。