### PR TITLE
starship に public-safe な git-identity context を追加(#96 PR3)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -116,3 +116,6 @@ jobs:
 
       - name: git-signing gating tests
         run: ./scripts/test-git-signing.sh
+
+      - name: starship prompt config tests
+        run: ./scripts/test-starship.sh

--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -27,6 +27,14 @@ identity file の中身は最小限にする。
 	email = example@example.invalid
 ```
 
+## プロンプト表示(starship、Issue #96)
+
+どの identity で commit するかを取り違えないよう、starship プロンプトが現在の context を常時表示する
+([docs/shell.md](shell.md))。**personal=緑 / その他の解決済み identity=黄(email 表示)/ repo 内で
+identity 未解決(`useConfigOnly` の fail-closed)=赤**。分類は runtime に「解決された committer email」と
+**local の `~/.config/git/personal.gitconfig`** を照合して行い、managed な `starship.toml` には identity 値を
+一切持たない(public-safe。`scripts/test-starship.sh` が回帰固定)。
+
 ## Remote URL による二次判定(hasconfig、Issue #52)
 
 identity の判定は「置き場所(gitdir)」が一次。加えて、**personal だけ** remote URL でも判定する

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -13,7 +13,7 @@
 
 すべて catalog 宣言 + brew install 済みで、`~/.zshrc` が guard 付きで読み込む:
 
-- **プロンプト**: starship(`~/.config/starship.toml`)。2行・git 状態・実行時間・exit code・関連 project でのみ runtime version を表示(mise が選ぶ version を反映)。
+- **プロンプト**: starship(`~/.config/starship.toml`)。2行・git 状態・実行時間・exit code・関連 project でのみ runtime version を表示(mise 連動)・**git identity context**(personal=緑 / その他=黄+email / repo 内で identity 未解決=赤)で誤コミットを視覚的に防ぐ。identity の分類は runtime に local の `~/.config/git/personal.gitconfig` と照合し、managed file に identity 値を入れない([docs/git-identity.md](git-identity.md))。
 - **移動**: zoxide(`z` / `zi`)+ fzf(`Ctrl-R` 履歴 / `Ctrl-T` ファイル / `Alt-C` サブディレクトリ cd)。
 - **補完**: zsh-completions を fpath に足し、compinit はキャッシュ(dump が無い/24h 超で再生成、通常は `-C` の高速パス)。fzf-tab で TAB 補完を fzf 化。
 - **入力補助**: zsh-autosuggestions(履歴ベース)+ zsh-syntax-highlighting。**syntax-highlighting は必ず最後に source**(直前までに定義した全 widget を wrap するため)。
@@ -69,6 +69,5 @@ managed 化自体を戻す場合は `chezmoi forget ~/.zshenv ~/.zshrc ~/.zprofi
 ## 対象外
 
 - プラグインマネージャ / oh-my-zsh(explicit-first 方針で不使用)。ツールの install は catalog + `install-packages.sh` の領分。
-- starship の git-identity context segment(#96 PR3 で別途。identity 値を managed file に入れない public-safe 実装)。
 - machine 固有値・secret の repo への持ち込み。
 - この module 単体での実 home への apply。

--- a/private_dot_config/starship.toml
+++ b/private_dot_config/starship.toml
@@ -70,4 +70,3 @@ when = '''
 command = "echo '⚠ no-identity'"
 format = "[$output]($style) "
 style = "bold red"
-

--- a/private_dot_config/starship.toml
+++ b/private_dot_config/starship.toml
@@ -11,6 +11,7 @@ add_newline = true
 format = """
 $directory\
 $git_branch$git_status$git_state\
+${custom.git_ctx_personal}${custom.git_ctx_other}${custom.git_ctx_none}\
 $nodejs$python$golang$rust\
 $cmd_duration$status
 $character"""
@@ -30,3 +31,43 @@ disabled = false
 [character]
 success_symbol = "[❯](green)"
 error_symbol = "[❯](red)"
+
+# Git identity context (#96): surface which identity will author commits, so a
+# wrong-context commit is caught before it happens. Public-safe: NO identity
+# values live here. Each `when` reads the resolved committer email and the LOCAL
+# ~/.config/git/personal.gitconfig (not managed) at runtime to classify the
+# context — personal -> green; any other resolved identity -> yellow (shows the
+# email); inside a repo with no identity (the useConfigOnly fail-closed case)
+# -> red. See docs/git-identity.md.
+[custom.git_ctx_personal]
+description = "git identity resolves to personal"
+when = '''
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 1
+  e=$(git config user.email 2>/dev/null)
+  [ -n "$e" ] && [ "$e" = "$(git config --file "$HOME/.config/git/personal.gitconfig" user.email 2>/dev/null)" ]
+'''
+command = "echo personal"
+format = "[$output]($style) "
+style = "bold green"
+
+[custom.git_ctx_other]
+description = "git identity is set but not personal"
+when = '''
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 1
+  e=$(git config user.email 2>/dev/null)
+  [ -n "$e" ] && [ "$e" != "$(git config --file "$HOME/.config/git/personal.gitconfig" user.email 2>/dev/null)" ]
+'''
+command = "git config user.email 2>/dev/null"
+format = "[$output]($style) "
+style = "bold yellow"
+
+[custom.git_ctx_none]
+description = "inside a repo but no git identity resolved (fail-closed)"
+when = '''
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 1
+  [ -z "$(git config user.email 2>/dev/null)" ]
+'''
+command = "echo '⚠ no-identity'"
+format = "[$output]($style) "
+style = "bold red"
+

--- a/scripts/test-starship.sh
+++ b/scripts/test-starship.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+STARSHIP_SRC="$DOTFILES_ROOT/private_dot_config/starship.toml"
+
+status=0
+
+check_contains() {
+  local name="$1" needle="$2"
+  if grep -Fq "$needle" "$STARSHIP_SRC"; then
+    ok "test passed: $name"
+  else
+    fail "test failed: $name (missing: $needle)"
+    status=1
+  fi
+}
+
+section "static checks: starship.toml"
+
+if [[ ! -f "$STARSHIP_SRC" ]]; then
+  fail "missing source: $STARSHIP_SRC"
+  exit 1
+fi
+
+# Public-safety: the managed prompt config must carry NO identity values. The
+# git-identity segment classifies the context by reading the LOCAL
+# personal.gitconfig at runtime, never by hard-coding name/email here
+# (docs/git-identity.md). Mirrors the dot_gitconfig guards.
+if grep -Eq '^[[:space:]]*(name|email)[[:space:]]*=' "$STARSHIP_SRC"; then
+  fail "test failed: starship.toml contains a name/email identity assignment"
+  status=1
+else
+  ok "test passed: no identity assignment in starship.toml"
+fi
+
+# An '@' would indicate a leaked email value (the file legitimately needs none).
+if grep -Fq '@' "$STARSHIP_SRC"; then
+  fail "test failed: starship.toml contains an '@' (possible email value)"
+  status=1
+else
+  ok "test passed: no email-like value in starship.toml"
+fi
+
+# The identity segment must classify by reading the local personal.gitconfig
+# (a runtime, value-free comparison), and define all three context modules.
+check_contains "classifies via local personal.gitconfig" '.config/git/personal.gitconfig'
+for module in git_ctx_personal git_ctx_other git_ctx_none; do
+  check_contains "defines custom.$module" "[custom.$module]"
+done
+
+# Parse the TOML so a malformed prompt config fails here, not on first shell.
+# Guarded on python3 (present in CI); skipped otherwise.
+if command -v python3 >/dev/null 2>&1; then
+  if python3 - "$STARSHIP_SRC" <<'PY'
+import sys
+try:
+    import tomllib
+except ModuleNotFoundError:
+    sys.exit(0)  # older python without tomllib: skip, not fail
+with open(sys.argv[1], "rb") as f:
+    tomllib.load(f)
+PY
+  then
+    ok "test passed: starship.toml is valid TOML"
+  else
+    fail "test failed: starship.toml is not valid TOML"
+    status=1
+  fi
+else
+  warn "python3 not found; skipping TOML parse check"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "starship tests passed"
+fi
+exit "$status"


### PR DESCRIPTION
#96 の PR3(最終)。プロンプトに「今どの identity で commit するか」を常時表示し、誤コミットを視覚的に防ぐ。

## 変更
- **`private_dot_config/starship.toml`**: 3 つの custom module を追加。
  - `git_ctx_personal`(緑「personal」)/ `git_ctx_other`(黄、email 表示)/ `git_ctx_none`(赤「⚠ no-identity」= repo 内で identity 未解決 = useConfigOnly fail-closed)。
  - format の git ブロック直後に配置。
- **`scripts/test-starship.sh`**(新規、validate.yml に wiring): public-safety guard(starship.toml に name/email/`@` が無い)+ 3 module 存在 + local personal.gitconfig 参照 + TOML パース。
- **`docs/shell.md` / `docs/git-identity.md`**: identity segment を記載。

## public-safety(設計の肝)
**starship.toml に identity 値を一切持たない。** 各 `when` が runtime に「解決された committer email」と **local の `~/.config/git/personal.gitconfig`**(managed 外)を照合して分類する。managed file が参照するのは file path のみで email 値は持たない → repo の「identity 値は local のみ」原則(#19/git-identity)と一致。ヘルパースクリプトも新規 managed file も不要なので `.config` の gate は不変。

## 検証
- `~/src/personal` の repo で prompt が **personal**(緑)、committer email が異なる repo(例: ~/dotfiles の noreply)では **その email**(黄)を表示。
- `test-starship`(public-safety + TOML)/ `test-render` / `shellcheck -S warning` / `bash -n` すべてパス。
- 実機 apply 済み。

相互レビュー(Claude 著 → Codex)。**観点**: public-safety(identity 値が managed に漏れない)、`when`/`command` の sh 互換性と分類ロジックの正当性(personal.gitconfig 不在時の挙動、repo 外で非表示、no-identity 検出)、starship format の妥当性、test の網羅、最小差分。