### PR TITLE
commit/tag 署名を既定 OFF にする(opt-in 化、infra は維持)(#97)

### DIFF
--- a/.chezmoidata/backup-paths.yaml
+++ b/.chezmoidata/backup-paths.yaml
@@ -25,8 +25,10 @@ backup_paths:
   # mcp env), so it is never committed; the encrypted archive carries it.
   # auth.json is intentionally excluded (1Password is the secret SoR). #78
   - { path: .codex/config.toml, type: file, category: ai-tools }
-  # Git personal identity (name/email, plus user.signingkey + commit.gpgsign
-  # once SSH signing is set up). Not chezmoi-managed — identity values must not
+  # Git personal identity (name/email, plus user.signingkey for the SSH signer).
+  # commit.gpgsign defaults off in the managed dot_gitconfig (#97); signing is
+  # opt-in per repo, so this file no longer pins it on. Not chezmoi-managed —
+  # identity values must not
   # enter the public repo (docs/git-identity.md) — so the encrypted archive
   # carries it, letting a new machine restore the identity instead of
   # recreating it by hand. The path itself is public-safe. (#85)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ Phase 2 以降の作業は、原則として Issue 作成、branch 作成、Pull
 - `main` への直接 commit は例外扱いにする。
 - script、policy、capability、profile、install、secret、network、AI agent 境界に関わる変更は PR 必須。
 - main 直 commit の例外を使った場合は、Notion worklog または follow-up Issue に理由を残す。
-- **AI(エージェント)が作る commit は署名しない(`--no-gpg-sign` を付ける)。** personal context は `commit.gpgsign=true` で人間の commit は SSH 署名され GitHub Verified になるが(`docs/git-identity.md`)、AI commit を署名すると op-ssh-sign の Touch ID が必要になり、PR 確認後の自動 merge 等の自動化が止まる。署名は**人間の attest** に限り、AI commit は署名対象外とする。署名 on/off は per-context(personal=署名 / work・client=なし)で per-repo ではなく、AI 非署名は commit 単位の opt-out(repo/context とは別軸)。
+
+署名(commit/tag gpgsign)は **git config の責務**で AI 指示ではないため、AGENTS.md では扱わない。既定 off・opt-in は per repo/context で、正本は `docs/git-identity.md` と `dot_gitconfig`(#97)。
 
 ## 作業ログ
 

--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -82,21 +82,26 @@ fatal: no email was given and auto-detection is disabled
   global identity の設定有無を検知する。値そのものは表示しない。
 - `scripts/test-gitconfig.sh` は `dot_gitconfig` の安全設定と includeIf の挙動を local fixture で検証する。
 
-## SSH 署名(git-signing module、Issue #85)
+## SSH 署名(git-signing module、Issue #85 / 既定 off は Issue #97)
 
-commit / tag を **SSH 署名**(1Password の op-ssh-sign)して GitHub で Verified にできる。
-`enableGitSigning` capability で gate。**personal は有効(true)** = `signing.gitconfig` が
-managed で配備される。**work / client は false**(gitdir のみ・署名なし)。鍵(`user.signingkey`)と
-`commit.gpgsign` は引き続き context 別 local の opt-in(下記)。
+commit / tag は 1Password の op-ssh-sign で **SSH 署名**できるが、**署名は既定 OFF(人も AI も
+区別なし)**。一人プロジェクトの無人 commit が署名プロンプトで止まらないためで、署名は「必須」では
+なく「必要な repo だけ opt-in」する。署名インフラ(鍵・mechanism)は残すので opt-in は一発。
 
-- **仕組みは managed**: `~/.config/git/signing.gitconfig`(`gpg.format=ssh` + signer プログラム
-  `/Applications/1Password.app/Contents/MacOS/op-ssh-sign`)を、`git-signing` module かつ
-  `enableGitSigning=true` のときだけ配備する。`dot_gitconfig` は常時 `[include]` し、ファイル
-  不在時は git が無視(no-op)。signer パスは public-safe(`/Applications` 配下・ユーザー名なし)。
-- **鍵と opt-in は context 別 local**: `user.signingkey`(どの鍵)と `commit.gpgsign`(署名する)は
-  `~/.config/git/<context>.gitconfig` に置く。**managed 側には鍵も gpgsign も置かない**。理由:
-  global に `commit.gpgsign=true` を置くと署名鍵の無い context(work/client repos)で commit が
-  失敗する。context ごとに鍵を入れて opt-in する方が安全(multi-account の署名鍵分離とも一致)。
+- **既定 off は managed**: `dot_gitconfig`(global)が `[commit] gpgsign=false` / `[tag] gpgsign=false`
+  を **includeIf 群より前** に持つ。includeIf は last-match-wins なので、後続の context include や
+  repo-local の `git config commit.gpgsign true` が上書きして opt-in できる。`false` の既定は無鍵
+  context でも安全(global に `true` を置くと署名鍵の無い context で commit が失敗するので置かない)。
+- **仕組み(mechanism)は managed**: `~/.config/git/signing.gitconfig`(`gpg.format=ssh` + signer
+  プログラム `/Applications/1Password.app/Contents/MacOS/op-ssh-sign`)を、`git-signing` module かつ
+  `enableGitSigning=true` のときだけ配備する。`dot_gitconfig` は常時 `[include]` し、ファイル不在時
+  は git が無視(no-op)。signer パスは public-safe(`/Applications` 配下・ユーザー名なし)。
+- **鍵は context 別 local、gpgsign の opt-in も local か per-repo**: `user.signingkey`(どの鍵)は
+  `~/.config/git/<context>.gitconfig` に置く。**managed 側には鍵を置かず、gpgsign は false の既定
+  だけ置く**(`true` の opt-in は repo-local の `git config commit.gpgsign true`、または常時署名したい
+  context の local file)。
+- **トレードオフ**: 既定 off なので直接 commit に GitHub "Verified" は付かない。PR を web / squash
+  merge した履歴は GitHub の web-flow 鍵で Verified のまま。
 - 署名鍵の**実体は 1Password**(SSH key)で、`user.signingkey` はその公開鍵参照。
 - GitHub では鍵を **Signing Key として登録**する(Authentication Key とは別枠)。committer email が
   そのアカウントの verified email であること。

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -11,6 +11,19 @@
 	# Refuse remote URLs that embed credentials.
 	credentialsInUrl = die
 
+# Commit/tag signing defaults OFF for every context, so unattended commits
+# (human or AI alike) never block on the 1Password signer prompt. Signing is
+# opt-in, not required. This MUST stay before the includeIf blocks below:
+# includeIf is last-match-wins, so a context file or a repo-local
+# `git config commit.gpgsign true` can opt back in. A `false` default is safe
+# everywhere; a global `true` would instead fail in key-less contexts. The
+# signing mechanism (signing.gitconfig) and key stay available, so opt-in is
+# one flag. See docs/git-identity.md.
+[commit]
+	gpgsign = false
+[tag]
+	gpgsign = false
+
 # Secondary, remote-URL-based identity selection (Git 2.36+): a fail-closed
 # safety net for personal repos cloned OUTSIDE ~/src/personal/. The gitdir
 # rules below stay authoritative because includeIf is last-match-wins and they

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -57,7 +57,7 @@ if command -v git >/dev/null 2>&1; then
   # local identity files (docs/git-identity.md), never in the managed mechanism.
   if [[ "$(capability_value "$profile" enableGitSigning)" == "true" ]]; then
     if module_active_for_profile "$profile" git-signing; then
-      ok "enableGitSigning=true; SSH signing mechanism managed (signing.gitconfig); set user.signingkey + commit.gpgsign per context (local)"
+      ok "enableGitSigning=true; SSH signing mechanism managed (signing.gitconfig); commit.gpgsign defaults off (managed), opt in per repo/context (local key + commit.gpgsign=true)"
     else
       warn "enableGitSigning=true but the git-signing module is inactive for this profile (signing mechanism not managed)"
     fi

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -61,6 +61,19 @@ done
 check_contains "git-signing include directive" "[include]"
 check_contains "git-signing include path" "path = ~/.config/git/signing.gitconfig"
 
+# Commit/tag signing defaults off (unattended commits never block on the signer
+# prompt); opt-in is per-repo/context. The managed file must carry the false
+# default and must NEVER force signing on globally: a global `gpgsign = true`
+# would break key-less contexts (work/client), the exact failure the design
+# avoids.
+check_contains "commit signing defaults off" "gpgsign = false"
+if grep -Eq '^[[:space:]]*gpgsign[[:space:]]*=[[:space:]]*true' "$GITCONFIG_SOURCE"; then
+  fail "test failed: managed source must not force gpgsign = true (breaks key-less contexts)"
+  status=1
+else
+  ok "test passed: managed source never forces signing on"
+fi
+
 # Public-safety: the ONLY hasconfig rules allowed are the three public personal
 # patterns asserted above. Match against the exact allowlist (not a loose
 # "contains kosako", which would also accept e.g. github.com/work-kosako): any

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -66,7 +66,21 @@ check_contains "git-signing include path" "path = ~/.config/git/signing.gitconfi
 # default and must NEVER force signing on globally: a global `gpgsign = true`
 # would break key-less contexts (work/client), the exact failure the design
 # avoids.
-check_contains "commit signing defaults off" "gpgsign = false"
+# commit and tag both default off — assert section-aware so dropping either
+# block fails (a plain `gpgsign = false` grep would still pass on just one).
+for sect in commit tag; do
+  if awk -v s="[$sect]" '
+      $0 == s { ins = 1; next }
+      /^\[/   { ins = 0 }
+      ins && /^[[:space:]]*gpgsign[[:space:]]*=[[:space:]]*false/ { found = 1 }
+      END { exit !found }
+    ' "$GITCONFIG_SOURCE"; then
+    ok "test passed: $sect.gpgsign = false (section-aware)"
+  else
+    fail "test failed: [$sect] section missing gpgsign = false"
+    status=1
+  fi
+done
 if grep -Eq '^[[:space:]]*gpgsign[[:space:]]*=[[:space:]]*true' "$GITCONFIG_SOURCE"; then
   fail "test failed: managed source must not force gpgsign = true (breaks key-less contexts)"
   status=1


### PR DESCRIPTION
Closes #97

## 概要

一人プロジェクトの無人 commit(人も AI も)が 1Password op-ssh-sign の Touch ID プロンプトで止まらないよう、**commit/tag 署名を既定 OFF・opt-in 化**する。#87/#88 が入れた「personal は既定で署名 ON」を**意図的に反転**。署名インフラ(鍵・mechanism)は残し、必要な repo は一発で opt-in 可能。

これは git config の変更であり behavioral rule ではない(人/AI を区別しない)。`AGENTS.md` / `CLAUDE.md` は触らない。

## 変更(tracked / この diff)

- **`dot_gitconfig`**: 明示的な既定 `[commit] gpgsign=false` / `[tag] gpgsign=false` を **includeIf 群より前**に追加。includeIf は last-match-wins なので、context include や repo-local の `git config commit.gpgsign true` が上書きして opt-in できる。`false` は無鍵 context でも安全(global `true` は無鍵 context で commit 失敗 → managed は依然 `true` を持たない)。
- **`scripts/test-gitconfig.sh`**: 「managed は `gpgsign = false` を持つ / `gpgsign = true` は持たない」を回帰固定。
- **`scripts/doctor.sh`**: 署名 report を「既定 off・per repo/context opt-in」に更新。
- **`docs/git-identity.md`**: 署名節を既定 off モデルに書き換え(原則を「managed には鍵を置かず gpgsign は false の既定だけ、true は local/per-repo」に精緻化 + Verified トレードオフ明記)。
- **`.chezmoidata/backup-paths.yaml`**: personal.gitconfig が gpgsign を pin する旨のコメントを実態に合わせ更新。

## 維持(やっていないこと)

- `enableGitSigning=true` / `signing.gitconfig`(format=ssh + op-ssh-sign)/ `user.signingkey` は不変 → opt-in は一発。
- 人/AI 区別の署名ルールは入れない。#89 の AI commit `--no-gpg-sign` は既定 off で冗長になるが無害なので据え置き。

## 実機操作(この diff 外)

- local `~/.config/git/personal.gitconfig`(chezmoi 非管理)から `commit/tag gpgsign=true` を除去(`signingkey` は残す)。
- `chezmoi apply ~/.gitconfig` + 暗号化 backup 再実行(新マシン復元で署名が再 pin されないように)。

## 検証

- `git config --global --get commit.gpgsign` => **false**、~/dotfiles 実効も false。
- temp repo で既定 commit(`--no-gpg-sign` なし)→ **無署名・プロンプト無し・exit 0**。
- repo-local `git config commit.gpgsign true` → 実効 **true**(opt-in 一発)。mechanism+鍵は #87 で署名実証済みのまま不変。
- `test-gitconfig` / `test-git-signing` / `test-doctor` / `test-render` / `test-policy` / `shellcheck -S warning` / `bash -n` すべてパス。

## トレードオフ(意図どおり)

既定 off なので直接 commit に GitHub "Verified" は付かない。PR を web/squash merge した履歴は GitHub web-flow 鍵で Verified のまま。