### PR TITLE
supply-chain/npm: claude-update helper で claude-code のネイティブバイナリを配置(#110)

### DIFF
--- a/docs/supply-chain-npm.md
+++ b/docs/supply-chain-npm.md
@@ -63,6 +63,33 @@ npm install --ignore-scripts=false
 
 project の `.npmrc` に `ignore-scripts=false` を置く方法もあるが、その project の依存全体に効くため、理由を project 側に書き残すこと。
 
+### Claude Code(ネイティブバイナリを postinstall で配置する例)
+
+Anthropic 公式 CLI `@anthropic-ai/claude-code` 2.x は、~226MB のネイティブバイナリを optional dependency(`@anthropic-ai/claude-code-<platform>`)として配布し、`postinstall`(`install.cjs`)でそれを package の bin にハードリンク配置する。`ignore-scripts=true` だと postinstall が走らずバイナリが配置されず(optional dep 自体は取得されている)、`claude` 実行時に次で落ちる:
+
+```text
+Error: claude native binary not installed.
+```
+
+`ignore-scripts` は all-or-nothing で npm に package 単位の許可機能が無いため、信頼できる first-party の `claude-code` についてのみ、**グローバルの `ignore-scripts=true` は維持したまま、監査済みの installer 1 本だけを path 指定で明示実行**する(hardening を全体で緩めない、という enforce の方針と最も整合する逃げ道)。
+
+```sh
+# 通常 install(optional dep を取得)→ 既知の installer だけを明示実行
+npm i -g @anthropic-ai/claude-code --include=optional
+node "$(npm root -g)/@anthropic-ai/claude-code/install.cjs"
+```
+
+この 2 手は `dot_zshrc` の `claude-update` 関数にまとめてある(更新時はこれを実行する)。
+
+検証:
+
+```sh
+claude --version                                       # → 2.x (Claude Code)
+ls -la "$(npm root -g)/@anthropic-ai/claude-code/bin/" # 本体が ~226MB(スタブでない)
+```
+
+`min-release-age=7` により最新ではなく公開 7 日以上経った版が入るのは仕様(下記「`min-release-age` の注意」)。
+
 ## `min-release-age` の注意
 
 - 単位は日数。pnpm の `minimumReleaseAge`(分単位)と混同しないこと。

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -164,6 +164,29 @@ _ai_clip_accept_line() {
 zle -N ai-clip-accept-line _ai_clip_accept_line
 bindkey '^O' ai-clip-accept-line
 
+# Update Claude Code despite the hardened ~/.npmrc (ignore-scripts=true). Claude
+# Code ships its ~226MB native binary as an optional dependency and places it via
+# a postinstall (install.cjs) that hardlinks it into the package bin; with
+# install scripts disabled the binary is never placed and `claude` fails with
+# "native binary not installed". ignore-scripts is all-or-nothing, so instead of
+# relaxing it globally we keep it on and, after a normal install, run ONLY this
+# one audited first-party installer by path. --include=optional guarantees the
+# platform package is present for install.cjs to link. See docs/supply-chain-npm.md.
+claude-update() {
+  command -v npm  >/dev/null 2>&1 || { print -u2 -- "claude-update: npm not found";  return 1; }
+  command -v node >/dev/null 2>&1 || { print -u2 -- "claude-update: node not found"; return 1; }
+  npm i -g @anthropic-ai/claude-code --include=optional || return
+  local root installer
+  root="$(npm root -g)" || return
+  installer="$root/@anthropic-ai/claude-code/install.cjs"
+  if [[ ! -f "$installer" ]]; then
+    print -u2 -- "claude-update: installer not found at $installer (package layout changed?)"
+    return 1
+  fi
+  node "$installer" || return
+  command -v claude >/dev/null 2>&1 && claude --version
+}
+
 # Local overrides win: machine-specific PATH, tool env, secrets, keybindings.
 # Sourced before the widget-wrapping plugins so any local keybindings are wrapped.
 [ -r "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"


### PR DESCRIPTION
Closes #110.

## 何を / なぜ

`~/.npmrc`(`npmHardeningMode=enforce`)の `ignore-scripts=true` が claude-code の `postinstall`(`install.cjs`)を止め、~226MB のネイティブバイナリ(optional dep の platform package)が配置されず `claude` が `native binary not installed` で落ちる。`ignore-scripts` は all-or-nothing なので、**グローバルには維持したまま、監査済み installer 1 本だけを path 指定で明示実行**する Option B を採用。

## 変更

- **`dot_zshrc`**: `claude-update` 関数を追加。`npm i -g @anthropic-ai/claude-code --include=optional` → `node "$(npm root -g)/.../install.cjs"`。npm/node 不在・installer 不在を guard。配置は `_ai_clip_*`(#106)と同じ「local override の前」。
- **`docs/supply-chain-npm.md`**: 「`ignore-scripts=true` の逃げ道」配下に Claude Code の節を追加(原因・Option B・helper・検証手順)。

bin-on-PATH の規約が無く、ユーザー向けヘルパは zsh 関数が既存パターンのため、`bin/claude-update` ではなく関数で実装。

## 検証

- `zsh -n dot_zshrc` OK / 関数定義 OK(抽出して `type` 確認)。
- `git diff --check` clean、`test-render.sh`(managed set 不変)・`test-npmrc.sh` PASS。
- グローバル `ignore-scripts=true` は不変(hardening を緩めていない)。
- 受け入れ条件の end-to-end(`claude-update` → `claude --version` 2.x / bin が ~226MB)は、実 install を ~226MB 取得し min-release-age で版が変わる副作用があるため未実行。inner コマンドは報告者が実機で復旧確認済みのもの。

## レビュー

author=Claude → reviewer=Codex(相互レビュー)。
