### PR TITLE
Exclude the Go toolchain's go/gofmt from catalog drift detection (#95)

### DIFF
--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -31,7 +31,7 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 実機との drift は `doctor.sh` の `software catalog` section(`report_catalog_drift`)が **report-only**(常に exit 0、欠けている package manager は skip)で報告する。検出は 3 種:
 
 - **未 install**(宣言済みだが入っていない)→ `warn`。
-- **台帳外**(undeclared / sprawl: 入っているが catalog に無い)→ `warn`。brew は `brew leaves`(top-level のみ。依存は拾わない)、npm は node 同梱の `npm` / `corepack` を除外(runtime の領分、node/go/uv と同じ扱い)、mas は App Store の無関係アプリが大量に誤検知されるため undeclared は出さない(宣言済み mas entry の presence のみ確認)。
+- **台帳外**(undeclared / sprawl: 入っているが catalog に無い)→ `warn`。brew は `brew leaves`(top-level のみ。依存は拾わない)、npm は node 同梱の `npm` / `corepack` を除外(runtime の領分、node/go/uv と同じ扱い)、go は toolchain 同梱の `go` / `gofmt` を除外(GOBIN を `$GOROOT/bin` に向ける mise 等では toolchain 本体が scan dir に同居するため。catalog で宣言・削除できる go_install package ではない)、mas は App Store の無関係アプリが大量に誤検知されるため undeclared は出さない(宣言済み mas entry の presence のみ確認)。
 - **source ズレ**(宣言 source の inventory には無いが `command` が PATH 上に在る = 別 source で入っている疑い)→ `info`。manager 横断の名前照合(脆い)はやらず、PATH 上の存在という堅い信号だけを使う。
 
 照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -492,6 +492,15 @@ report_catalog_drift() {
   if [[ "$have_go" -eq 1 ]]; then
     while IFS= read -r b; do
       [[ -z "$b" ]] && continue
+      # `go` and `gofmt` are the Go distribution's own binaries, shipped in
+      # $GOROOT/bin. A toolchain manager (mise) sets GOBIN to that same dir,
+      # so they land in the scanned bin dir next to `go install` packages.
+      # They are not catalog-managed go_install sprawl -- they cannot be
+      # declared or removed via the catalog -- so exclude them from undeclared
+      # detection, the same way npm's node-bundled npm/corepack are excluded.
+      case "$b" in
+        go|gofmt) continue ;;
+      esac
       grep -Fxq -- "$b" "$decl_go_bins" || {
         warn "undeclared: $b (go binary not in catalog)"
         drift_count=$((drift_count + 1))

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -548,6 +548,17 @@ chmod +x "$drift_dir/go/bin/stray-tool"
 run_drift "catalog drift: flags an undeclared go binary" \
   "undeclared: stray-tool (go binary not in catalog)"
 
+# The Go toolchain's own binaries (go, gofmt) sit in the scanned bin dir when
+# the toolchain manager points GOBIN at $GOROOT/bin (mise does). They are not
+# catalog-managed go_install packages, so they must not surface as undeclared
+# sprawl -- the seed already declares goreleaser/tacho, so adding only go/gofmt
+# must leave the catalog drift-free.
+setup_drift
+touch "$drift_dir/go/bin/go" "$drift_dir/go/bin/gofmt"
+chmod +x "$drift_dir/go/bin/go" "$drift_dir/go/bin/gofmt"
+run_drift "catalog drift: go toolchain binaries are not undeclared sprawl" \
+  "no catalog drift"
+
 setup_drift
 rm -f "$drift_fakebin/brew"
 run_drift "catalog drift: skips a missing package manager (report-only)" \


### PR DESCRIPTION
## 背景 / closes #95

#95 は catalog drift 解消(goreleaser 未 install / librsvg 孤児)。実施中に doctor の catalog drift が完全には消えない **既存 false-positive** を発見したため、本 PR でそれを修正して完了条件「no catalog drift」を満たす。

### 実機側の reconcile(本 PR 外・適用済み)
- **goreleaser**: `install-packages.sh --apply` で install(catalog 宣言は元から有り、機械状態の追従のみ)。
- **librsvg**: 被依存ゼロ(`brew uses --installed` 空)の孤児 → `brew uninstall`。除去で孤児化した `icu4c@78` / `xz` を `brew autoremove` で掃除。

### 本 PR の修正(コード)
doctor の undeclared-go-binary チェックは `GOBIN`(無ければ `GOPATH/bin`)配下の実行ファイルを catalog と突き合わせる。**mise は `GOBIN` を `$GOROOT/bin` に向ける**ため、toolchain 本体の `go` / `gofmt` が `go install` package(goreleaser/tacho)と同じ dir に同居し、`undeclared: go` / `undeclared: gofmt` と誤報告されていた。これらは catalog で宣言も削除もできない(toolchain は mise の領分)。

- `scripts/lib-policy.sh`: undeclared go-bin ループで `go` / `gofmt` を除外(npm の node 同梱 `npm` / `corepack` 除外と同型)。positive な go_install 判定や他 manager は不変・最小差分。
- `scripts/test-policy.sh`: 「go/gofmt は undeclared sprawl にしない」回帰テストを追加(既存の stray-tool は引き続き flag されることも担保)。
- `docs/policy-model.md`: undeclared 除外の規約に go toolchain を追記(npm/corepack の隣に並置)。

## 検証
- `shellcheck -S warning scripts/*.sh`(CI と同条件)= クリーン。残る SC2016 は info レベルで本 PR 前から存在(line 508、未変更行)・CI severity 対象外。
- `./scripts/test-policy.sh` = 全通過(exit 0)。新規 `catalog drift: go toolchain binaries are not undeclared sprawl` / 既存 `flags an undeclared go binary` 双方 pass。
- `./scripts/doctor.sh` = `[ok] installed: goreleaser (go_install)` / **`[ok] no catalog drift`**。

## レビュー
author = Claude(commit trailer の `Co-Authored-By: Claude ...`)。相互レビュー契約により reviewer = Codex。