### PR TITLE
Add remote-URL (hasconfig) identity selection for personal (#52)

### DIFF
--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -27,6 +27,24 @@ identity file の中身は最小限にする。
 	email = example@example.invalid
 ```
 
+## Remote URL による二次判定(hasconfig、Issue #52)
+
+identity の判定は「置き場所(gitdir)」が一次。加えて、**personal だけ** remote URL でも判定する
+二次ルール(`includeIf "hasconfig:remote.*.url:..."`、Git 2.36+)を持つ。`~/src/personal/` の
+外に clone した personal リポでも、remote が `github.com/kosako/**` なら personal identity が
+当たる保険(fail-closed と相性が良い「置き場所」と「remote」の二重判定)。
+
+- **gitdir が authoritative**: hasconfig ルールは gitdir ルールより **前**に置く。includeIf は
+  後勝ちなので、置き場所(gitdir)が当たればそちらが優先される(例: `~/src/work/` に置いた
+  `github.com/kosako` remote のリポは work identity)。hasconfig は gitdir が当たらないときだけ効く。
+- **personal に限る(public 制約)**: `dot_gitconfig` は public repo に入るため、会社・クライアントの
+  org 名 / URL は書けない。公開可能な personal(`github.com/kosako`)だけを二次判定し、work / client は
+  gitdir のみ + org 名は local identity file 側に留める。
+- **URL 表記を網羅**: HTTPS(`https://github.com/kosako/**`)、scp 形 SSH(`git@github.com:kosako/**`)、
+  `ssh://` 形(`ssh://git@github.com/kosako/**`)はそれぞれ別文字列として literal にマッチするため、
+  3 つとも宣言する(1 つでも欠けるとその clone 形では取りこぼす)。
+- work / client を `~/src/` の外に clone した場合は二次判定が無いので commit は fail-closed(安全側)。
+
 ## 管理方式の決定(2026-06-11、Issue #19)
 
 identity file は当面、完全手動・local only とする。

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -11,6 +11,24 @@
 	# Refuse remote URLs that embed credentials.
 	credentialsInUrl = die
 
+# Secondary, remote-URL-based identity selection (Git 2.36+): a fail-closed
+# safety net for personal repos cloned OUTSIDE ~/src/personal/. The gitdir
+# rules below stay authoritative because includeIf is last-match-wins and they
+# are listed last, so a repo's on-disk placement always overrides its remote
+# when both match. Only personal is matched here: its GitHub URL is public,
+# while work/client org names/URLs are confidential and must never appear in
+# this public file (those contexts stay gitdir-only). All three URL spellings
+# are listed because Git matches the remote URL literally: the HTTPS,
+# scp-style SSH (host:owner), and ssh:// SSH forms are distinct strings.
+[includeIf "hasconfig:remote.*.url:https://github.com/kosako/**"]
+	path = ~/.config/git/personal.gitconfig
+
+[includeIf "hasconfig:remote.*.url:git@github.com:kosako/**"]
+	path = ~/.config/git/personal.gitconfig
+
+[includeIf "hasconfig:remote.*.url:ssh://git@github.com/kosako/**"]
+	path = ~/.config/git/personal.gitconfig
+
 [includeIf "gitdir:~/src/personal/"]
 	path = ~/.config/git/personal.gitconfig
 

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -47,6 +47,24 @@ for context in personal work client sandbox agent; do
   check_contains "include path for $context" "path = ~/.config/git/$context.gitconfig"
 done
 
+# Personal also has remote-URL (hasconfig) rules covering all three URL
+# spellings; work/client must never (their org URLs are confidential).
+for pattern in \
+  'hasconfig:remote.*.url:https://github.com/kosako/**' \
+  'hasconfig:remote.*.url:git@github.com:kosako/**' \
+  'hasconfig:remote.*.url:ssh://git@github.com/kosako/**'; do
+  check_contains "hasconfig personal pattern: $pattern" "[includeIf \"$pattern\"]"
+done
+
+# Public-safety: every hasconfig rule must reference only the public personal
+# owner. A work/client org name appearing here would leak into a public repo.
+if grep -F 'hasconfig:remote' "$GITCONFIG_SOURCE" | grep -vq 'kosako'; then
+  fail "test failed: a hasconfig rule references a non-public owner (github.com/kosako only)"
+  status=1
+else
+  ok "test passed: hasconfig rules are personal/public-safe only"
+fi
+
 if grep -Eq '^[[:space:]]*(name|email)[[:space:]]*=' "$GITCONFIG_SOURCE"; then
   fail "test failed: source contains an identity assignment"
   status=1
@@ -54,8 +72,11 @@ else
   ok "test passed: no identity assignment in source"
 fi
 
-if grep -q '@' "$GITCONFIG_SOURCE"; then
-  fail "test failed: source contains an @ (possible email value)"
+# An '@' is allowed only inside the SSH remote-URL patterns of the hasconfig
+# includeIf headers (git@... / ssh://git@...); anywhere else it likely
+# indicates a leaked email value.
+if grep -F '@' "$GITCONFIG_SOURCE" | grep -vqF 'hasconfig:remote.*.url'; then
+  fail "test failed: source contains an @ outside hasconfig URL patterns (possible email value)"
   status=1
 else
   ok "test passed: no email-like value in source"
@@ -141,6 +162,82 @@ elif grep -qi "credential" <<< "$output"; then
 else
   printf '%s\n' "$output" >&2
   fail "test failed: credential URL failed for another reason"
+  status=1
+fi
+
+section "fixture checks: remote-URL identity (hasconfig)"
+
+# A work identity file + ~/src/work/ so the ordering test below (placement
+# stays authoritative) can resolve a work identity.
+cat > "$fixture/.config/git/work.gitconfig" <<'EOF'
+[user]
+	name = Dotfiles Work Test
+	email = dotfiles-work@example.invalid
+EOF
+mkdir -p "$fixture/src/work/demo"
+
+# A personal repo cloned OUTSIDE ~/src/ still resolves the personal identity
+# from its remote URL, for each of the three URL spellings.
+has_i=0
+for url in \
+  "https://github.com/kosako/x.git" \
+  "git@github.com:kosako/x.git" \
+  "ssh://git@github.com/kosako/x.git"; do
+  has_i=$((has_i + 1))
+  repo="$fixture/outside/has-$has_i"
+  mkdir -p "$repo"
+  run_git "$repo" init --quiet --initial-branch=main
+  run_git "$repo" config remote.origin.url "$url"
+  if output="$(run_git "$repo" commit --allow-empty -m test 2>&1)"; then
+    author="$(run_git "$repo" log -1 --format='%ae')"
+    if [[ "$author" == "dotfiles-test@example.invalid" ]]; then
+      ok "test passed: outside-root repo with personal remote resolves personal identity ($url)"
+    else
+      fail "test failed: outside-root repo resolved unexpected author: $author ($url)"
+      status=1
+    fi
+  else
+    printf '%s\n' "$output" >&2
+    fail "test failed: commit failed for outside-root personal remote ($url)"
+    status=1
+  fi
+done
+
+# A non-personal remote outside ~/src/ must NOT match: the hasconfig patterns
+# are exact to github.com/kosako, never a catch-all (fail-closed).
+repo="$fixture/outside/has-other"
+mkdir -p "$repo"
+run_git "$repo" init --quiet --initial-branch=main
+run_git "$repo" config remote.origin.url "https://github.com/someorg/x.git"
+if output="$(run_git "$repo" commit --allow-empty -m test 2>&1)"; then
+  printf '%s\n' "$output" >&2
+  fail "test failed: non-personal remote outside roots resolved an identity"
+  status=1
+elif grep -Eqi 'no (email|name) was given|user\.useConfigOnly' <<< "$output"; then
+  ok "test passed: non-personal remote outside roots stays fail-closed"
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: non-personal remote failed for another reason"
+  status=1
+fi
+
+# Placement stays authoritative: a repo IN ~/src/work/ keeps the work identity
+# even when its remote is a personal (github.com/kosako) URL, because the
+# gitdir rule is listed after the hasconfig rules and wins when both match.
+repo="$fixture/src/work/demo"
+run_git "$repo" init --quiet --initial-branch=main
+run_git "$repo" config remote.origin.url "https://github.com/kosako/x.git"
+if output="$(run_git "$repo" commit --allow-empty -m test 2>&1)"; then
+  author="$(run_git "$repo" log -1 --format='%ae')"
+  if [[ "$author" == "dotfiles-work@example.invalid" ]]; then
+    ok "test passed: gitdir placement overrides remote (work dir + personal remote -> work)"
+  else
+    fail "test failed: placement did not override remote; author: $author"
+    status=1
+  fi
+else
+  printf '%s\n' "$output" >&2
+  fail "test failed: commit failed in work context with personal remote"
   status=1
 fi
 

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -56,13 +56,20 @@ for pattern in \
   check_contains "hasconfig personal pattern: $pattern" "[includeIf \"$pattern\"]"
 done
 
-# Public-safety: every hasconfig rule must reference only the public personal
-# owner. A work/client org name appearing here would leak into a public repo.
-if grep -F 'hasconfig:remote' "$GITCONFIG_SOURCE" | grep -vq 'kosako'; then
-  fail "test failed: a hasconfig rule references a non-public owner (github.com/kosako only)"
+# Public-safety: the ONLY hasconfig rules allowed are the three public personal
+# patterns asserted above. Match against the exact allowlist (not a loose
+# "contains kosako", which would also accept e.g. github.com/work-kosako): any
+# other hasconfig line is a confidential org leaking into this public file.
+unexpected_hasconfig="$(grep -F 'hasconfig:remote' "$GITCONFIG_SOURCE" \
+  | grep -vF 'hasconfig:remote.*.url:https://github.com/kosako/**' \
+  | grep -vF 'hasconfig:remote.*.url:git@github.com:kosako/**' \
+  | grep -vF 'hasconfig:remote.*.url:ssh://git@github.com/kosako/**' || true)"
+if [[ -n "$unexpected_hasconfig" ]]; then
+  fail "test failed: unexpected hasconfig rule(s) in source (only the 3 public personal patterns allowed):"
+  printf '%s\n' "$unexpected_hasconfig" >&2
   status=1
 else
-  ok "test passed: hasconfig rules are personal/public-safe only"
+  ok "test passed: hasconfig rules are exactly the 3 public personal patterns"
 fi
 
 if grep -Eq '^[[:space:]]*(name|email)[[:space:]]*=' "$GITCONFIG_SOURCE"; then


### PR DESCRIPTION
## Summary

Adds a secondary, remote-URL-based git identity rule for the **personal**
context, so a personal repo cloned **outside** `~/src/personal/` still resolves
the personal identity from its remote.

- Today identity is selected purely by placement (`includeIf gitdir:~/src/<ctx>/`).
  A personal repo cloned elsewhere matches nothing → `useConfigOnly=true` fails
  the commit (fail-closed, but the remote already proves it's personal).
- New rule: `includeIf "hasconfig:remote.*.url:..."` (Git 2.36+) for personal only.

### Design (verified empirically against git 2.50 before coding)

- **Placement stays authoritative.** `includeIf` is last-match-wins, so the
  hasconfig rules are listed **before** the gitdir rules: a `github.com/kosako`
  repo sitting in `~/src/work/` still gets the *work* identity. hasconfig only
  supplies identity when no gitdir matched (i.e. outside `~/src/`).
- **All three URL spellings needed.** Git matches the remote URL literally:
  `https://github.com/kosako/**`, `git@github.com:kosako/**`, and
  `ssh://git@github.com/kosako/**` — the `ssh://` form does **not** match the
  scp-style pattern (confirmed empirically). A non-kosako remote matches none.
- **Public-safety (论点 A).** Only `personal` is matched — its GitHub URL is
  public. `work`/`client` org names/URLs are confidential and must never appear
  in this public file, so they stay **gitdir-only**.

## Linked Issue

Closes #52.

## Validation

Local, all green:

- `test-gitconfig` — new static checks for the three patterns + a guard that
  every hasconfig rule references only `github.com/kosako`; fixtures proving all
  three URL forms resolve personal outside `~/src/`, a non-kosako remote stays
  fail-closed, and placement overrides remote.
- `validate-policy --all`, `test-policy`, `test-doctor`, `test-render`,
  `test-claude-settings`, `test-npmrc`, `test-install-packages`,
  `test-secrets-gate`, `test-private-backup`, `shellcheck -S warning`,
  `bash -n`, `git diff --check`.

Empirical matrix (git 2.50): `https`/`scp`/`ssh://` kosako remotes → personal;
`someorg` remote → unset (fail-closed); work-dir + kosako remote → work.

## Side Effects

None applied. `dot_gitconfig` is not a `.tmpl` and is not applied to the real
home in this change. No identity values, org names, or absolute paths enter the
public repo (only the public `github.com/kosako` owner).

## Residual Risk

- `work`/`client` cloned outside `~/src/` remain fail-closed (no public-safe
  hasconfig possible) — by design.
- A new repo with no remote yet relies on gitdir as before.

## Next

- Remaining: #45 (environmentKind enum), #17 (SSH), #16 (VS Code), #73 (homework).