### PR TITLE
Signing ops: AI commits unsigned; back up 1Password agent.toml (#89)

### DIFF
--- a/.chezmoidata/backup-paths.yaml
+++ b/.chezmoidata/backup-paths.yaml
@@ -31,3 +31,10 @@ backup_paths:
   # carries it, letting a new machine restore the identity instead of
   # recreating it by hand. The path itself is public-safe. (#85)
   - { path: .config/git/personal.gitconfig, type: file, category: git }
+  # 1Password SSH agent config. op-ssh-sign (commit signing) and SSH auth reach
+  # the key through this agent, which only serves the vaults/items listed here;
+  # without it signing fails (it was the #87 gotcha). Not chezmoi-managed (it is
+  # machine/1Password-state specific); the encrypted archive carries it so a new
+  # machine restores the served-vault config. Path and vault names are
+  # public-safe; no key material is in it. (#89)
+  - { path: .config/1Password/ssh/agent.toml, type: file, category: ssh }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Phase 2 以降の作業は、原則として Issue 作成、branch 作成、Pull
 - `main` への直接 commit は例外扱いにする。
 - script、policy、capability、profile、install、secret、network、AI agent 境界に関わる変更は PR 必須。
 - main 直 commit の例外を使った場合は、Notion worklog または follow-up Issue に理由を残す。
+- **AI(エージェント)が作る commit は署名しない(`--no-gpg-sign` を付ける)。** personal context は `commit.gpgsign=true` で人間の commit は SSH 署名され GitHub Verified になるが(`docs/git-identity.md`)、AI commit を署名すると op-ssh-sign の Touch ID が必要になり、PR 確認後の自動 merge 等の自動化が止まる。署名は**人間の attest** に限り、AI commit は署名対象外とする。署名 on/off は per-context(personal=署名 / work・client=なし)で per-repo ではなく、AI 非署名は commit 単位の opt-out(repo/context とは別軸)。
 
 ## 作業ログ
 


### PR DESCRIPTION
## Summary

Two follow-ups to enabling personal git signing (#87):

1. **AGENTS.md**: AI/agent commits must use `--no-gpg-sign`. personal context
   signs human commits (`commit.gpgsign=true` → GitHub Verified), but signing an
   AI commit needs op-ssh-sign **Touch ID**, which blocks autonomous "review the
   PR then merge" automation. Signing is the **human's attest** only; AI commits
   opt out **per-commit** (orthogonal to the signing policy, which is
   per-context — personal signs / work·client don't — **not per-repo**). This
   PR's own commit is `--no-gpg-sign` (`%G?` = N), the first application.
2. **backup-paths.yaml**: add `.config/1Password/ssh/agent.toml`. op-ssh-sign
   reaches the key via the 1Password SSH agent, which only serves the
   vaults/items listed in `agent.toml`; without it signing fails (the #87
   gotcha — a vault-name mismatch). Backing it up lets a new machine restore the
   served-vault config. Path + vault names are public-safe; no key material.

## Linked Issue

Closes #89.

## Validation

Local, all green: `validate-policy --all` (backup catalog incl. the new entry),
`test-private-backup`, `test-secrets-gate`, `test-policy`, `test-render`,
`test-doctor`, `test-gitconfig`, `test-git-signing`, `shellcheck -S warning`,
`bash -n`, `git diff --check`. The commit is unsigned by design.

## Side Effects

Docs (AGENTS.md) + backup catalog declaration. No apply. After merge, re-run
`private-backup.sh backup` to capture `agent.toml` into the archive.

## Next

Re-run the backup to capture agent.toml. The git-signing thread is otherwise
complete (signing confirmed Verified on GitHub).