### PR TITLE
fix: interactive shell で native claude を優先(~/.local/bin 再前置)(#114)

### DIFF
--- a/docs/shell.md
+++ b/docs/shell.md
@@ -86,7 +86,7 @@
 
 `~/.zshenv` は **すべての zsh 起動**(対話/非対話・login/非login)で読まれる。ここに mise の shims(`$HOME/.local/share/mise/shims`)を PATH 前置し、子プロセスが spawn する非対話 shell でも mise 管理 runtime(`node` 等)が解決するようにする。`~/.zshrc` の `mise activate` は対話 shell でしか走らないため、非対話側は shims が拾う(両者は併用、削除不要)。詳細は [docs/runtime.md](runtime.md)。
 
-あわせて `$HOME/.local/bin` も PATH 前置する(shims より前)。native installer で入れた自己更新型 CLI がここに入るため。代表例が native `claude`(Claude Code。npm-global ではなく `claude.ai/install.sh` で導入)で、stray な npm/Homebrew copy より優先される。経緯は [docs/supply-chain-npm.md](supply-chain-npm.md)。
+あわせて `$HOME/.local/bin` も PATH 前置する。native installer で入れた自己更新型 CLI がここに入るため。代表例が native `claude`(Claude Code。npm-global ではなく `claude.ai/install.sh` で導入)で、stray な npm/Homebrew copy より優先される。経緯は [docs/supply-chain-npm.md](supply-chain-npm.md)。ただし `.zshenv` の前置は**非対話 shell 用**で、対話 shell では後から `brew shellenv`(`~/.zprofile`)と `mise activate`(`~/.zshrc`)が PATH を前置して埋もれるため、`~/.zshrc` が `mise activate` の後で `~/.local/bin` を**再前置**して native を優先させる(`~/.zshrc.local` の override より前なので local PATH は引き続き勝つ)。
 
 - **最小限に保つ**: 全 zsh 起動で走るので、`.zshenv` には PATH 以外の重い処理・副作用を入れない。
 - **local override は無し**: `.zshenv` は `~/.zshenv.local` を source しない(副作用を避けるため)。machine 固有 PATH は `~/.zshrc.local`(対話)に置く。

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -13,6 +13,7 @@ export PATH="$HOME/.local/share/mise/shims:$PATH"
 
 # User-local bin for native-installed CLIs that self-update outside any package
 # manager — notably the native `claude` from claude.ai/install.sh (NOT the npm
-# package; see docs/supply-chain-npm.md). Put it ahead of package-manager bins so
-# the native binary wins over any stray npm/Homebrew copy. No-op when empty.
+# package; see docs/supply-chain-npm.md). Prepended here so it wins in
+# non-interactive shells; interactive shells re-assert it in ~/.zshrc after
+# `mise activate` / `brew shellenv` (which prepend later). No-op when empty.
 export PATH="$HOME/.local/bin:$PATH"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -72,6 +72,15 @@ command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
 # mise runtime activation (interactive); shims in ~/.zshenv cover non-interactive.
 command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"
 
+# Re-assert ~/.local/bin at the front of PATH. ~/.zshenv prepends it too, but both
+# `brew shellenv` (~/.zprofile) and `mise activate` above prepend AFTER that and
+# bury it, so in interactive shells a stray npm/Homebrew `claude` would otherwise
+# win over the native one in ~/.local/bin. Re-prepending here (before the
+# ~/.zshrc.local override below, so a local PATH still wins) fixes that. mise
+# runtimes are unaffected: nothing in ~/.local/bin shadows node/go/uv.
+# See docs/shell.md and docs/supply-chain-npm.md.
+export PATH="$HOME/.local/bin:$PATH"
+
 # Modern CLI: interactive aliases only (scripts are unaffected; `command ls` /
 # `command cat` still reach the originals). bat runs without a pager to stay
 # cat-like. See docs/shell.md.


### PR DESCRIPTION
Closes #114. #112 / PR #113 のフォローアップ(PATH 順序バグ)。

## 原因
zsh 起動順 `.zshenv` → `.zprofile` → `.zshrc`。`~/.local/bin` を前置する `.zshenv` の**後**に `brew shellenv`(`.zprofile`)と `mise activate`(`.zshrc`)が PATH を前置するため、interactive shell で `~/.local/bin` が後方(実測 pos 18)に埋もれ、`/opt/homebrew/bin` の stray claude(2.1.181)が native(2.1.186)に勝っていた。

## 修正
- `dot_zshrc`: `mise activate` の後に `~/.local/bin` を再前置(interactive 用。`~/.zshrc.local` override より前なので local PATH は引き続き勝つ)。`.zshenv` の前置は非対話用に維持。
- `dot_zshenv` / `docs/shell.md`: コメント・記述を実態に同期。

## 検証
- clean login shell で `command -v claude` → `~/.local/bin/claude`、`claude --version` = 2.1.186。
- `node` は引き続き mise 配下に解決(`~/.local/bin` に claude しか無く shadow しない)。
- `zsh -n dot_zshrc dot_zshenv` / `test-render.sh` / `git diff --check` 緑。

author=Claude → reviewer=Codex。重点 = PATH 再前置の順序的正しさ(mise runtime を shadow しないか、local override より前か)、docs 整合。