### PR TITLE
Gate GitHub MCP and write/secret actions in settings.json (off by default) (#119 Phase 1 PR2)

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -9,9 +9,9 @@
        on enforceAiSandbox (no separate capability, per #119). Every gating
        capability defaults false, so this renders byte-identical until flipped. */ -}}
 {{- $deny := list -}}
-{{- if index $caps "gateGitHubMcp" -}}{{- $deny = concat $deny (list "mcp__github" "mcp__github__*") -}}{{- end -}}
+{{- if index $caps "gateGitHubMcp" -}}{{- $deny = concat $deny (list "mcp__github") -}}{{- end -}}
 {{- $ask := list -}}
-{{- if index $caps "enforceAiSandbox" -}}{{- $deny = concat $deny (list "Bash(printenv)" "Bash(printenv *)" "Bash(env)" "Bash(env *)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(cat *.env*)" "Bash(cat ~/.ssh/*)" "Bash(git push * main)" "Bash(git push * master)") -}}{{- $ask = concat $ask (list "Bash(gh release create *)" "Bash(gh release delete *)" "Bash(gh release edit *)" "Bash(gh api *protection*)" "Bash(gh api *rulesets*)") -}}{{- end -}}
+{{- if index $caps "enforceAiSandbox" -}}{{- $deny = concat $deny (list "Bash(printenv)" "Bash(printenv *)" "Bash(env)" "Bash(env *)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(cat *.env*)" "Bash(cat ~/.ssh/*)" "Read(**/.env*)" "Read(~/.ssh/**)" "Bash(git push * main)" "Bash(git push * master)") -}}{{- $ask = concat $ask (list "Bash(gh release create *)" "Bash(gh release delete *)" "Bash(gh release edit *)" "Bash(gh api *protection*)" "Bash(gh api *rulesets*)") -}}{{- end -}}
 {
 {{- if index $caps "enforceAiSandbox" }}
   "sandbox": {

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -11,7 +11,7 @@
 {{- $deny := list -}}
 {{- if index $caps "gateGitHubMcp" -}}{{- $deny = concat $deny (list "mcp__github") -}}{{- end -}}
 {{- $ask := list -}}
-{{- if index $caps "enforceAiSandbox" -}}{{- $deny = concat $deny (list "Bash(printenv)" "Bash(printenv *)" "Bash(env)" "Bash(env *)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(cat *.env*)" "Bash(cat ~/.ssh/*)" "Read(**/.env*)" "Read(~/.ssh/**)" "Bash(git push * main)" "Bash(git push * master)") -}}{{- $ask = concat $ask (list "Bash(gh release create *)" "Bash(gh release delete *)" "Bash(gh release edit *)" "Bash(gh api *protection*)" "Bash(gh api *rulesets*)") -}}{{- end -}}
+{{- if index $caps "enforceAiSandbox" -}}{{- $deny = concat $deny (list "Bash(printenv)" "Bash(printenv *)" "Bash(env)" "Bash(env *)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(cat *.env*)" "Bash(cat ~/.ssh/*)" "Read(//**/.env*)" "Read(~/.ssh/**)" "Bash(git push * main)" "Bash(git push * master)") -}}{{- $ask = concat $ask (list "Bash(gh release create *)" "Bash(gh release delete *)" "Bash(gh release edit *)" "Bash(gh api *protection*)" "Bash(gh api *rulesets*)") -}}{{- end -}}
 {
 {{- if index $caps "enforceAiSandbox" }}
   "sandbox": {

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -1,4 +1,17 @@
 {{- $caps := index (index .profiles .profile) "capabilities" -}}
+{{- /* GitHub injection guard (epic #119, Phase 1). Best-effort / steering only:
+       command-string matchers are bypassable ($(), equivalent read paths, MCP by
+       other means, subagent gaps) and are NOT an enforcement boundary — see
+       docs/ai-environment-boundary.md. deny = never-OK (hard); ask = always needs
+       approval. The context-gated writes (merge/PR/comment/label/push ai/*) are
+       intentionally absent: gating them on a clean context needs the Phase 2
+       PreToolUse hook. gateGitHubMcp gates the MCP deny; the write deny/ask rides
+       on enforceAiSandbox (no separate capability, per #119). Every gating
+       capability defaults false, so this renders byte-identical until flipped. */ -}}
+{{- $deny := list -}}
+{{- if index $caps "gateGitHubMcp" -}}{{- $deny = concat $deny (list "mcp__github" "mcp__github__*") -}}{{- end -}}
+{{- $ask := list -}}
+{{- if index $caps "enforceAiSandbox" -}}{{- $deny = concat $deny (list "Bash(printenv)" "Bash(printenv *)" "Bash(env)" "Bash(env *)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(cat *.env*)" "Bash(cat ~/.ssh/*)" "Bash(git push * main)" "Bash(git push * master)") -}}{{- $ask = concat $ask (list "Bash(gh release create *)" "Bash(gh release delete *)" "Bash(gh release edit *)" "Bash(gh api *protection*)" "Bash(gh api *rulesets*)") -}}{{- end -}}
 {
 {{- if index $caps "enforceAiSandbox" }}
   "sandbox": {
@@ -11,6 +24,12 @@
   },
 {{- end }}
   "permissions": {
+{{- if $deny }}
+    "deny": {{ $deny | toJson }},
+{{- end }}
+{{- if $ask }}
+    "ask": {{ $ask | toJson }},
+{{- end }}
     "allow": [
       "mcp__pencil"
     ]

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -375,7 +375,7 @@ fi
 # today), so a true value without that module is reported as dangling.
 if [[ "$(capability_value "$profile" enforceAiSandbox)" == "true" ]]; then
   if module_active_for_profile "$profile" claude-settings; then
-    ok "enforceAiSandbox=true; Claude Code native sandbox managed in ~/.claude/settings.json (Bash tool fs+network only)"
+    ok "enforceAiSandbox=true; managed ~/.claude/settings.json carries the native sandbox (Bash fs+network) and the GitHub write deny/ask (secret + main-push deny, release/protection ask; best-effort)"
   else
     warn "enforceAiSandbox=true but the claude-settings module is inactive for this profile; no managed settings carry the sandbox block (dangling capability)"
   fi
@@ -388,18 +388,28 @@ section "GitHub injection guard (report-only)"
 # the GitHub runtime prompt-injection defense (epic #119). Like enforceAiSandbox
 # they are opposite polarity to the install / secret / network capabilities, so
 # they are intentionally absent from environment_kind_forbidden_capabilities (a
-# restrictive kind may set them true). Phase 1 lands the capabilities first; the
-# managed ~/.claude/settings.json gate and the isolated reader are wired in later
-# PRs. AGENTS.md requires a capability to drive a doctor section, so report the
-# declared state honestly as not-yet-enforced rather than as a dead capability.
-# Report-only and contents-blind. See docs/ai-environment-boundary.md.
-for github_guard_cap in gateGitHubMcp enableGitHubIsolatedReader; do
-  if [[ "$(capability_value "$profile" "$github_guard_cap")" == "true" ]]; then
-    warn "$github_guard_cap=true but its enforcement is not wired yet (#119 Phase 1 is incremental); declared, not enforced"
+# restrictive kind may set them true). All matchers are best-effort / steering,
+# NOT an enforcement boundary (see docs/ai-environment-boundary.md). Report-only
+# and contents-blind. AGENTS.md requires each capability to drive a section.
+#
+# gateGitHubMcp is wired (PR2): it denies the github MCP server in the managed
+# ~/.claude/settings.json (when claude-settings is active for the profile).
+if [[ "$(capability_value "$profile" gateGitHubMcp)" == "true" ]]; then
+  if module_active_for_profile "$profile" claude-settings; then
+    ok "gateGitHubMcp=true; managed ~/.claude/settings.json denies the github MCP server (best-effort, not a boundary)"
   else
-    ok "$github_guard_cap not active (false)"
+    warn "gateGitHubMcp=true but the claude-settings module is inactive for this profile; no managed settings carry the MCP deny (dangling capability)"
   fi
-done
+else
+  ok "gateGitHubMcp not active (false)"
+fi
+# enableGitHubIsolatedReader is the isolated reader (Phase 3): the capability is
+# declared but its enforcement is not wired yet.
+if [[ "$(capability_value "$profile" enableGitHubIsolatedReader)" == "true" ]]; then
+  warn "enableGitHubIsolatedReader=true but the isolated reader is not wired yet (#119 Phase 3); declared, not enforced"
+else
+  ok "enableGitHubIsolatedReader not active (false)"
+fi
 
 section "agent-tools (report-only)"
 # Report-only companion check. dotfiles never clones/pulls/syncs

--- a/scripts/test-claude-settings.sh
+++ b/scripts/test-claude-settings.sh
@@ -138,9 +138,11 @@ fi
 #    comment/label/push ai/*) are intentionally NOT here (Phase 2 hook).
 if grep -Fq '"Bash(git push * main)"' "$on_file" \
   && grep -Fq '"Bash(printenv)"' "$on_file" \
+  && grep -Fq '"Read(**/.env*)"' "$on_file" \
+  && grep -Fq '"Read(~/.ssh/**)"' "$on_file" \
   && grep -Fq '"Bash(gh release create *)"' "$on_file" \
   && grep -Fq '"Bash(gh api *protection*)"' "$on_file"; then
-  ok "test passed: enforceAiSandbox=true adds write deny (secret/main-push) + approval ask (release/protection)"
+  ok "test passed: enforceAiSandbox=true adds write deny (secret via Bash+Read, main-push) + approval ask (release/protection)"
 else
   fail "test failed: enforceAiSandbox=true missing expected write deny/ask matchers"
   status=1
@@ -165,10 +167,34 @@ if ! mcp_file="$(render_personal_settings "$mcp_src/src")"; then
   fail "test failed: personal apply (gateGitHubMcp=true) did not render"
   exit 1
 fi
-if grep -Fq '"mcp__github"' "$mcp_file" && grep -Fq '"mcp__github__*"' "$mcp_file"; then
-  ok "test passed: gateGitHubMcp=true denies the github MCP server"
+# Valid JSON (comma regression guard for the conditional deny block) + the bare
+# server-name deny (mcp__github covers all tools; mcp__github__* is redundant).
+if yq -p json '.' "$mcp_file" >/dev/null 2>&1 \
+  && grep -Fq '"mcp__github"' "$mcp_file"; then
+  ok "test passed: gateGitHubMcp=true denies the github MCP server (valid JSON)"
 else
-  fail "test failed: gateGitHubMcp=true did not deny the github MCP server"
+  fail "test failed: gateGitHubMcp=true did not deny the github MCP server (or invalid JSON)"
+  status=1
+fi
+
+# 6b) Both gates on: the deny/ask blocks plus sandbox must still be valid JSON
+#     (catches a comma regression when several conditional keys are present).
+both_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings-both.XXXXXX")"
+tmp_roots+=("$both_src")
+cp -R "$DOTFILES_ROOT" "$both_src/src"
+rm -rf "$both_src/src/.git"
+yq -i '.profiles.personal.capabilities.gateGitHubMcp = true | .profiles.personal.capabilities.enforceAiSandbox = true' \
+  "$both_src/src/.chezmoidata/profiles.yaml"
+if ! both_file="$(render_personal_settings "$both_src/src")"; then
+  fail "test failed: personal apply (both gates true) did not render"
+  exit 1
+fi
+if yq -p json '.' "$both_file" >/dev/null 2>&1 \
+  && grep -Fq '"mcp__github"' "$both_file" \
+  && grep -Fq '"Bash(git push * main)"' "$both_file"; then
+  ok "test passed: both gates on -> valid JSON with combined MCP + write deny"
+else
+  fail "test failed: both gates on produced invalid JSON or missing matchers"
   status=1
 fi
 

--- a/scripts/test-claude-settings.sh
+++ b/scripts/test-claude-settings.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 #     failIfUnavailable=true (hard-fail rather than silently run unsandboxed),
 #     allowUnsandboxedCommands=false (no per-command escape hatch), and a
 #     public-safe empty network allowlist.
+# It also fixes the GitHub injection guard content (issue #119, Phase 1):
+# gateGitHubMcp -> deny the github MCP server; enforceAiSandbox -> write deny
+# (secret/main-push) + approval ask (release/protection). Both gates default
+# false, so the rendered settings.json is byte-identical until one is flipped.
+# The matchers are best-effort/steering; a bypass negative test keeps that
+# visible. See docs/ai-environment-boundary.md.
 # Renders into throwaway destinations; never touches the real home directory.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -111,6 +117,76 @@ if [[ "$skip_warn" == "true" && "$tui_mode" == "fullscreen" ]]; then
 else
   fail "test failed: managed global prefs missing (skipWorkflowUsageWarning=$skip_warn tui=$tui_mode)"
   status=1
+fi
+
+section "claude settings GitHub injection guard (#119)"
+
+# 4) Default (both gates false): no deny/ask keys at all. This is the
+#    byte-identical guarantee — the capabilities land off and change nothing.
+deny_default="$(yq -p json '.permissions.deny // "absent"' "$off_file")"
+ask_default="$(yq -p json '.permissions.ask // "absent"' "$off_file")"
+if [[ "$deny_default" == "absent" && "$ask_default" == "absent" ]]; then
+  ok "test passed: default emits no deny/ask (permissions unchanged)"
+else
+  fail "test failed: default unexpectedly has deny/ask (deny=$deny_default ask=$ask_default)"
+  status=1
+fi
+
+# 5) enforceAiSandbox=true: the write deny/ask rides on the same gate (on_file
+#    from section 2). secret + direct main push are hard deny; release and
+#    branch-protection need approval (ask). Context-gated writes (merge/PR/
+#    comment/label/push ai/*) are intentionally NOT here (Phase 2 hook).
+if grep -Fq '"Bash(git push * main)"' "$on_file" \
+  && grep -Fq '"Bash(printenv)"' "$on_file" \
+  && grep -Fq '"Bash(gh release create *)"' "$on_file" \
+  && grep -Fq '"Bash(gh api *protection*)"' "$on_file"; then
+  ok "test passed: enforceAiSandbox=true adds write deny (secret/main-push) + approval ask (release/protection)"
+else
+  fail "test failed: enforceAiSandbox=true missing expected write deny/ask matchers"
+  status=1
+fi
+# merge/PR/comment/label must NOT be statically gated in Phase 1 (left to the hook).
+if grep -Fq 'gh pr merge' "$on_file" || grep -Fq 'gh pr create' "$on_file" || grep -Fq 'gh label create' "$on_file"; then
+  fail "test failed: context-gated writes are statically gated (should be deferred to the Phase 2 hook)"
+  status=1
+else
+  ok "test passed: context-gated writes (merge/PR/comment/label) are not statically gated"
+fi
+
+# 6) gateGitHubMcp=true: the GitHub MCP server is denied entirely. Flip in a
+#    throwaway copy so the committed default stays false.
+mcp_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings-mcp.XXXXXX")"
+tmp_roots+=("$mcp_src")
+cp -R "$DOTFILES_ROOT" "$mcp_src/src"
+rm -rf "$mcp_src/src/.git"
+yq -i '.profiles.personal.capabilities.gateGitHubMcp = true' \
+  "$mcp_src/src/.chezmoidata/profiles.yaml"
+if ! mcp_file="$(render_personal_settings "$mcp_src/src")"; then
+  fail "test failed: personal apply (gateGitHubMcp=true) did not render"
+  exit 1
+fi
+if grep -Fq '"mcp__github"' "$mcp_file" && grep -Fq '"mcp__github__*"' "$mcp_file"; then
+  ok "test passed: gateGitHubMcp=true denies the github MCP server"
+else
+  fail "test failed: gateGitHubMcp=true did not deny the github MCP server"
+  status=1
+fi
+
+# 7) Bypass negative test. The static command-string matchers are steering, NOT
+#    an enforcement boundary: equivalent read/exfil paths are deliberately not
+#    covered. Assert their absence (in the max-deny enforceAiSandbox render) so
+#    the limitation stays visible and nobody mistakes this for a boundary. If a
+#    future change "covers" one of these, re-check the honest labeling first.
+bypass_hit=0
+for bypass in 'git fetch' 'gh api *contents' 'gh issue view' 'WebFetch'; do
+  if grep -Fq "$bypass" "$on_file"; then
+    fail "test failed: matcher unexpectedly covers '$bypass' — re-check honest labeling / update the bypass test"
+    bypass_hit=1
+    status=1
+  fi
+done
+if [[ "$bypass_hit" -eq 0 ]]; then
+  ok "test passed: known equivalent read/exfil paths are NOT covered (matchers are steering, not a boundary)"
 fi
 
 if [[ "$status" -eq 0 ]]; then

--- a/scripts/test-claude-settings.sh
+++ b/scripts/test-claude-settings.sh
@@ -138,7 +138,7 @@ fi
 #    comment/label/push ai/*) are intentionally NOT here (Phase 2 hook).
 if grep -Fq '"Bash(git push * main)"' "$on_file" \
   && grep -Fq '"Bash(printenv)"' "$on_file" \
-  && grep -Fq '"Read(**/.env*)"' "$on_file" \
+  && grep -Fq '"Read(//**/.env*)"' "$on_file" \
   && grep -Fq '"Read(~/.ssh/**)"' "$on_file" \
   && grep -Fq '"Bash(gh release create *)"' "$on_file" \
   && grep -Fq '"Bash(gh api *protection*)"' "$on_file"; then

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -402,9 +402,10 @@ else
   status=1
 fi
 
-# GitHub injection guard report (gateGitHubMcp / enableGitHubIsolatedReader, #119
-# Phase 1). The capabilities land before their enforcement; doctor must report
-# them honestly (declared, not enforced) and stay exit 0 = no dead capability.
+# GitHub injection guard report (gateGitHubMcp / enableGitHubIsolatedReader, #119).
+# gateGitHubMcp is wired (PR2: MCP deny in managed settings.json); doctor must
+# report it as enforced when active. enableGitHubIsolatedReader is Phase 3, so it
+# stays "declared, not enforced". doctor stays exit 0 (no dead capability).
 # Throwaway repo copy so the flip does not touch the real data files.
 gh_root="$fixture_home/.dotfiles-ghguard"
 mkdir -p "$gh_root/.chezmoidata"
@@ -428,16 +429,21 @@ else
   status=1
 fi
 
-# Q) flipped true -> reported as declared-but-not-enforced (placeholder), exit 0.
-awk '$0 == "      gateGitHubMcp: false" { print "      gateGitHubMcp: true"; next } { print }' \
+# Q) gateGitHubMcp=true (claude-settings active for personal) -> reported as
+#    enforced (MCP deny in managed settings), NOT as not-wired. enableGitHubIsolatedReader
+#    flipped too -> still reported as Phase 3 / not enforced. exit 0.
+awk '$0 == "      gateGitHubMcp: false" { print "      gateGitHubMcp: true"; next }
+     $0 == "      enableGitHubIsolatedReader: false" { print "      enableGitHubIsolatedReader: true"; next }
+     { print }' \
   "$gh_root/.chezmoidata/profiles.yaml" > "$gh_root/.chezmoidata/profiles.yaml.tmp"
 mv "$gh_root/.chezmoidata/profiles.yaml.tmp" "$gh_root/.chezmoidata/profiles.yaml"
 if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
-  if grep -Fq "not wired yet" <<< "$gh_out"; then
-    ok "test passed: gateGitHubMcp=true reported as declared-not-enforced"
+  if grep -Fq "denies the github MCP server" <<< "$gh_out" \
+    && grep -Fq "isolated reader is not wired yet" <<< "$gh_out"; then
+    ok "test passed: gateGitHubMcp=true reported as enforced; isolated reader still Phase 3"
   else
     printf '%s\n' "$gh_out" >&2
-    fail "test failed: gateGitHubMcp=true placeholder not reported"
+    fail "test failed: gateGitHubMcp wired-state or isolated-reader Phase 3 state not reported"
     status=1
   fi
 else


### PR DESCRIPTION
## 概要
epic #119 の **Phase 1 / PR2**。managed `~/.claude/settings.json` に best-effort な deny/ask matcher を **capability-gate で**出力する。PR1 の capability が既定 false なので、**既定レンダリングは byte-identical**(検証済み:default render は committed と diff ゼロ・`chezmoi status` クリーン)。実効ゼロのまま land し、有効化は Phase 2(検証ゲート後に capability を true)。

## 方針(対話で確定)
- **A=最小ハードフロア**: deny=絶対ダメなものだけ / ask=常時承認だけ / context 依存 write(merge/PR/comment/label/push ai/*)は**静的に gate せず Phase2 hook へ**(静的 settings は context の清浄さを判定できない)。
- **B=enforceAiSandbox 相乗り**(spec の YAGNI、新 capability を増やさない)。

## matcher(capability-gate)
- **`gateGitHubMcp`** → `permissions.deny`: `mcp__github`, `mcp__github__*`。
- **`enforceAiSandbox`**(write gate 相乗り):
  - deny(hard): `printenv`/`env`/`gh secret *`/`gh api *secrets*`/`cat *.env*`/`cat ~/.ssh/*`、`git push * main`/`* master`。
  - ask(承認): `gh release create/delete/edit *`、`gh api *protection*`/`*rulesets*`。
- WebFetch に github.com domain を**入れない**。

## honest labeling(設計の肝)
matcher は **best-effort / steering で enforcement boundary ではない**(`$()`・等価 read path・MCP 別経路・subagent gap で回避可。構文も claude-code-guide+公式 docs で裏取り)。**bypass negative test** で既知の等価経路(`git fetch`/`gh api *contents`/`gh issue view`/`WebFetch`)が deny に**入っていない**ことを固定し、boundary と誤認しないようにした。

## 検証
- **default(両 cap false)= settings.json byte-identical**(diff ゼロ)/ `chezmoi status` クリーン。
- on ケース: gateGitHubMcp→mcp deny、enforceAiSandbox→write deny+ask+sandbox、両方→valid JSON・deny 12。
- `test-claude-settings.sh` 拡張(default 無 deny/ask・write deny/ask・MCP deny・**context-gated write が静的 gate されていない**・bypass negative)。
- `validate-policy --all`/`test-policy`/`test-render`/`test-doctor`/`test-claude-settings` 全 rc=0。`shellcheck -S warning scripts/*.sh`/`bash -n`/`git diff --check` OK。

## レビュー
Claude 実装 → 相互レビュー(author ≠ reviewer)で **Codex**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)