### PR TITLE
Wire the GitHub injection-guard capabilities (no enforcement yet) (#119 Phase 1 PR1)

### DIFF
--- a/.chezmoidata/capabilities.schema.yaml
+++ b/.chezmoidata/capabilities.schema.yaml
@@ -41,3 +41,7 @@ capabilities:
     type: boolean
   enableAiPolicy:
     type: boolean
+  gateGitHubMcp:
+    type: boolean
+  enableGitHubIsolatedReader:
+    type: boolean

--- a/.chezmoidata/profiles.yaml
+++ b/.chezmoidata/profiles.yaml
@@ -38,6 +38,8 @@ profiles:
       enforceAiSandbox: false
       enableAgentToolsStatus: false
       enableAiPolicy: true
+      gateGitHubMcp: false
+      enableGitHubIsolatedReader: false
 
   work-minimal:
     environmentKind: work
@@ -69,6 +71,8 @@ profiles:
       enforceAiSandbox: false
       enableAgentToolsStatus: false
       enableAiPolicy: true
+      gateGitHubMcp: false
+      enableGitHubIsolatedReader: false
 
   work-dev:
     environmentKind: work
@@ -105,3 +109,5 @@ profiles:
       enforceAiSandbox: false
       enableAgentToolsStatus: false
       enableAiPolicy: true
+      gateGitHubMcp: false
+      enableGitHubIsolatedReader: false

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -383,6 +383,24 @@ else
   ok "Claude Code native sandbox not enforced via managed settings (enforceAiSandbox=false)"
 fi
 
+section "GitHub injection guard (report-only)"
+# gateGitHubMcp / enableGitHubIsolatedReader are safety-hardening capabilities for
+# the GitHub runtime prompt-injection defense (epic #119). Like enforceAiSandbox
+# they are opposite polarity to the install / secret / network capabilities, so
+# they are intentionally absent from environment_kind_forbidden_capabilities (a
+# restrictive kind may set them true). Phase 1 lands the capabilities first; the
+# managed ~/.claude/settings.json gate and the isolated reader are wired in later
+# PRs. AGENTS.md requires a capability to drive a doctor section, so report the
+# declared state honestly as not-yet-enforced rather than as a dead capability.
+# Report-only and contents-blind. See docs/ai-environment-boundary.md.
+for github_guard_cap in gateGitHubMcp enableGitHubIsolatedReader; do
+  if [[ "$(capability_value "$profile" "$github_guard_cap")" == "true" ]]; then
+    warn "$github_guard_cap=true but its enforcement is not wired yet (#119 Phase 1 is incremental); declared, not enforced"
+  else
+    ok "$github_guard_cap not active (false)"
+  fi
+done
+
 section "agent-tools (report-only)"
 # Report-only companion check. dotfiles never clones/pulls/syncs
 # agent-tools. Presence is always reported, but running its status.sh

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -402,6 +402,48 @@ else
   status=1
 fi
 
+# GitHub injection guard report (gateGitHubMcp / enableGitHubIsolatedReader, #119
+# Phase 1). The capabilities land before their enforcement; doctor must report
+# them honestly (declared, not enforced) and stay exit 0 = no dead capability.
+# Throwaway repo copy so the flip does not touch the real data files.
+gh_root="$fixture_home/.dotfiles-ghguard"
+mkdir -p "$gh_root/.chezmoidata"
+cp -R "$DOTFILES_ROOT/scripts" "$gh_root/scripts"
+cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$gh_root/.chezmoidata/"
+
+# P) default (false) -> reported as not active, exit 0.
+if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "gateGitHubMcp not active" <<< "$gh_out"; then
+    ok "test passed: gateGitHubMcp=false reported as not active"
+  else
+    printf '%s\n' "$gh_out" >&2
+    fail "test failed: GitHub guard capability not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$gh_out" >&2
+  fail "test failed: doctor must stay exit 0 (GitHub guard, default)"
+  status=1
+fi
+
+# Q) flipped true -> reported as declared-but-not-enforced (placeholder), exit 0.
+awk '$0 == "      gateGitHubMcp: false" { print "      gateGitHubMcp: true"; next } { print }' \
+  "$gh_root/.chezmoidata/profiles.yaml" > "$gh_root/.chezmoidata/profiles.yaml.tmp"
+mv "$gh_root/.chezmoidata/profiles.yaml.tmp" "$gh_root/.chezmoidata/profiles.yaml"
+if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "not wired yet" <<< "$gh_out"; then
+    ok "test passed: gateGitHubMcp=true reported as declared-not-enforced"
+  else
+    printf '%s\n' "$gh_out" >&2
+    fail "test failed: gateGitHubMcp=true placeholder not reported"
+    status=1
+  fi
+else
+  printf '%s\n' "$gh_out" >&2
+  fail "test failed: doctor must stay exit 0 (GitHub guard, flipped true)"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "doctor tests passed"
 fi

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -411,10 +411,12 @@ mkdir -p "$gh_root/.chezmoidata"
 cp -R "$DOTFILES_ROOT/scripts" "$gh_root/scripts"
 cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$gh_root/.chezmoidata/"
 
-# P) default (false) -> reported as not active, exit 0.
+# P) default (false) -> BOTH capabilities reported as not active, exit 0. Check
+#    both so the section can't silently drop one (the dead-capability guard).
 if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
-  if grep -Fq "gateGitHubMcp not active" <<< "$gh_out"; then
-    ok "test passed: gateGitHubMcp=false reported as not active"
+  if grep -Fq "gateGitHubMcp not active" <<< "$gh_out" \
+    && grep -Fq "enableGitHubIsolatedReader not active" <<< "$gh_out"; then
+    ok "test passed: both GitHub guard capabilities reported as not active"
   else
     printf '%s\n' "$gh_out" >&2
     fail "test failed: GitHub guard capability not reported"

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -376,8 +376,24 @@ run_ok \
   "enforceAiSandbox=true is allowed for every environmentKind (not forbidden)" \
   "$fixture/scripts/validate-policy.sh" --all
 
+# gateGitHubMcp / enableGitHubIsolatedReader (#119 Phase 1) are also
+# safety-hardening capabilities, so they must NOT be in the forbidden table
+# either: a restrictive kind (work) may set them true. Flip both across every
+# profile and assert --all still validates.
 make_fixture
-insert_once "$fixture/.chezmoidata/profiles.yaml" "      enableAiPolicy: true" "    extraSection:"
+awk '$0 == "      gateGitHubMcp: false" { print "      gateGitHubMcp: true"; next }
+     $0 == "      enableGitHubIsolatedReader: false" { print "      enableGitHubIsolatedReader: true"; next }
+     { print }' \
+  "$fixture/.chezmoidata/profiles.yaml" > "$fixture/.chezmoidata/profiles.yaml.tmp"
+mv "$fixture/.chezmoidata/profiles.yaml.tmp" "$fixture/.chezmoidata/profiles.yaml"
+run_ok \
+  "GitHub guard capabilities are allowed for every environmentKind (not forbidden)" \
+  "$fixture/scripts/validate-policy.sh" --all
+
+# Anchor on the LAST capability line so the bogus section lands after the whole
+# capabilities block (update this if a later capability is added below).
+make_fixture
+insert_once "$fixture/.chezmoidata/profiles.yaml" "      enableGitHubIsolatedReader: false" "    extraSection:"
 insert_once "$fixture/.chezmoidata/profiles.yaml" "    extraSection:" "      sneakyKey: true"
 run_ok \
   "ignores sections after capabilities" \


### PR DESCRIPTION
## 概要
epic #119(GitHub runtime prompt-injection 防御)の **Phase 1 / PR1**。capability 2 本を**配線だけ**(実効ゼロ)land する。settings.json gate は PR2、隔離 reader は Phase 3。

- `gateGitHubMcp` / `enableGitHubIsolatedReader`(boolean)を schema に追加、全 3 profile に `false` で宣言。
- **安全強化型**(enforceAiSandbox と同極性)なので `environment_kind_forbidden_capabilities` には**入れない**(制限環境でこそ true にしたい)。
- doctor に report-only の "GitHub injection guard" section。AGENTS.md「宣言だけで何も駆動しない capability を作らない・placeholder は doctor が未実装を report」に従い、**honest に「declared, not enforced」と報告**(false→not active / true→「enforcement not wired yet」warn)。
- test-policy: 2 本が全 environmentKind で許可される(forbidden でない)ことを assert(enforceAiSandbox の polarity テストと同型)。「ignores sections after capabilities」テストのアンカーを新しい最終 cap に更新。
- test-doctor: section が default(not active)と flip(declared, not enforced)を報告し exit 0 を assert。

## 実効ゼロの確認
`settings.json.tmpl` は新 cap を参照しないので **settings.json は byte-identical**。`test-render`(managed set 不変)/ `test-claude-settings`(内容不変)パス。

## 検証
`validate-policy --all` / `test-policy` / `test-doctor` / `test-render` / `test-claude-settings` 全て rc=0。`bash -n` / `shellcheck -S warning scripts/*.sh` / `git diff --check` OK。`doctor personal|work-dev` で section が both false→not active を報告。

## スコープ外(後続 PR)
- PR2: settings.json で MCP gate + write deny/gate matcher + WebFetch domain。
- PR3: token 分離の実態整理 + trust list 規約 + backup-paths + doctor presence。
- PR4: docs。

設計正本は private 設計メモ、public トラッカは #119。

## レビュー
Claude 実装 → 相互レビュー(author ≠ reviewer)で **Codex**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)