### PR TITLE
Fix ssh-1password: Match all so config.local is Include'd globally (#121)

### DIFF
--- a/docs/local-overrides.md
+++ b/docs/local-overrides.md
@@ -27,15 +27,22 @@ managed 側の既定値を上書きできる必要があるため、これを意
 
 ## SSH: managed-wins(末尾 Include)
 
-managed な `~/.ssh/config` は末尾に local file を Include する。
+managed な `~/.ssh/config` は末尾に local file を Include する。ただし `Host`/`Match`
+ブロックの直後に置くとその section に閉じ込められるため、`Match all` で global に戻してから
+Include する。
 
 ```text
+Host github.com
+    IdentityAgent "...op-agent.sock"
+Match all
 Include config.local
 ```
 
 ssh_config は **first-match-wins** のため、末尾 Include は managed 設定が優先される
 **managed-wins** になる。SSH は安全境界(どの host にどの鍵・agent を使うか)であり、
 local file が managed の安全設定を上書きできてはならないため、zsh とは逆の勝ち方を意図とする。
+`Match all` が無いと Include が直前の Host ブロックに閉じ込められ、local の host が
+github.com 接続時しか読まれない(#121)。
 
 local 側は managed が定義していない Host を追加する用途に限る。実装・移行手順は
 [ssh](ssh.md)(`ssh-1password` module、`enable1PasswordSSH` gate)。

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -28,10 +28,25 @@ work-*=false)。`true` のとき managed config に `Host github.com` の `Ident
 
 ## managed-wins(末尾 Include)
 
-managed config は末尾で `Include config.local` する。ssh_config は **first-match-wins** なので、
+managed config は末尾で config.local を Include する。ssh_config は **first-match-wins** なので、
 managed の上のブロックが勝つ = **managed-wins**([local-overrides](local-overrides.md))。
 `config.local` は managed が定義していない host を **追加する**用途に限る(managed の安全設定を
 上書きさせない)。`config.local` が無くても SSH は壊れない(欠落 Include は無視される)。
+
+```text
+Host github.com
+    IdentityAgent "...op-agent.sock"
+
+Match all
+Include config.local
+```
+
+**`Match all` が必須**。ssh_config の section は次の `Host`/`Match` まで続くので、`Include` を
+`Host github.com` ブロックの**直後にそのまま**置くと Include がそのブロックに閉じ込められ、
+config.local は **github.com に接続したときしか読まれない**(他 host が解決されない)。`Match all`
+で global section に戻してから Include すると、config.local は全 host に効きつつ、上の managed
+ブロックが先に評価されて勝つ(#121 で `ssh -G` 検証)。capability OFF で managed ブロックが
+無いときは `Include config.local` 単体で既に global。
 
 ## 既存 `~/.ssh/config` からの移行
 

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -12,6 +12,12 @@
 # offered to hosts we choose. Gated by enable1PasswordSSH.
 Host github.com
     IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
-{{ end -}}
 
+# Reset to a global section before the Include. Without this, the Include would
+# stay inside the Host github.com block above and config.local would only be
+# read when connecting to github.com (ssh_config sections run until the next
+# Host/Match). Match all keeps the Include global while the managed blocks above
+# still win (first-match-wins = managed-wins).
+Match all
+{{ end -}}
 Include config.local

--- a/scripts/test-ssh.sh
+++ b/scripts/test-ssh.sh
@@ -59,8 +59,9 @@ if [[ ! -f "$on_cfg" ]]; then
   status=1
 elif grep -q '^Host github.com$' "$on_cfg" \
   && grep -Fqx '    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"' "$on_cfg" \
+  && grep -q '^Match all$' "$on_cfg" \
   && grep -q '^Include config.local$' "$on_cfg"; then
-  ok "test passed: enable1PasswordSSH=true emits scoped github.com agent + Include config.local"
+  ok "test passed: enable1PasswordSSH=true emits scoped github.com agent + Match all + Include config.local"
 else
   fail "test failed: enable1PasswordSSH=true config missing github.com agent or Include"
   status=1
@@ -114,6 +115,45 @@ if [[ -f "$on_cfg" ]]; then
     status=1
   else
     ok "test passed: managed config carries no Host *, no keys, only the public github.com host"
+  fi
+fi
+
+section "ssh -G resolution (Include is global, managed-wins)"
+
+# 4) Behavioral check with the real ssh parser. A text match alone missed the
+#    bug where `Include config.local` sat inside the Host github.com block and
+#    was only read when connecting to github.com (#121). Point the Include at a
+#    throwaway config.local that defines a host the managed config does NOT, and
+#    assert ssh resolves it (proves the Include is global) and that github.com
+#    still gets the managed agent (proves managed-wins). Relative Include paths
+#    resolve under ~/.ssh, so rewrite to an absolute path for an isolated test.
+if ! command -v ssh >/dev/null 2>&1; then
+  item "ssh not found; skipping ssh -G resolution check"
+elif [[ -f "$on_cfg" ]]; then
+  probe_local="$base/config.local"
+  cat > "$probe_local" <<EOF
+Host probe-vm
+  HostName 10.9.8.7
+  User probeuser
+Host *
+  IdentityAgent /tmp/probe-local.sock
+EOF
+  probe_cfg="$base/probe-config"
+  sed "s#^Include config.local\$#Include $probe_local#" "$on_cfg" > "$probe_cfg"
+
+  # IdentityAgent paths contain a space ("Group Containers"), so capture the
+  # whole value after the keyword rather than a single field.
+  probe_host="$(ssh -G -F "$probe_cfg" probe-vm 2>/dev/null | sed -n 's/^hostname //p')"
+  gh_agent="$(ssh -G -F "$probe_cfg" github.com 2>/dev/null | sed -n 's/^identityagent //p')"
+
+  if [[ "$probe_host" != "10.9.8.7" ]]; then
+    fail "test failed: config.local host not resolved (Include is not global): hostname=$probe_host"
+    status=1
+  elif [[ "$gh_agent" != *"1password/t/agent.sock" ]]; then
+    fail "test failed: github.com did not keep the managed agent (managed-wins broken): identityagent=$gh_agent"
+    status=1
+  else
+    ok "test passed: ssh resolves a config.local-only host (global Include) and github.com keeps the managed agent (managed-wins)"
   fi
 fi
 


### PR DESCRIPTION
## 概要
`Closes #121`。#17(PR #120)の **follow-up バグ修正**。

managed `~/.ssh/config` が `Include config.local` を `Host github.com` ブロックの直後にそのまま置いていたため、ssh_config の section スコープで Include が**そのブロックに閉じ込められ**、config.local(VM 等の machine 固有 host)が **github.com 接続時しか読まれず**、他 host が解決できなかった。`ssh -G` で確認(#120 では text 一致だけ見て挙動未検証=見逃し)。

## 修正
`Include` の前に **`Match all`** を入れて global section に戻す。config.local が全 host に効きつつ、上の managed ブロックが先に評価されて勝つ(first-match-wins = **managed-wins**)。`ssh -G` で実証:
- `github.com` → managed の op socket が勝つ(managed-wins)。
- config.local 限定 host(例 `probe-vm`)→ 解決される(Include が global)。

## 変更
- `private_dot_ssh/config.tmpl`: github.com ブロックがある(capability ON)とき `Match all` を Include の前に出力。OFF 時は先行 Host が無いので bare Include で既に global。
- `scripts/test-ssh.sh`: **`ssh -G` 挙動検証を追加**(config.local 限定 host の解決=global Include / github.com の managed-wins)+ `Match all` の存在 assert。text 一致だけでは捕まえられなかった再発防止。
- `docs/ssh.md` / `docs/local-overrides.md`: 例に `Match all` を明記し、bare な末尾 Include が直前 Host に閉じ込められる旨を説明。

## 検証
- `validate-policy --all` / `test-policy` / `test-render` / `test-doctor` / `test-ssh`(新 `ssh -G` 節含む)全て rc=0。`bash -n` / `shellcheck -S warning scripts/*.sh` / `git diff --check` OK。
- 実機は移行前の動作する config に**復旧済み**。この修正 merge 後に再 apply して VM/github/`chezmoi status` を確認する。

## レビュー
Claude 実装 → 相互レビュー(author ≠ reviewer)で **Codex** がレビュー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)