### PR TITLE
Declare 1password-cli (op) in the software catalog (#83)

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -40,6 +40,7 @@ packages:
   - { name: shellcheck, source: brew_formula }
   - { name: tmux, source: brew_formula }
   - { name: yq, source: brew_formula }
+  - { name: 1password-cli, source: brew_cask, bin: op }
   - { name: copilot-cli, source: brew_cask }
   - { name: iterm2, source: brew_cask }
   - { name: swiftbar, source: brew_cask }

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -480,7 +480,7 @@ EOF
   # Default inventory == the reality-seed catalog (drift-free baseline).
   printf '%s\n' age chezmoi gh mise shellcheck tmux yq > "$drift_dir/brew_formulae"
   printf '%s\n' age chezmoi gh mise shellcheck tmux yq > "$drift_dir/brew_leaves"
-  printf '%s\n' copilot-cli iterm2 swiftbar > "$drift_dir/brew_casks"
+  printf '%s\n' 1password-cli copilot-cli iterm2 swiftbar > "$drift_dir/brew_casks"
   # npm and corepack are node-bundled; including them proves they are
   # filtered out and never reported as undeclared.
   printf '%s' '{"dependencies":{"@anthropic-ai/claude-code":{},"@openai/codex":{},"npm":{},"corepack":{}}}' \


### PR DESCRIPTION
## Summary

Declares `1password-cli` (the `op` CLI) in the software catalog. Activating the
#60 private-backup identity seam (`--identity-command 'op read op://...'`, #51)
required installing op via `brew install --cask 1password-cli`, which doctor
then flagged as undeclared catalog sprawl. op is now a real dependency of the
backup's key supply, so it belongs in the catalog.

- `packages.yaml`: add `{ name: 1password-cli, source: brew_cask, bin: op }`.
- `test-policy.sh`: add `1password-cli` to `setup_drift`'s fake `brew_cask`
  reality-seed, so the drift-free baseline stays clean (otherwise the catalog
  declares a cask the fixture inventory lacks → "not installed" drift breaks the
  "no catalog drift" assertion).

## Linked Issue

Closes #83.

## Validation

Local, all green: `validate-policy --all`, `test-policy` (drift baseline incl.
the new cask), `test-install-packages`, `test-doctor`, `test-render`,
`test-gitconfig`, `test-claude-settings`, `shellcheck -S warning`, `bash -n`.
`doctor` now reports `installed: 1password-cli (brew_cask)` instead of
undeclared.

## Side Effects

None. Catalog declaration only (no install action; install is manual). Other
pre-existing drift (`librsvg`, `go`, `gofmt`) is unrelated.

## Next

Return to the git-signing module (the original thread).