### PR TITLE
Enable git signing for personal (enableGitSigning=true) (#87)

### DIFF
--- a/.chezmoidata/profiles.yaml
+++ b/.chezmoidata/profiles.yaml
@@ -25,7 +25,7 @@ profiles:
       installGuiApps: true
       enableMacOSDefaults: false
       enable1PasswordSSH: true
-      enableGitSigning: false
+      enableGitSigning: true
       enableDirenv: true
       enableRuntimeManagement: true
       enableVsCodeSettings: true

--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -85,7 +85,9 @@ fatal: no email was given and auto-detection is disabled
 ## SSH 署名(git-signing module、Issue #85)
 
 commit / tag を **SSH 署名**(1Password の op-ssh-sign)して GitHub で Verified にできる。
-`enableGitSigning` capability で gate、既定 off=opt-in。
+`enableGitSigning` capability で gate。**personal は有効(true)** = `signing.gitconfig` が
+managed で配備される。**work / client は false**(gitdir のみ・署名なし)。鍵(`user.signingkey`)と
+`commit.gpgsign` は引き続き context 別 local の opt-in(下記)。
 
 - **仕組みは managed**: `~/.config/git/signing.gitconfig`(`gpg.format=ssh` + signer プログラム
   `/Applications/1Password.app/Contents/MacOS/op-ssh-sign`)を、`git-signing` module かつ

--- a/scripts/test-git-signing.sh
+++ b/scripts/test-git-signing.sh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 # Gating test for the git-signing module (issue #85). signing.gitconfig (the
 # SSH-signing mechanism: gpg.format=ssh + 1Password signer) is a managed file
-# applied ONLY when enableGitSigning is true; the committed default is false, so
-# ~/.gitconfig's unconditional [include] is a no-op until opted in. The signing
+# applied ONLY when enableGitSigning is true. Both gated states are forced in
+# throwaway source copies so the test is independent of the committed default
+# (the unconditional [include] in ~/.gitconfig is a no-op when the file is
+# absent). The signing
 # key and the per-context commit.gpgsign live in the local identity files
 # (docs/git-identity.md) and are intentionally out of the managed mechanism.
 # Renders into throwaway destinations; never touches the real home directory.
@@ -48,16 +50,23 @@ apply_personal() {
 
 section "git-signing gating"
 
-# 1) Committed default (enableGitSigning=false): signing.gitconfig is not applied.
-if ! off_home="$(apply_personal "$DOTFILES_ROOT")"; then
-  fail "test failed: personal apply (default) did not render"
+# 1) enableGitSigning=false: signing.gitconfig is not applied. Force the value in
+#    a copy so the test is independent of the committed default.
+off_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing-off.XXXXXX")"
+tmp_roots+=("$off_src")
+cp -R "$DOTFILES_ROOT" "$off_src/src"
+rm -rf "$off_src/src/.git"
+yq -i '.profiles.personal.capabilities.enableGitSigning = false' \
+  "$off_src/src/.chezmoidata/profiles.yaml"
+if ! off_home="$(apply_personal "$off_src/src")"; then
+  fail "test failed: personal apply (enableGitSigning=false) did not render"
   exit 1
 fi
 if [[ -e "$off_home/.config/git/signing.gitconfig" ]]; then
   fail "test failed: signing.gitconfig applied while enableGitSigning=false"
   status=1
 else
-  ok "test passed: default (enableGitSigning=false) does not apply signing.gitconfig"
+  ok "test passed: enableGitSigning=false does not apply signing.gitconfig"
 fi
 
 # 2) enableGitSigning=true: signing.gitconfig is applied with the SSH mechanism.

--- a/scripts/test-render.sh
+++ b/scripts/test-render.sh
@@ -53,7 +53,7 @@ expected_managed() {
   local profile="$1"
   case "$profile" in
     personal)
-      printf '%s\n' .claude .claude/settings.json .config .config/mise .config/mise/config.toml .gitconfig .npmrc .zprofile .zshenv .zshrc
+      printf '%s\n' .claude .claude/settings.json .config .config/git .config/git/signing.gitconfig .config/mise .config/mise/config.toml .gitconfig .npmrc .zprofile .zshenv .zshrc
       ;;
     work-minimal)
       printf '%s\n' .config .gitconfig


### PR DESCRIPTION
## Summary

Activates the #85 git-signing module on **personal**: flips `enableGitSigning`
to true so `chezmoi apply` deploys the managed `signing.gitconfig`
(`gpg.format=ssh` + 1Password `op-ssh-sign`).

- `profiles.yaml`: personal `enableGitSigning` false → true (work profiles
  unchanged — still gitdir-only, no signing).
- `test-render.sh`: personal `expected_managed` gains `.config/git` +
  `.config/git/signing.gitconfig` (managed once the capability is true).
- `test-git-signing.sh`: the off-state case now forces `enableGitSigning=false`
  in a throwaway copy instead of relying on the committed default (now true), so
  both gated states stay covered regardless of the default.

## Linked Issue

Closes #87.

## Context (out of band, hands-on)

- An Ed25519 SSH key was generated in 1Password (`Private / GitHub SSH (kosako)`).
- `~/.config/git/personal.gitconfig` already has `user.signingkey` (the public
  key); `commit.gpgsign` is turned on after this merges + `chezmoi apply` (so the
  mechanism is in place first), and the key is registered on GitHub as a
  **Signing Key**.

## Validation

Local, all green: `validate-policy --all`, `test-render` (personal managed set
now includes the signing paths), `test-git-signing` (off→not applied / on→applied
mechanism-only, both forced in copies), `test-doctor` (reports
`SSH signing mechanism managed`), `test-policy`, `test-gitconfig`,
`test-claude-settings`, `shellcheck -S warning`, `bash -n`, `git diff --check`.

## Side Effects

This is the opt-in flip: after merge, `chezmoi apply` on personal deploys
`signing.gitconfig`. No key material or identity value enters the repo (only the
public `op-ssh-sign` path). Work/client are unaffected.

## Next

`chezmoi apply` → set `commit.gpgsign=true` in personal.gitconfig → test a signed
commit shows **Verified** on GitHub → re-run `private-backup.sh backup`.