### PR TITLE
shell: fzf-tab プレビュー + cd 時の自動一覧(#104, #96 follow-up)

### DIFF
--- a/docs/shell.md
+++ b/docs/shell.md
@@ -40,7 +40,7 @@
 - `z <キーワード>` … frecency で過去によく行った dir にジャンプ(zoxide)。`z foo bar` で複数キーワード絞り込み。`zi` で fzf 選択。
 - `Ctrl-T` … ファイル / dir を fzf 選択してカーソル位置に挿入。`Alt-C` … サブ dir へ fzf で cd。
   - iTerm2 で `Alt-C` が無反応なら Profiles → Keys で Option キーを「Esc+」に設定する。
-- **cd で移動するたびに、そのディレクトリの内容を自動一覧**(eza、chpwd フック)。`z` / `Ctrl-T` / `Alt-C` 経由の移動でも出る。`add-zsh-hook` 使用なので `~/.zshrc.local` で別の chpwd フックを足しても共存する。
+- **cd で移動するたびに、そのディレクトリの内容を自動一覧**(eza、chpwd フック)。`z` / `Alt-C` / 通常の `cd` など実際にディレクトリを移動する操作で出る(`Ctrl-T` は path をカーソルに挿入するだけで移動しないため出ない)。`add-zsh-hook` 使用なので `~/.zshrc.local` で別の chpwd フックを足しても共存する。
 
 ### 履歴
 

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -40,6 +40,7 @@
 - `z <キーワード>` … frecency で過去によく行った dir にジャンプ(zoxide)。`z foo bar` で複数キーワード絞り込み。`zi` で fzf 選択。
 - `Ctrl-T` … ファイル / dir を fzf 選択してカーソル位置に挿入。`Alt-C` … サブ dir へ fzf で cd。
   - iTerm2 で `Alt-C` が無反応なら Profiles → Keys で Option キーを「Esc+」に設定する。
+- **cd で移動するたびに、そのディレクトリの内容を自動一覧**(eza、chpwd フック)。`z` / `Ctrl-T` / `Alt-C` 経由の移動でも出る。`add-zsh-hook` 使用なので `~/.zshrc.local` で別の chpwd フックを足しても共存する。
 
 ### 履歴
 
@@ -51,7 +52,7 @@
 
 - `TAB` … 候補が複数あると fzf ピッカーで選択(fzf-tab)。例:`git checkout <TAB>` / `cd <TAB>` / `kill <TAB>`。矢印 / `Ctrl-J`・`Ctrl-K` で移動、Enter で確定。
 - `**<TAB>` … 任意コマンド引数を fzf 補完(例:`ssh **<TAB>`、`vim ~/src/**<TAB>`)。
-- 補完候補の**中身プレビュー**(dir 中身・ファイル内容)は既定では出ない。要れば fzf-tab の `fzf-preview` zstyle を `~/.zshrc.local` に追加する(例:`zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza --tree --level=1 --color=always $realpath'`)。
+- 補完候補の**中身プレビュー**:ピッカーで候補を選んでいる間、ディレクトリなら中身(eza --tree)、ファイルなら内容(bat)を表示(fzf-tab の `fzf-preview` zstyle で設定済み)。path を持たない補完(git ブランチ等)ではプレビューは空。
 
 ### 検索・一覧・閲覧
 

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -45,6 +45,16 @@ fi
 # and before the widget-wrapping plugins (autosuggestions / syntax-highlighting).
 [ -r "$HOMEBREW_PREFIX/share/fzf-tab/fzf-tab.zsh" ] && \
   source "$HOMEBREW_PREFIX/share/fzf-tab/fzf-tab.zsh"
+# fzf-tab previews: while choosing in the picker, show directory contents (eza)
+# for a dir candidate and file contents (bat) for a file. Non-path completions
+# set no $realpath, so the preview is simply empty. eza/bat are guarded by the
+# 2>/dev/null fallthrough, so this is a no-op when they are absent.
+zstyle ':fzf-tab:complete:*:*' fzf-preview '
+  if [ -d "$realpath" ]; then
+    eza --tree --level=1 --color=always --icons=auto -- "$realpath" 2>/dev/null
+  elif [ -f "$realpath" ]; then
+    bat --color=always --style=plain --line-range=:100 -- "$realpath" 2>/dev/null
+  fi'
 
 # fzf: Ctrl-R (history), Ctrl-T (files), Alt-C (cd into a subdir) + completion.
 command -v fzf >/dev/null 2>&1 && eval "$(fzf --zsh)"
@@ -72,6 +82,14 @@ if command -v eza >/dev/null 2>&1; then
   alias lt='eza --tree --level=2 --icons=auto'
 fi
 command -v bat >/dev/null 2>&1 && alias cat='bat --paging=never'
+
+# Auto-list the directory after every cd (eza). add-zsh-hook preserves any other
+# chpwd hooks (e.g. one defined in ~/.zshrc.local).
+if command -v eza >/dev/null 2>&1; then
+  autoload -Uz add-zsh-hook
+  _eza_chpwd() { eza --group-directories-first --icons=auto }
+  add-zsh-hook chpwd _eza_chpwd
+fi
 
 # Local overrides win: machine-specific PATH, tool env, secrets, keybindings.
 # Sourced before the widget-wrapping plugins so any local keybindings are wrapped.


### PR DESCRIPTION
Closes #104

#96 の対話シェルに2つの体験向上(managed `dot_zshrc`)。

## 変更
- **fzf-tab プレビュー**: 補完ピッカーで候補がディレクトリなら中身(eza --tree)、ファイルなら内容(bat)を表示。`zstyle ':fzf-tab:complete:*:*' fzf-preview` 1本で dir/file を `$realpath` で分岐。path 無し補完では空、eza/bat 不在では `2>/dev/null` で no-op。
- **cd 自動一覧**: eza の chpwd フックで移動時にディレクトリ内容を一覧(`z` / `Ctrl-T` / `Alt-C` 経由も)。`add-zsh-hook` 使用で `~/.zshrc.local` の chpwd フックと共存。
- **docs/shell.md** を実態に追従(プレビューは設定済みに変更、cd 自動一覧を移動セクションに追記)。

## 検証
- `zsh -n dot_zshrc` OK、`chezmoi apply` 後 smoke で chpwd フック登録(`_eza_chpwd`)と fzf-tab preview zstyle 設定を確認。
- `test-render` / `git diff --check`(whitespace)パス。

相互レビュー(Claude 著 → Codex)。**観点**: zstyle/`$realpath` の扱い、chpwd フックが既存を壊さない(add-zsh-hook)、guard(eza/bat/fzf-tab 不在で no-op)、icons=auto の非 tty 挙動、docs 一致、最小差分。