### PR TITLE
Implement git-signing module (SSH signing via 1Password) (#85)

### DIFF
--- a/.chezmoidata/backup-paths.yaml
+++ b/.chezmoidata/backup-paths.yaml
@@ -25,3 +25,9 @@ backup_paths:
   # mcp env), so it is never committed; the encrypted archive carries it.
   # auth.json is intentionally excluded (1Password is the secret SoR). #78
   - { path: .codex/config.toml, type: file, category: ai-tools }
+  # Git personal identity (name/email, plus user.signingkey + commit.gpgsign
+  # once SSH signing is set up). Not chezmoi-managed — identity values must not
+  # enter the public repo (docs/git-identity.md) — so the encrypted archive
+  # carries it, letting a new machine restore the identity instead of
+  # recreating it by hand. The path itself is public-safe. (#85)
+  - { path: .config/git/personal.gitconfig, type: file, category: git }

--- a/.chezmoidata/modules.yaml
+++ b/.chezmoidata/modules.yaml
@@ -46,7 +46,12 @@ modules:
   macos-defaults:
     description: opt-in の macOS defaults。
   git-signing:
-    description: 後続 module。commit / tag signing。
+    description: commit / tag の SSH 署名(1Password op-ssh-sign)。仕組みのみ managed、鍵と opt-in は context 別 local。
+    paths:
+      - .config/git
+      - .config/git/signing.gitconfig
+    requires:
+      enableGitSigning: true
   ai-policy:
     description: AI agent 権限方針。
   ai-tools:

--- a/.chezmoidata/profiles.yaml
+++ b/.chezmoidata/profiles.yaml
@@ -19,6 +19,7 @@ profiles:
       - update-policy
       - ai-policy
       - claude-settings
+      - git-signing
     capabilities:
       installPackages: true
       installGuiApps: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,3 +113,6 @@ jobs:
 
       - name: claude settings sandbox content tests
         run: ./scripts/test-claude-settings.sh
+
+      - name: git-signing gating tests
+        run: ./scripts/test-git-signing.sh

--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -82,8 +82,27 @@ fatal: no email was given and auto-detection is disabled
   global identity の設定有無を検知する。値そのものは表示しない。
 - `scripts/test-gitconfig.sh` は `dot_gitconfig` の安全設定と includeIf の挙動を local fixture で検証する。
 
+## SSH 署名(git-signing module、Issue #85)
+
+commit / tag を **SSH 署名**(1Password の op-ssh-sign)して GitHub で Verified にできる。
+`enableGitSigning` capability で gate、既定 off=opt-in。
+
+- **仕組みは managed**: `~/.config/git/signing.gitconfig`(`gpg.format=ssh` + signer プログラム
+  `/Applications/1Password.app/Contents/MacOS/op-ssh-sign`)を、`git-signing` module かつ
+  `enableGitSigning=true` のときだけ配備する。`dot_gitconfig` は常時 `[include]` し、ファイル
+  不在時は git が無視(no-op)。signer パスは public-safe(`/Applications` 配下・ユーザー名なし)。
+- **鍵と opt-in は context 別 local**: `user.signingkey`(どの鍵)と `commit.gpgsign`(署名する)は
+  `~/.config/git/<context>.gitconfig` に置く。**managed 側には鍵も gpgsign も置かない**。理由:
+  global に `commit.gpgsign=true` を置くと署名鍵の無い context(work/client repos)で commit が
+  失敗する。context ごとに鍵を入れて opt-in する方が安全(multi-account の署名鍵分離とも一致)。
+- 署名鍵の**実体は 1Password**(SSH key)で、`user.signingkey` はその公開鍵参照。
+- GitHub では鍵を **Signing Key として登録**する(Authentication Key とは別枠)。committer email が
+  そのアカウントの verified email であること。
+- 復元との関係: identity + 署名紐付けを持つ `personal.gitconfig` は backup catalog に含めるので
+  (#85)、新マシンでは復元される([private-backup](private-backup.md))。
+
 ## 対象外
 
-- Git signing(後続 `git-signing` module)。
-- secret store(1Password など)からの identity / signing material の取得。
+- secret store(1Password など)からの identity 値の自動取得(署名鍵は 1Password agent 経由で
+  使うが、dotfiles は identity / 鍵素材を fetch しない)。
 - Git remote mutation。

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -109,11 +109,12 @@ main 直 commit は例外扱いにする。
 ./scripts/test-doctor.sh
 ./scripts/test-render.sh
 ./scripts/test-claude-settings.sh
+./scripts/test-git-signing.sh
 bash -n scripts/*.sh
 git diff --check
 ```
 
-`test-render.sh` / `test-claude-settings.sh` は chezmoi を必要とする(CI では version pin して導入する)。
+`test-render.sh` / `test-claude-settings.sh` / `test-git-signing.sh` は chezmoi を必要とする(CI では version pin して導入する)。
 
 `preflight` / `doctor` を変更した場合:
 

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -43,3 +43,11 @@
 
 [includeIf "gitdir:~/src/agent/"]
 	path = ~/.config/git/agent.gitconfig
+
+# SSH-based commit/tag signing mechanism, managed only when enableGitSigning is
+# on (git-signing module). The include is unconditional: Git silently ignores a
+# missing path, so this is a no-op until signing is opted in. The signing key
+# and the per-context commit.gpgsign live in the local identity files above
+# (see docs/git-identity.md).
+[include]
+	path = ~/.config/git/signing.gitconfig

--- a/private_dot_config/git/signing.gitconfig
+++ b/private_dot_config/git/signing.gitconfig
@@ -1,0 +1,10 @@
+# Managed by chezmoi from kosako/dotfiles.
+# SSH-based commit/tag signing mechanism, gated by enableGitSigning via the
+# git-signing module. Non-secret: only the signer program path. The signing KEY
+# (user.signingkey) and the per-context opt-in (commit.gpgsign) live in the
+# local identity files under ~/.config/git/ (see docs/git-identity.md), never
+# here. This file tells Git HOW to sign, not WHICH key or WHETHER to sign.
+[gpg]
+	format = ssh
+[gpg "ssh"]
+	program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -50,6 +50,20 @@ if command -v git >/dev/null 2>&1; then
   else
     warn "transfer.credentialsInUrl is not die"
   fi
+  # enableGitSigning gates the managed SSH-signing mechanism
+  # (~/.config/git/signing.gitconfig: gpg.format=ssh + 1Password signer).
+  # AGENTS.md requires a capability to drive a doctor section. The signing KEY
+  # (user.signingkey) and the per-context commit.gpgsign opt-in live in the
+  # local identity files (docs/git-identity.md), never in the managed mechanism.
+  if [[ "$(capability_value "$profile" enableGitSigning)" == "true" ]]; then
+    if module_active_for_profile "$profile" git-signing; then
+      ok "enableGitSigning=true; SSH signing mechanism managed (signing.gitconfig); set user.signingkey + commit.gpgsign per context (local)"
+    else
+      warn "enableGitSigning=true but the git-signing module is inactive for this profile (signing mechanism not managed)"
+    fi
+  else
+    ok "Git signing mechanism not managed (enableGitSigning=false)"
+  fi
 else
   warn "git not found"
 fi

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -312,6 +312,52 @@ else
   status=1
 fi
 
+# Git signing report (enableGitSigning, issue #85). doctor stays report-only /
+# exit 0 and must reflect both the active and the dangling (capability true but
+# git-signing module inactive) cases. Throwaway repo copy so the edits do not
+# touch the real data files.
+sign_root="$fixture_home/.dotfiles-signing"
+mkdir -p "$sign_root/.chezmoidata"
+cp -R "$DOTFILES_ROOT/scripts" "$sign_root/scripts"
+cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$sign_root/.chezmoidata/"
+
+# L) enableGitSigning=true with the git-signing module active -> managed mechanism.
+awk '$0 == "      enableGitSigning: false" { print "      enableGitSigning: true"; next } { print }' \
+  "$sign_root/.chezmoidata/profiles.yaml" > "$sign_root/.chezmoidata/profiles.yaml.tmp"
+mv "$sign_root/.chezmoidata/profiles.yaml.tmp" "$sign_root/.chezmoidata/profiles.yaml"
+if sg_out="$(HOME="$fixture_home" "$sign_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "SSH signing mechanism managed" <<< "$sg_out"; then
+    ok "test passed: enableGitSigning=true reports the managed signing mechanism"
+  else
+    printf '%s\n' "$sg_out" >&2
+    fail "test failed: managed signing mechanism not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$sg_out" >&2
+  fail "test failed: doctor must stay exit 0 (enableGitSigning=true, module active)"
+  status=1
+fi
+
+# M) enableGitSigning=true but the git-signing module removed -> dangling warning,
+#    still exit 0.
+awk '$0 == "      - git-signing" { next } { print }' \
+  "$sign_root/.chezmoidata/profiles.yaml" > "$sign_root/.chezmoidata/profiles.yaml.tmp"
+mv "$sign_root/.chezmoidata/profiles.yaml.tmp" "$sign_root/.chezmoidata/profiles.yaml"
+if sg_out="$(HOME="$fixture_home" "$sign_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "git-signing module is inactive" <<< "$sg_out"; then
+    ok "test passed: enableGitSigning=true with module inactive is reported as dangling"
+  else
+    printf '%s\n' "$sg_out" >&2
+    fail "test failed: dangling enableGitSigning not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$sg_out" >&2
+  fail "test failed: doctor must stay exit 0 (enableGitSigning dangling)"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "doctor tests passed"
 fi

--- a/scripts/test-git-signing.sh
+++ b/scripts/test-git-signing.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Gating test for the git-signing module (issue #85). signing.gitconfig (the
+# SSH-signing mechanism: gpg.format=ssh + 1Password signer) is a managed file
+# applied ONLY when enableGitSigning is true; the committed default is false, so
+# ~/.gitconfig's unconditional [include] is a no-op until opted in. The signing
+# key and the per-context commit.gpgsign live in the local identity files
+# (docs/git-identity.md) and are intentionally out of the managed mechanism.
+# Renders into throwaway destinations; never touches the real home directory.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+require_yq || exit 1
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  fail "chezmoi not found; render tests require it"
+  exit 1
+fi
+
+status=0
+tmp_roots=()
+
+cleanup() {
+  local dir
+  for dir in "${tmp_roots[@]:-}"; do
+    [[ -n "$dir" ]] && rm -rf "$dir"
+  done
+}
+trap cleanup EXIT
+
+# Apply the personal profile from SOURCE_DIR into a throwaway home and print the
+# home path. Returns non-zero on a failed apply.
+apply_personal() {
+  local source_dir="$1" root
+  root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing.XXXXXX")"
+  tmp_roots+=("$root")
+  mkdir -p "$root/home"
+  printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
+  if ! chezmoi --config "$root/chezmoi.toml" \
+      --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1; then
+    return 1
+  fi
+  printf '%s\n' "$root/home"
+}
+
+section "git-signing gating"
+
+# 1) Committed default (enableGitSigning=false): signing.gitconfig is not applied.
+if ! off_home="$(apply_personal "$DOTFILES_ROOT")"; then
+  fail "test failed: personal apply (default) did not render"
+  exit 1
+fi
+if [[ -e "$off_home/.config/git/signing.gitconfig" ]]; then
+  fail "test failed: signing.gitconfig applied while enableGitSigning=false"
+  status=1
+else
+  ok "test passed: default (enableGitSigning=false) does not apply signing.gitconfig"
+fi
+
+# 2) enableGitSigning=true: signing.gitconfig is applied with the SSH mechanism.
+src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing-src.XXXXXX")"
+tmp_roots+=("$src")
+cp -R "$DOTFILES_ROOT" "$src/src"
+rm -rf "$src/src/.git"
+yq -i '.profiles.personal.capabilities.enableGitSigning = true' \
+  "$src/src/.chezmoidata/profiles.yaml"
+
+if ! on_home="$(apply_personal "$src/src")"; then
+  fail "test failed: personal apply (enableGitSigning=true) did not render"
+  exit 1
+fi
+f="$on_home/.config/git/signing.gitconfig"
+if [[ ! -f "$f" ]]; then
+  fail "test failed: signing.gitconfig not applied while enableGitSigning=true"
+  status=1
+elif grep -q 'format = ssh' "$f" && grep -q 'op-ssh-sign' "$f"; then
+  ok "test passed: enableGitSigning=true applies signing.gitconfig (ssh format + 1Password signer)"
+else
+  fail "test failed: signing.gitconfig missing expected ssh/op-ssh-sign content"
+  status=1
+fi
+
+# 3) The managed mechanism must NOT carry the key or the per-context opt-in;
+#    those are local per-context (a leak would force signing globally / expose a key).
+if [[ -f "$f" ]] && grep -qiE '^[[:space:]]*(signingkey|gpgsign)[[:space:]]*=' "$f"; then
+  fail "test failed: signing.gitconfig contains user.signingkey/commit.gpgsign (must be local per-context)"
+  status=1
+else
+  ok "test passed: signing.gitconfig carries the mechanism only (no key, no gpgsign)"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "git-signing tests passed"
+fi
+exit "$status"

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -56,6 +56,11 @@ for pattern in \
   check_contains "hasconfig personal pattern: $pattern" "[includeIf \"$pattern\"]"
 done
 
+# The git-signing module's mechanism is pulled in via an unconditional include
+# (a no-op when the file is absent / signing off).
+check_contains "git-signing include directive" "[include]"
+check_contains "git-signing include path" "path = ~/.config/git/signing.gitconfig"
+
 # Public-safety: the ONLY hasconfig rules allowed are the three public personal
 # patterns asserted above. Match against the exact allowlist (not a loose
 # "contains kosako", which would also accept e.g. github.com/work-kosako): any


### PR DESCRIPTION
## Summary

Fills in the placeholder `git-signing` module so commits/tags can be **SSH-signed
with 1Password** and verified on GitHub, gated by `enableGitSigning`. Default
off (wired, opt-in) — no applied behavior changes in this PR.

### Mechanism vs key/opt-in split (key design decision)
- **Managed, non-secret**: `~/.config/git/signing.gitconfig` = `gpg.format=ssh` +
  `gpg.ssh.program` (the 1Password `op-ssh-sign` path, public-safe under
  `/Applications`, no username). Applied only when the `git-signing` module is
  active **and** `enableGitSigning=true`.
- **Local, per-context**: `user.signingkey` + `commit.gpgsign` live in
  `~/.config/git/<context>.gitconfig`, never in the managed mechanism. A global
  `commit.gpgsign=true` would fail commits in a context with no signing key
  (work/client repos); per-context opt-in is safe and matches multi-account
  signing-key separation.

### Changes
- `modules.yaml`: `git-signing` declares `.config/git` + `.config/git/signing.gitconfig`
  with `requires enableGitSigning=true`. The dir path is needed so the source
  subdir doesn't leave `.config/git` managed for every profile (the same reason
  `claude-settings` declares `.claude`).
- `profiles.yaml`: `personal` lists `git-signing` (dormant while the cap is false).
- `dot_gitconfig`: unconditional `[include] path = ~/.config/git/signing.gitconfig`
  — Git ignores a missing path, so it's a no-op until opted in.
- `doctor.sh`: reports `enableGitSigning` + the dangling true-but-module-inactive
  case (AGENTS.md: a capability must drive a doctor section).
- `backup-paths.yaml`: add `.config/git/personal.gitconfig` so the identity (and
  `user.signingkey` once set) is **restored on a new machine** instead of
  recreated by hand (encrypted archive carries it; path is public-safe). **(#85 论点 C — confirmed)**
- `test-git-signing.sh` (new, wired into CI render job + the validation list):
  default off doesn't apply `signing.gitconfig`; on applies it with the ssh
  mechanism and carries **no** key/gpgsign. `test-gitconfig.sh` asserts the include.
- `docs/git-identity.md`: mechanism/local split, op-ssh-sign, GitHub signing-key
  registration, multi-context, restore tie-in.

## Linked Issue

Closes #85.

## Validation

Local, all green: `validate-policy --all`, `test-git-signing` (gating: off→not
applied, on→applied mechanism-only), `test-render` (default managed sets
unchanged — `.config/git` correctly gated), `test-gitconfig`, `test-doctor`,
`test-policy`, `test-claude-settings`, `test-private-backup`, `test-secrets-gate`,
`test-npmrc`, `test-install-packages`, `shellcheck -S warning`, `bash -n`,
`git diff --check`.

## Side Effects

None applied. `enableGitSigning=false` everywhere → `signing.gitconfig` not
applied, rendered managed sets unchanged from `main`. No signing key / identity
value enters the repo (only the public `op-ssh-sign` path).

## Next (activation — separate, hands-on)

1. Choose/confirm a 1Password SSH key to sign with; register it on GitHub as a
   **Signing Key**.
2. In `~/.config/git/personal.gitconfig`: add `user.signingkey` + `commit.gpgsign=true`.
3. Flip `enableGitSigning: true` on personal, `chezmoi apply`.
4. Re-run `private-backup.sh backup` to capture the updated `personal.gitconfig`.