### PR TITLE
Absorb Claude's public-safe global prefs into managed settings.json (#93)

### DIFF
--- a/docs/claude-settings.md
+++ b/docs/claude-settings.md
@@ -13,7 +13,7 @@ tool-specific config template(agent-tools 側の責務)とは別物
 
 | 対象 | 置き場所 | 管理 |
 | --- | --- | --- |
-| personal・public-safe な `settings.json`(model / effort / public plugin / 通知 / statusLine) | public repo(`dot_claude/settings.json.tmpl`) | ✅ chezmoi(**personal profile のみ**) |
+| personal・public-safe な `settings.json`(model / effort / public plugin / 通知 / statusLine / tui / workflow 警告抑止 等の global preference) | public repo(`dot_claude/settings.json.tmpl`) | ✅ chezmoi(**personal profile のみ**) |
 | personal・機密(secret を含む設定など) | `~/.claude/settings.local.json` | ❌ 非コミット・管理外 |
 | work / client の settings | 暗号化バックアップ(#60)か各マシン手設定 | ❌ public repo に生値を置かない |
 | skill / instruction(`skills/`、`agent-tools/CLAUDE.md`) | agent-tools が配布 | ❌ 別 repo の責務 |
@@ -39,9 +39,24 @@ work / client は別系統(上表)。
 Claude Code は `settings.json`(共有)と `settings.local.json`(ローカル)の 2 ファイルを
 持つ。dotfiles は **前者だけ**を管理し、後者は常に管理外(`.chezmoiignore` で明示)。
 
-Claude が動的に足す permission は `settings.local.json` に書かれるため `settings.json` は
-安定し、chezmoi の「source が正」モデルと衝突しない。例外は plugin 有効化などで稀に
-`settings.json` 自体が書き換わるケースで、その際は手で再 `chezmoi add` する。
+Claude Code は書き先を 2 つに分ける: **動的に承認した permission** は
+`settings.local.json`(machine / context 固有・絶対 path を含むので非 public-safe)へ、
+**global な preference**(`effortLevel` / `tui` / `skipWorkflowUsageWarning` / 通知 /
+`remoteControlAtStartup` / plugin 有効化など)は **`settings.json` 本体**へ書く。
+前者は管理外なので衝突しないが、後者は managed な `settings.json` を Claude が
+書き換えるため、template に無いキーは `chezmoi apply` で消える(drift)。
+
+**方針(issue #93, 案 a「取り込む」)**: Claude が `settings.json` に書く **安定・public-safe な
+global preference は managed template に取り込む**。こうすると `chezmoi apply` がその
+キーに対して no-op になり、live が drift しない & 新マシン bootstrap の baseline も忠実に
+なる。permission 承認は引き続き `settings.local.json`(管理外)に任せる。`settings.json` と
+`settings.local.json` の責務境界はこれで固定する。
+
+この境界は **完全な drift ゼロを保証しない**(構造上の限界)。Claude が将来 *新しい* global
+preference キーを `settings.json` に書くと、template に取り込むまでの間は一時的に
+`chezmoi status` が `M` を出す。これは想定内で、対処は「その安定 public-safe キーを
+template に追記して再 apply する(= 取り込みの継続運用)」。`settings.local.json` 行きの
+permission 承認は対象外。
 
 ## gate の仕組み
 

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -36,5 +36,7 @@
   },
   "effortLevel": "xhigh",
   "agentPushNotifEnabled": true,
-  "remoteControlAtStartup": true
+  "remoteControlAtStartup": true,
+  "skipWorkflowUsageWarning": true,
+  "tui": "fullscreen"
 }

--- a/scripts/test-claude-settings.sh
+++ b/scripts/test-claude-settings.sh
@@ -97,6 +97,22 @@ else
   fi
 fi
 
+section "claude settings managed global prefs"
+
+# 3) issue #93, option (a): stable, public-safe global preferences that Claude
+#    Code persists to settings.json (NOT settings.local.json) are absorbed into
+#    the managed template, so `chezmoi apply` is a no-op for them and the live
+#    file does not drift. off_file is the committed-default personal render from
+#    section 1; lock the two currently-absorbed keys there.
+skip_warn="$(yq -p json '.skipWorkflowUsageWarning // "absent"' "$off_file")"
+tui_mode="$(yq -p json '.tui // "absent"' "$off_file")"
+if [[ "$skip_warn" == "true" && "$tui_mode" == "fullscreen" ]]; then
+  ok "test passed: managed template carries skipWorkflowUsageWarning=true and tui=fullscreen"
+else
+  fail "test failed: managed global prefs missing (skipWorkflowUsageWarning=$skip_warn tui=$tui_mode)"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "claude settings tests passed"
 fi


### PR DESCRIPTION
## 背景 / closes #93

`chezmoi status` で `.claude/settings.json` が恒常的に `M`。原因は **Claude Code が書き先を 2 つに分ける**こと: permission 承認は `settings.local.json`(管理外)へ、global preference(`tui` / `skipWorkflowUsageWarning` 等)は **`settings.json` 本体**へ書く。後者のキーが managed template に無く、`chezmoi apply` で消える(workflow 使用警告が復活する等)。

## 方針(issue #93 案 a「取り込む」・ユーザー承認済み)
Claude が `settings.json` に書く **安定・public-safe な global preference を managed template に取り込む**。apply がそのキーに no-op になり drift せず、新マシン bootstrap baseline も忠実になる。permission 承認は引き続き `settings.local.json`(管理外)。これで settings.json / settings.local.json の責務境界を固定。

論点 (b)「動的キーを local へ寄せる」は Claude の書き込み先(global pref は settings.json)と戦い drift が再発するため不採用。(c)「drift 許容」は `chezmoi status` の `M` が恒常化し alert fatigue のため不採用。

## 変更
- `dot_claude/settings.json.tmpl`: 現在 drift している public-safe global pref `skipWorkflowUsageWarning: true` / `tui: "fullscreen"` を追加。
- `docs/claude-settings.md`: 2 層の責務境界を実態(global pref は settings.json 本体に書かれる)に更新 + 取り込み方針 + 「新キーは取り込むまで一時 drift する」構造的限界を明記。表の代表キー列も追従。
- `scripts/test-claude-settings.sh`: personal render に 2 キーが含まれることを回帰固定。

## 検証
- `shellcheck -S warning scripts/test-claude-settings.sh` = クリーン。
- `./scripts/test-claude-settings.sh` = 全通過(新規 `managed template carries skipWorkflowUsageWarning=true and tui=fullscreen` 含む)。
- `./scripts/test-render.sh` = 全通過(profile 別 managed set 不変・claude-settings は personal のみ)。
- `chezmoi diff ~/.claude/settings.json` = 取り込み後は **reorder のみ**(2 キーは削除されない)。`chezmoi apply ~/.claude/settings.json` 後 **`chezmoi status` が完全に空**(settings.json drift 解消・live は 2 キー保持を確認)。

## 完了条件(#93)
- [x] settings.json / settings.local.json の責務境界を方針決定(案 a)
- [x] `chezmoi status` の drift 解消(apply 済・status クリア)
- [x] `docs/claude-settings.md` に動的キーの扱いを追記
- [x] `test-claude-settings.sh` が方針を回帰固定

## レビュー
author = Claude(commit trailer)。相互レビュー契約により reviewer = Codex。