### PR TITLE
shell ツールを catalog に追加 + install(#96 PR1)

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -40,6 +40,22 @@ packages:
   - { name: shellcheck, source: brew_formula }
   - { name: tmux, source: brew_formula }
   - { name: yq, source: brew_formula }
+  # Interactive shell environment (#96): prompt, navigation, completion, modern
+  # CLI. Installed via brew, sourced/initialised from dot_zshrc (no plugin
+  # manager). The zsh-* plugins have no executable; brew_formula presence is
+  # detected via `brew list`, so they need no bin.
+  - { name: starship, source: brew_formula }
+  - { name: zoxide, source: brew_formula }
+  - { name: fzf, source: brew_formula }
+  - { name: fzf-tab, source: brew_formula }
+  - { name: zsh-autosuggestions, source: brew_formula }
+  - { name: zsh-syntax-highlighting, source: brew_formula }
+  - { name: zsh-completions, source: brew_formula }
+  - { name: ripgrep, source: brew_formula, bin: rg }
+  - { name: fd, source: brew_formula }
+  - { name: eza, source: brew_formula }
+  - { name: bat, source: brew_formula }
+  - { name: direnv, source: brew_formula }
   - { name: 1password-cli, source: brew_cask, bin: op }
   - { name: copilot-cli, source: brew_cask }
   - { name: iterm2, source: brew_cask }

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -508,6 +508,18 @@ run_drift() {
         bash -c 'set -euo pipefail; source "$LIBPOLICY"; report_catalog_drift'
 }
 
+# Drop one entry from the seeded brew inventory to simulate a declared-but-
+# absent package. Mutating the seed (rather than re-listing it) keeps each
+# override case inheriting the full reality-seed, so it introduces exactly one
+# drift and can never silently diverge from shell_env_formulae.
+drift_seed_remove() {
+  local entry="$1" f
+  for f in brew_formulae brew_leaves; do
+    grep -vx "$entry" "$drift_dir/$f" > "$drift_dir/$f.tmp"
+    mv "$drift_dir/$f.tmp" "$drift_dir/$f"
+  done
+}
+
 setup_drift
 run_drift "catalog drift: clean when reality matches the catalog" "no catalog drift"
 
@@ -517,20 +529,14 @@ run_drift "catalog drift: flags an undeclared brew leaf" \
   "undeclared: librsvg (brew_formula leaf not in catalog)"
 
 setup_drift
-printf '%s\n' age gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
-  > "$drift_dir/brew_formulae"
-printf '%s\n' age gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
-  > "$drift_dir/brew_leaves"
+drift_seed_remove chezmoi
 run_drift "catalog drift: flags a declared package that is not installed" \
   "not installed: chezmoi (brew_formula)"
 
 setup_drift
 # Declared via brew but absent from brew, while the command resolves on
 # PATH -> source drift (info), not "not installed".
-printf '%s\n' age chezmoi mise shellcheck tmux yq "${shell_env_formulae[@]}" \
-  > "$drift_dir/brew_formulae"
-printf '%s\n' age chezmoi mise shellcheck tmux yq "${shell_env_formulae[@]}" \
-  > "$drift_dir/brew_leaves"
+drift_seed_remove gh
 printf '#!/bin/sh\nexit 0\n' > "$drift_fakebin/gh"
 chmod +x "$drift_fakebin/gh"
 run_drift "catalog drift: source mismatch is info when the command is on PATH" \

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -435,6 +435,12 @@ run_fail_contains \
 # Globals set by setup_drift: drift_dir (fake inventory + go bin),
 # drift_fakebin (fake managers + yq symlink). Reuses `fixture` from
 # make_fixture for the sourced lib-policy.sh and packages.yaml.
+#
+# shell_env_formulae mirrors the #96 interactive-shell brew formulae now in the
+# catalog so the reality-seed stays drift-free; reused by the override cases
+# below so each still introduces exactly one drift.
+shell_env_formulae=(starship zoxide fzf fzf-tab zsh-autosuggestions \
+  zsh-syntax-highlighting zsh-completions ripgrep fd eza bat direnv)
 setup_drift() {
   make_fixture
   drift_dir="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-drift.XXXXXX")"
@@ -478,8 +484,10 @@ EOF
   done
 
   # Default inventory == the reality-seed catalog (drift-free baseline).
-  printf '%s\n' age chezmoi gh mise shellcheck tmux yq > "$drift_dir/brew_formulae"
-  printf '%s\n' age chezmoi gh mise shellcheck tmux yq > "$drift_dir/brew_leaves"
+  printf '%s\n' age chezmoi gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+    > "$drift_dir/brew_formulae"
+  printf '%s\n' age chezmoi gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+    > "$drift_dir/brew_leaves"
   printf '%s\n' 1password-cli copilot-cli iterm2 swiftbar > "$drift_dir/brew_casks"
   # npm and corepack are node-bundled; including them proves they are
   # filtered out and never reported as undeclared.
@@ -509,16 +517,20 @@ run_drift "catalog drift: flags an undeclared brew leaf" \
   "undeclared: librsvg (brew_formula leaf not in catalog)"
 
 setup_drift
-printf '%s\n' age gh mise shellcheck tmux yq > "$drift_dir/brew_formulae"
-printf '%s\n' age gh mise shellcheck tmux yq > "$drift_dir/brew_leaves"
+printf '%s\n' age gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+  > "$drift_dir/brew_formulae"
+printf '%s\n' age gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+  > "$drift_dir/brew_leaves"
 run_drift "catalog drift: flags a declared package that is not installed" \
   "not installed: chezmoi (brew_formula)"
 
 setup_drift
 # Declared via brew but absent from brew, while the command resolves on
 # PATH -> source drift (info), not "not installed".
-printf '%s\n' age chezmoi mise shellcheck tmux yq > "$drift_dir/brew_formulae"
-printf '%s\n' age chezmoi mise shellcheck tmux yq > "$drift_dir/brew_leaves"
+printf '%s\n' age chezmoi mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+  > "$drift_dir/brew_formulae"
+printf '%s\n' age chezmoi mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+  > "$drift_dir/brew_leaves"
 printf '#!/bin/sh\nexit 0\n' > "$drift_fakebin/gh"
 chmod +x "$drift_fakebin/gh"
 run_drift "catalog drift: source mismatch is info when the command is on PATH" \


### PR DESCRIPTION
#96 の PR1(2段階のうち第1段)。zsh 環境再設計のツールを catalog 宣言 + 実機 install。PR2 で dot_zshrc を再構築する。

## 変更(tracked)

- **`.chezmoidata/packages.yaml`**: 12 brew formula を追加。
  - prompt: starship / 移動: zoxide, fzf / 入力補助・補完: zsh-autosuggestions, zsh-syntax-highlighting, zsh-completions, fzf-tab / 裏方: ripgrep(bin: rg), fd / 情報表示: eza, bat / project env 継ぎ目: direnv。
  - zsh-* プラグインは executable 無し → `bin` 無し(brew_formula は `brew list` で presence 検出)。ripgrep のみ `bin: rg`。
- **`scripts/test-policy.sh`**: catalog drift の reality-seed に共有配列 `shell_env_formulae` を導入し、12 ツールを反映。drift-free baseline はクリーンのまま、各 override ケースは引き続き「ちょうど1つの drift」を導入。

## 実機操作(diff 外)

- 12 ツールを `brew install`(goreleaser は #95 の別判断なので**巻き込まない**)。doctor が全て `[ok] installed` を報告。

## スコープ外

- dot_zshrc の再構築・starship.toml・docs/doctor 反映は **PR2**。
- goreleaser(declared-not-installed)/ librsvg(orphan)は **#95**。

## 検証

- `validate-policy --all` / `test-policy`(drift baseline + 全 case)/ `test-install-packages` / `shellcheck -S warning` / `bash -n` すべてパス。
- `brew list` で12ツール install 確認、doctor catalog section が全て `[ok] installed`・新規 undeclared 無し。

相互レビュー(Claude 著 → Codex)。