### PR TITLE
Add catalog install action, gated and idempotent (#53, stage 2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -73,6 +73,9 @@ jobs:
       - name: private-backup backup/verify tests
         run: ./scripts/test-private-backup.sh
 
+      - name: catalog install gate tests
+        run: ./scripts/test-install-packages.sh
+
       - name: whitespace check (committed tree)
         run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD
 

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -36,7 +36,7 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 
 照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。
 
-install は `install-packages.sh`(手動起動・`chezmoi apply` 非結合)が担う。catalog の未 install entry を、`installPackages`(brew_formula / npm_global / go_install)と `installGuiApps`(brew_cask / mas)で gate して install する。**dry-run 既定**(`--apply` で実行)、既 install は skip して**更新しない**(install と update の分離、[update-policy](update-policy.md))、track-only / manual は対象外、npm/go の manager 不在時は skip+warn。environmentKind 制約で work / client / sandbox / agent は gate(installPackages/installGuiApps)が false なので install されない。
+install は `install-packages.sh`(手動起動・`chezmoi apply` 非結合)が担う。catalog の未 install entry を、`installPackages`(brew_formula / npm_global / go_install)と `installGuiApps`(brew_cask / mas)で gate して install する。**dry-run 既定**(`--apply` で実行)、既 install は skip して**更新しない**(install と update の分離、[update-policy](update-policy.md))、track-only / manual は対象外、npm/go の manager 不在時は skip+warn。environmentKind 制約で work / client / agent は gate(installPackages/installGuiApps)が false 必須なので install されない(`environment_kind_forbidden_capabilities`)。sandbox は install 制約の対象外(secret のみ禁止)で、profile が install gate を true にすれば install されうる。
 
 ## Rules
 

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -34,7 +34,9 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 - **台帳外**(undeclared / sprawl: 入っているが catalog に無い)→ `warn`。brew は `brew leaves`(top-level のみ。依存は拾わない)、npm は node 同梱の `npm` / `corepack` を除外(runtime の領分、node/go/uv と同じ扱い)、mas は App Store の無関係アプリが大量に誤検知されるため undeclared は出さない(宣言済み mas entry の presence のみ確認)。
 - **source ズレ**(宣言 source の inventory には無いが `command` が PATH 上に在る = 別 source で入っている疑い)→ `info`。manager 横断の名前照合(脆い)はやらず、PATH 上の存在という堅い信号だけを使う。
 
-照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。install action は後続 phase。
+照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。
+
+install は `install-packages.sh`(手動起動・`chezmoi apply` 非結合)が担う。catalog の未 install entry を、`installPackages`(brew_formula / npm_global / go_install)と `installGuiApps`(brew_cask / mas)で gate して install する。**dry-run 既定**(`--apply` で実行)、既 install は skip して**更新しない**(install と update の分離、[update-policy](update-policy.md))、track-only / manual は対象外、npm/go の manager 不在時は skip+warn。environmentKind 制約で work / client / sandbox / agent は gate(installPackages/installGuiApps)が false なので install されない。
 
 ## Rules
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -143,6 +143,27 @@ fixture HOME で doctor の managed-path orphan 検出を検証する。実 home
   archive / 件数を表示すること。local 補足は **存在のみ**で中身(secret らしき行)を漏らさないこと。
 - いずれの場合も doctor が exit 0 を維持すること(report-only)。
 
+## install-packages.sh
+
+software catalog(`.chezmoidata/packages.yaml`)の **未 install entry を install** する(#53 第2段)。
+手動起動のみ・`chezmoi apply` 非結合。**dry-run 既定**で、`--apply` を付けたときだけ実 install する。
+実 profile を chezmoi config から fail-closed に解決し、source を `installPackages`(brew_formula /
+npm_global / go_install)/ `installGuiApps`(brew_cask / mas)で gate する(work / client / agent は
+これらが false なので何も install しない)。既 install は skip して**更新しない**(install と update の
+分離、[docs/update-policy.md](../docs/update-policy.md))。track-only / manual は対象外。npm / go の
+manager が PATH に無ければ skip + warn(runtime は mise の領分)。
+
+```sh
+./scripts/install-packages.sh           # dry-run: 何が install されるか表示
+./scripts/install-packages.sh --apply   # 未 install entry を実際に install
+```
+
+## test-install-packages.sh
+
+`install-packages.sh` の gate と fail-closed 契約を検証する。source→capability の対応、
+`profile_installs_source` が personal のみ install を許し work 系は許さないこと、profile 未解決時の
+拒否、解決済み work profile の dry-run が 0 件を計画すること(副作用なし)を確認する。
+
 ## private-backup.sh
 
 private な設定(`.local` 上書き + curated アプリ設定)を **age identity 鍵**で単一アーカイブに

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Catalog installer (#53 stage 2). Installs catalog entries
+# (.chezmoidata/packages.yaml) that are declared installable and not yet
+# present, gated by the host profile's install capabilities (installPackages
+# / installGuiApps, resolved fail-closed from the real chezmoi profile).
+#
+# Manual invocation only — never wired into `chezmoi apply`. Dry-run by
+# default; --apply performs installs. Install and update are separate (see
+# docs/update-policy.md): an entry already present is skipped, never
+# reinstalled or upgraded, so `go install ...@latest` / `npm install -g`
+# never run for something already there.
+#
+# Language runtimes (node/go/uv) are mise's domain and are not in the catalog;
+# this tool needs the source's manager (brew / npm / go) on PATH to install,
+# and skips with a warning when it is absent (fail-safe, no capability added).
+
+TOOL_NAME="install-packages.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+usage() {
+  cat >&2 <<EOF
+usage:
+  $TOOL_NAME [--apply]
+
+Installs catalog entries (.chezmoidata/packages.yaml) that are declared
+installable and not yet present, gated by the host profile's installPackages
+/ installGuiApps capabilities. Dry-run by default; --apply performs installs.
+Never upgrades an already-installed entry. Manual only; not wired into
+chezmoi apply.
+EOF
+}
+
+# Whether NAME is already installed for SOURCE. canonical = pkg|name,
+# bincmd = bin|name. Read-only; a present entry is left untouched (no upgrade).
+is_installed() {
+  local source="$1" canonical="$2" bincmd="$3"
+  case "$source" in
+    brew_formula)
+      brew list --formula -1 2>/dev/null | grep -Fxq -- "$canonical" && return 0
+      command -v "$bincmd" >/dev/null 2>&1 ;;
+    brew_cask)
+      brew list --cask -1 2>/dev/null | grep -Fxq -- "$canonical" ;;
+    npm_global)
+      npm ls -g --depth=0 --json 2>/dev/null \
+        | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null \
+        | grep -Fxq -- "$canonical" && return 0
+      command -v "$bincmd" >/dev/null 2>&1 ;;
+    go_install)
+      command -v "$bincmd" >/dev/null 2>&1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Whether the manager SOURCE needs is on PATH. npm_global / go_install depend
+# on a runtime (node / go) that mise provides; absence means "skip", not
+# "install failed".
+manager_present() {
+  case "$1" in
+    brew_formula | brew_cask) command -v brew >/dev/null 2>&1 ;;
+    npm_global) command -v npm >/dev/null 2>&1 ;;
+    go_install) command -v go >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Build the install command for SOURCE into the INSTALL_CMD array (global).
+# Returns 1 for an unsupported source.
+build_install_cmd() {
+  local source="$1" canonical="$2" pkg="$3"
+  case "$source" in
+    brew_formula) INSTALL_CMD=(brew install "$canonical") ;;
+    brew_cask) INSTALL_CMD=(brew install --cask "$canonical") ;;
+    npm_global) INSTALL_CMD=(npm install -g "$pkg") ;;
+    go_install) INSTALL_CMD=(go install "${pkg}@latest") ;;
+    *) return 1 ;;
+  esac
+}
+
+main() {
+  local apply=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply) apply=1; shift ;;
+      -h | --help) usage; return 0 ;;
+      *) fail "unknown argument: $1"; usage; return 2 ;;
+    esac
+  done
+
+  require_yq || return 1
+  [[ -f "$PACKAGES_FILE" ]] || { fail "catalog missing: $PACKAGES_FILE"; return 1; }
+
+  # Fail-closed profile resolution: never assume a default. work / client /
+  # sandbox / agent then gate out via installPackages / installGuiApps = false.
+  local profile
+  if ! profile="$(resolve_runtime_profile)"; then
+    fail "cannot resolve the machine profile from chezmoi config; refusing. Run: chezmoi init --source ~/dotfiles"
+    return 1
+  fi
+  if ! profile_exists "$profile"; then
+    fail "machine profile '$profile' is not defined in profiles.yaml; refusing"
+    return 1
+  fi
+
+  section "catalog install (profile: $profile)"
+  if [[ "$apply" -eq 1 ]]; then
+    item "apply mode: missing installable entries will be installed"
+  else
+    item "dry-run: nothing will be installed (pass --apply to perform)"
+  fi
+
+  local rows
+  rows="$(catalog_packages)" || { fail "could not read catalog packages"; return 1; }
+
+  local name source pkg bin track_only canonical bincmd cap
+  local planned=0 installed_now=0 skipped=0 failed=0
+  local INSTALL_CMD=()
+  while IFS='|' read -r name source pkg bin track_only; do
+    [[ -z "$name$source" ]] && continue
+    canonical="${pkg:-$name}"
+    bincmd="${bin:-$name}"
+
+    # track-only / manual: inventory only, never installed by tooling.
+    if [[ "$track_only" == "true" || "$source" == "manual" ]]; then
+      item "skip $name: track-only ($source)"
+      skipped=$((skipped + 1)); continue
+    fi
+
+    # Capability gate (fail-closed per source). Keeps work / client / agent
+    # from installing anything: their installPackages / installGuiApps = false.
+    if ! profile_installs_source "$profile" "$source"; then
+      cap="$(source_install_capability "$source" 2>/dev/null || echo '?')"
+      item "skip $name: $cap not granted for '$profile' ($source)"
+      skipped=$((skipped + 1)); continue
+    fi
+
+    # Manager must be present (npm/go come from mise). Absent -> skip, not fail.
+    if ! manager_present "$source"; then
+      warn "skip $name: manager for $source not on PATH (runtime not ready?)"
+      skipped=$((skipped + 1)); continue
+    fi
+
+    # Idempotent: never touch an already-installed entry (install != update).
+    if is_installed "$source" "$canonical" "$bincmd"; then
+      ok "already installed: $name ($source)"
+      skipped=$((skipped + 1)); continue
+    fi
+
+    if ! build_install_cmd "$source" "$canonical" "$pkg"; then
+      warn "skip $name: unsupported source '$source'"
+      skipped=$((skipped + 1)); continue
+    fi
+
+    planned=$((planned + 1))
+    if [[ "$apply" -eq 1 ]]; then
+      item "installing: $name -> ${INSTALL_CMD[*]}"
+      if "${INSTALL_CMD[@]}"; then
+        ok "installed: $name ($source)"
+        installed_now=$((installed_now + 1))
+      else
+        warn "install failed: $name ($source)"
+        failed=$((failed + 1))
+      fi
+    else
+      item "would install: $name -> ${INSTALL_CMD[*]}"
+    fi
+  done <<< "$rows"
+
+  if [[ "$apply" -eq 1 ]]; then
+    ok "done: $installed_now installed, $skipped skipped, $failed failed"
+    [[ "$failed" -eq 0 ]]
+  else
+    ok "dry-run: $planned would be installed, $skipped skipped (pass --apply to perform)"
+  fi
+}
+
+main "$@"

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -182,4 +182,8 @@ main() {
   fi
 }
 
-main "$@"
+# Run only when executed, not when sourced (test-install-packages.sh sources
+# this to unit-test build_install_cmd without performing installs).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -51,31 +51,36 @@ is_installed() {
       command -v "$bincmd" >/dev/null 2>&1 ;;
     go_install)
       command -v "$bincmd" >/dev/null 2>&1 ;;
+    mas)
+      mas list 2>/dev/null | awk '{print $1}' | grep -Fxq -- "$canonical" ;;
     *) return 0 ;;
   esac
 }
 
 # Whether the manager SOURCE needs is on PATH. npm_global / go_install depend
-# on a runtime (node / go) that mise provides; absence means "skip", not
-# "install failed".
+# on a runtime (node / go) that mise provides, and mas needs the `mas` CLI;
+# absence means "skip", not "install failed".
 manager_present() {
   case "$1" in
     brew_formula | brew_cask) command -v brew >/dev/null 2>&1 ;;
     npm_global) command -v npm >/dev/null 2>&1 ;;
     go_install) command -v go >/dev/null 2>&1 ;;
+    mas) command -v mas >/dev/null 2>&1 ;;
     *) return 1 ;;
   esac
 }
 
-# Build the install command for SOURCE into the INSTALL_CMD array (global).
-# Returns 1 for an unsupported source.
+# Build the install command for SOURCE into the INSTALL_CMD array (global),
+# using CANONICAL (= pkg, defaulting to name) as the install id. Returns 1
+# for an unsupported source.
 build_install_cmd() {
-  local source="$1" canonical="$2" pkg="$3"
+  local source="$1" canonical="$2"
   case "$source" in
     brew_formula) INSTALL_CMD=(brew install "$canonical") ;;
     brew_cask) INSTALL_CMD=(brew install --cask "$canonical") ;;
-    npm_global) INSTALL_CMD=(npm install -g "$pkg") ;;
-    go_install) INSTALL_CMD=(go install "${pkg}@latest") ;;
+    npm_global) INSTALL_CMD=(npm install -g "$canonical") ;;
+    go_install) INSTALL_CMD=(go install "${canonical}@latest") ;;
+    mas) INSTALL_CMD=(mas install "$canonical") ;;
     *) return 1 ;;
   esac
 }
@@ -149,7 +154,7 @@ main() {
       skipped=$((skipped + 1)); continue
     fi
 
-    if ! build_install_cmd "$source" "$canonical" "$pkg"; then
+    if ! build_install_cmd "$source" "$canonical"; then
       warn "skip $name: unsupported source '$source'"
       skipped=$((skipped + 1)); continue
     fi

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -236,6 +236,32 @@ catalog_source_preference() {
   c="$category" yq '.source_preference[strenv(c)][]?' "$PACKAGES_FILE"
 }
 
+# Map a catalog source to the capability that gates installing it (#53 stage
+# 2). brew_formula / npm_global / go_install are package installs
+# (installPackages); brew_cask / mas are GUI apps (installGuiApps). manual and
+# any unknown source map to nothing — never installed by tooling. Returns 1
+# (and prints nothing) for the uninstallable sources.
+source_install_capability() {
+  case "$1" in
+    brew_formula | npm_global | go_install) printf 'installPackages\n' ;;
+    brew_cask | mas) printf 'installGuiApps\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Whether PROFILE may install SOURCE: the gating capability must be literally
+# true. Fail-closed — an unknown profile, an uninstallable source (manual /
+# unknown), or a non-true / absent capability all return 1. No side effects;
+# prints nothing. environmentKind constraints already force installPackages /
+# installGuiApps false on work / client / sandbox / agent, so this gate keeps
+# the catalog installer from ever acting there.
+profile_installs_source() {
+  local profile="$1" source="$2" cap
+  cap="$(source_install_capability "$source")" || return 1
+  profile_exists "$profile" || return 1
+  [[ "$(capability_value "$profile" "$cap")" == "true" ]]
+}
+
 # Report drift between the declared catalog (packages.yaml) and what is
 # actually installed, per source. Report-only: every path returns 0 so a
 # caller under `set -e` (doctor.sh) keeps its exit code, and all probes are

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -253,8 +253,8 @@ source_install_capability() {
 # true. Fail-closed — an unknown profile, an uninstallable source (manual /
 # unknown), or a non-true / absent capability all return 1. No side effects;
 # prints nothing. environmentKind constraints already force installPackages /
-# installGuiApps false on work / client / sandbox / agent, so this gate keeps
-# the catalog installer from ever acting there.
+# installGuiApps false on work / client / agent (sandbox forbids only secret
+# access), so this gate keeps the catalog installer from acting on those kinds.
 profile_installs_source() {
   local profile="$1" source="$2" cap
   cap="$(source_install_capability "$source")" || return 1

--- a/scripts/test-install-packages.sh
+++ b/scripts/test-install-packages.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify the catalog installer's gate and fail-closed contract (#53 stage 2):
+# - source -> capability mapping is correct.
+# - profile_installs_source only installs a source where the gating capability
+#   is literally true; work / client / agent install nothing; unknown profiles
+#   and manual sources install nothing (fail-closed).
+# - install-packages.sh refuses when no profile resolves, and for a resolved
+#   work profile plans zero installs in dry-run (no side effects).
+# The pure capability checks run without chezmoi, so this is stable in CI.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+status=0
+pass() { ok "test passed: $*"; }
+miss() {
+  fail "test failed: $*"
+  status=1
+}
+
+# 1. source -> install capability mapping.
+check_cap() {
+  local src="$1" want="$2" got
+  if got="$(source_install_capability "$src")" && [[ "$got" == "$want" ]]; then
+    pass "$src -> $want"
+  else
+    miss "$src should map to $want (got '${got:-<none>}')"
+  fi
+}
+check_cap brew_formula installPackages
+check_cap npm_global installPackages
+check_cap go_install installPackages
+check_cap brew_cask installGuiApps
+check_cap mas installGuiApps
+if source_install_capability manual >/dev/null 2>&1; then
+  miss "manual must not map to an install capability"
+else
+  pass "manual maps to no install capability"
+fi
+
+# 2. profile_installs_source: personal installs every installable source;
+#    work-minimal / work-dev install none (installPackages/GuiApps are false).
+for src in brew_formula npm_global go_install brew_cask mas; do
+  if profile_installs_source personal "$src"; then
+    pass "personal installs $src"
+  else
+    miss "personal should install $src"
+  fi
+  for denied in work-minimal work-dev; do
+    if profile_installs_source "$denied" "$src"; then
+      miss "$denied must not install $src"
+    else
+      pass "$denied does not install $src"
+    fi
+  done
+done
+
+# 3. Fail-closed: unknown profile and manual source never install.
+if profile_installs_source no-such-profile brew_formula; then
+  miss "unknown profile must not install"
+else
+  pass "unknown profile installs nothing"
+fi
+if profile_installs_source personal manual; then
+  miss "manual source must never install"
+else
+  pass "manual source installs nothing even for personal"
+fi
+
+# 4. The installer refuses when none of its tools/profile resolve (empty PATH).
+# shellcheck disable=SC2123 # emptying PATH is the point: simulate no tooling
+if ( PATH=""; "$SCRIPT_DIR/install-packages.sh" >/dev/null 2>&1 ); then
+  miss "installer must refuse with no resolvable tooling/profile"
+else
+  pass "installer refuses fail-closed with empty PATH"
+fi
+
+# 5/6. Fixture chezmoi drives resolve_runtime_profile deterministically; real
+#      yq stays resolvable because the fixture dir is only prepended.
+fixture_bin="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-install-test.XXXXXX")"
+trap 'rm -rf "$fixture_bin"' EXIT
+fake_chezmoi() {
+  cat > "$fixture_bin/chezmoi" <<SH
+#!/bin/sh
+printf '%s\n' '$1'
+exit 0
+SH
+  chmod +x "$fixture_bin/chezmoi"
+}
+
+# 5. A resolved work profile plans zero installs (everything gates out before
+#    any probing, so this is deterministic and has no side effects).
+fake_chezmoi '{"profile":"work-minimal"}'
+if out="$(PATH="$fixture_bin:$PATH" "$SCRIPT_DIR/install-packages.sh" 2>&1)"; then
+  if grep -Fq "dry-run: 0 would be installed" <<< "$out"; then
+    pass "work-minimal plans zero installs (gated out)"
+  else
+    printf '%s\n' "$out" >&2
+    miss "work-minimal should plan zero installs"
+  fi
+else
+  printf '%s\n' "$out" >&2
+  miss "installer must exit 0 in dry-run for a resolved work profile"
+fi
+
+# 6. An undefined resolved profile is refused (fail-closed).
+fake_chezmoi '{"profile":"no-such-profile"}'
+if ( PATH="$fixture_bin:$PATH" "$SCRIPT_DIR/install-packages.sh" >/dev/null 2>&1 ); then
+  miss "installer must refuse an undefined resolved profile"
+else
+  pass "installer refuses an undefined resolved profile"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "install-packages tests passed"
+fi
+exit "$status"

--- a/scripts/test-install-packages.sh
+++ b/scripts/test-install-packages.sh
@@ -83,17 +83,29 @@ fi
 fixture_bin="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-install-test.XXXXXX")"
 trap 'rm -rf "$fixture_bin"' EXIT
 fake_chezmoi() {
+  # $1 = chezmoi data payload, $2 = exit code
   cat > "$fixture_bin/chezmoi" <<SH
 #!/bin/sh
 printf '%s\n' '$1'
-exit 0
+exit ${2:-0}
 SH
   chmod +x "$fixture_bin/chezmoi"
 }
 
-# 5. A resolved work profile plans zero installs (everything gates out before
-#    any probing, so this is deterministic and has no side effects).
-fake_chezmoi '{"profile":"work-minimal"}'
+# 5a. chezmoi resolves a valid profile but exits non-zero -> refuse. With yq
+#     and bash present (only chezmoi fails), this reaches and pins
+#     resolve_runtime_profile's fail-closed path; the gate must not trust a
+#     masked payload.
+fake_chezmoi '{"profile":"personal"}' 3
+if ( PATH="$fixture_bin:$PATH" "$SCRIPT_DIR/install-packages.sh" >/dev/null 2>&1 ); then
+  miss "installer must refuse when chezmoi exits non-zero (even with a valid profile)"
+else
+  pass "installer refuses on chezmoi non-zero exit (fail-closed resolve)"
+fi
+
+# 5b. A resolved work profile plans zero installs (everything gates out before
+#     any probing, so this is deterministic and has no side effects).
+fake_chezmoi '{"profile":"work-minimal"}' 0
 if out="$(PATH="$fixture_bin:$PATH" "$SCRIPT_DIR/install-packages.sh" 2>&1)"; then
   if grep -Fq "dry-run: 0 would be installed" <<< "$out"; then
     pass "work-minimal plans zero installs (gated out)"
@@ -107,7 +119,7 @@ else
 fi
 
 # 6. An undefined resolved profile is refused (fail-closed).
-fake_chezmoi '{"profile":"no-such-profile"}'
+fake_chezmoi '{"profile":"no-such-profile"}' 0
 if ( PATH="$fixture_bin:$PATH" "$SCRIPT_DIR/install-packages.sh" >/dev/null 2>&1 ); then
   miss "installer must refuse an undefined resolved profile"
 else

--- a/scripts/test-install-packages.sh
+++ b/scripts/test-install-packages.sh
@@ -126,6 +126,32 @@ else
   pass "installer refuses an undefined resolved profile"
 fi
 
+# 7. build_install_cmd builds the right command per source from the canonical
+#    id (pkg, defaulting to name) — pins the npm pkg-less and mas/go fixes
+#    without performing installs. Sourcing is safe: the main run is guarded.
+# shellcheck source=scripts/install-packages.sh
+source "$SCRIPT_DIR/install-packages.sh"
+check_cmd() {
+  local src="$1" canonical="$2" want="$3" INSTALL_CMD=()
+  if build_install_cmd "$src" "$canonical" && [[ "${INSTALL_CMD[*]}" == "$want" ]]; then
+    pass "build_install_cmd $src -> $want"
+  else
+    miss "build_install_cmd $src should be '$want' (got '${INSTALL_CMD[*]:-<none>}')"
+  fi
+}
+check_cmd brew_formula age "brew install age"
+check_cmd brew_cask iterm2 "brew install --cask iterm2"
+# pkg-less npm entry: canonical falls back to name, never an empty id.
+check_cmd npm_global some-tool "npm install -g some-tool"
+check_cmd npm_global @scope/pkg "npm install -g @scope/pkg"
+check_cmd go_install github.com/x/y/v2 "go install github.com/x/y/v2@latest"
+check_cmd mas 497799835 "mas install 497799835"
+if build_install_cmd manual whatever 2>/dev/null; then
+  miss "build_install_cmd must reject an uninstallable source"
+else
+  pass "build_install_cmd rejects manual/unknown source"
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "install-packages tests passed"
 fi


### PR DESCRIPTION
## 概要

#53 第2段。software catalog(`packages.yaml`)の **未 install entry を install** する手動 action を追加。grill で設計確定(範囲=全 source / gate=既存 `installPackages`・`installGuiApps` に集約・新 capability ゼロ / 既 install は更新しない)。

## 変更

- **`lib-policy.sh`**: `source_install_capability`(brew_formula/npm_global/go_install→installPackages、brew_cask/mas→installGuiApps、manual→不可)+ `profile_installs_source`(fail-closed gate)。`profile_allows_secrets_access` と同型で純粋・テスト可能。
- **`install-packages.sh`**(新規): 実 profile を fail-closed 解決 → 未 install entry を gate して install。**dry-run 既定 / `--apply` で実行**。既 install は skip して**更新しない**(install と update の分離、`update-policy.md` 厳守)。npm/go の manager 不在時は skip+warn(runtime は mise の領分)。track-only/manual は対象外。手動起動のみ・`chezmoi apply` 非結合。
- **`test-install-packages.sh`**(新規): source→capability、profile×source の gate(**personal のみ install / work-minimal・work-dev は 0 件**)、未解決 profile の拒否、work dry-run が 0 件計画を回帰固定。fake chezmoi fixture で決定的。
- **docs**: `policy-model.md` の「install action は後続 phase」を実装記述に更新(矛盾解消)。`scripts/README.md` に2スクリプトを追記。

## 検証

- 全8テストスイート + `shellcheck -S warning scripts/*.sh` + `validate-policy` PASS。
- 実機 dry-run(personal)で 13 件 already-installed 検出・1 件(goreleaser)would install を確認(read-only、`--apply` なし)。

## レビュー

Claude が書いたので相互レビューは Codex 側。**gate(work 系で install されない)**・**install/update 分離(既 install を更新しない)**・fail-closed(profile 未解決で拒否)・mise runtime 依存の扱いを重点に。