### PR TITLE
doctor: disclose the #119 write/secret hard-floor is inert on personal (#119)

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -403,6 +403,23 @@ if [[ "$(capability_value "$profile" gateGitHubMcp)" == "true" ]]; then
 else
   ok "gateGitHubMcp not active (false)"
 fi
+# The #119 write/secret hard-floor (secret read, ~/.ssh, main-push hard deny;
+# release/protection ask) is emitted into the managed settings.json by the
+# enforceAiSandbox capability, not by a #119-specific one (the epic's "no
+# separate capability" decision). So it is only live when enforceAiSandbox is
+# true; on personal that capability stays false (its egress block is unusable on
+# a daily driver), so the floor is INERT even though gateGitHubMcp is on. Disclose
+# the live state here so the green MCP-deny line above is not read as a complete
+# injection guard. Splitting the context-independent floor (secret/ssh/main-push)
+# from the egress block is #119 Phase 2. Only meaningful where claude-settings
+# manages the file at all.
+if module_active_for_profile "$profile" claude-settings; then
+  if [[ "$(capability_value "$profile" enforceAiSandbox)" == "true" ]]; then
+    item "write/secret hard-floor active (rides on enforceAiSandbox; secret + main-push deny, release/protection ask — see sandbox section)"
+  else
+    item "write/secret hard-floor INERT (enforceAiSandbox=false): secret read, ~/.ssh, main-push deny and release/protection ask are not rendered — #119 Phase 2 splits it from the egress block"
+  fi
+fi
 # enableGitHubIsolatedReader is the isolated reader (Phase 3): the capability is
 # declared but its enforcement is not wired yet.
 if [[ "$(capability_value "$profile" enableGitHubIsolatedReader)" == "true" ]]; then

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -419,8 +419,9 @@ cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$gh_root/.chezmoidata/"
 #    guard).
 if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "denies the github MCP server" <<< "$gh_out" \
-    && grep -Fq "enableGitHubIsolatedReader not active" <<< "$gh_out"; then
-    ok "test passed: gateGitHubMcp enforced (MCP deny), isolated reader not active"
+    && grep -Fq "enableGitHubIsolatedReader not active" <<< "$gh_out" \
+    && grep -Fq "write/secret hard-floor INERT" <<< "$gh_out"; then
+    ok "test passed: gateGitHubMcp enforced (MCP deny), isolated reader not active, write/secret floor disclosed inert"
   else
     printf '%s\n' "$gh_out" >&2
     fail "test failed: GitHub guard capability not reported"
@@ -489,6 +490,29 @@ if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; 
 else
   printf '%s\n' "$gh_out" >&2
   fail "test failed: doctor must stay exit 0 (GitHub guard, flipped true)"
+  status=1
+fi
+
+# R) enforceAiSandbox=true: the injection-guard section discloses the write/secret
+#    hard-floor as ACTIVE (it rides on enforceAiSandbox). Covers the other branch
+#    of the floor disclosure; case P covered the inert (enforceAiSandbox=false)
+#    branch. Builds on case Q's mutated copy (claude-settings active for personal).
+#    exit 0.
+awk '$0 == "      enforceAiSandbox: false" { print "      enforceAiSandbox: true"; next }
+     { print }' \
+  "$gh_root/.chezmoidata/profiles.yaml" > "$gh_root/.chezmoidata/profiles.yaml.tmp"
+mv "$gh_root/.chezmoidata/profiles.yaml.tmp" "$gh_root/.chezmoidata/profiles.yaml"
+if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "write/secret hard-floor active" <<< "$gh_out"; then
+    ok "test passed: enforceAiSandbox=true -> write/secret floor disclosed active"
+  else
+    printf '%s\n' "$gh_out" >&2
+    fail "test failed: write/secret floor active-state not reported when enforceAiSandbox=true"
+    status=1
+  fi
+else
+  printf '%s\n' "$gh_out" >&2
+  fail "test failed: doctor must stay exit 0 (write/secret floor active)"
   status=1
 fi
 


### PR DESCRIPTION
## なぜ

Phase 2 着手前に Phase 1 land 物を監査した結果、honest-labeling の穴が 1 つ出た。

`doctor` の "GitHub injection guard" section は `gateGitHubMcp=true` の MCP deny を緑の `ok` で報告する一方、**設計正本 決定6 の「secret access は常に hard deny」「main 直 push は hard deny」が personal で完全に inert である事実を一切報告していなかった**。

- この write/secret hard-floor は `enforceAiSandbox`(#119 の「独立 capability を増やさない」決定で相乗り)が render する。
- `enforceAiSandbox=true` は egress 全遮断(`allowedDomains` 空)を伴い daily driver の personal では ON にできない → personal では floor が 1 つも render されない。
- 結果、`doctor` を見ると injection guard が緑で「効いている」ように読め、**偽の安心**を生む(secret deny は実際には personal で無効)。

docs(`ai-policy.md` の policy-intent 明記、`ai-environment-boundary.md` の限界記述)は正直だが、`doctor` section の沈黙だけが残っていた。

## 何を

injection guard section に、**claude-settings が active なときだけ** floor の live state を `item`(中立・report-only・contents-blind)で開示:

- `enforceAiSandbox=true` → `write/secret hard-floor active (...)`
- `enforceAiSandbox=false` → `write/secret hard-floor INERT (enforceAiSandbox=false): ... not rendered — #119 Phase 2 splits it from the egress block`

緑の MCP-deny 行の直下に出るので、injection guard が「完全」だと誤読されない。**honest-labeling のみ**で render 変更なし(`chezmoi status` クリーン)。これは「context 非依存の hard 床を egress block から分離する」Phase 2 タスクB を surface する入口でもある。

## 検証

- `test-doctor.sh`: 既存 case P(committed personal, `enforceAiSandbox=false`)に INERT 開示の assert を追加 + 新 case R(`enforceAiSandbox=true`)で ACTIVE 開示を assert(= `enforceAiSandbox=true` 枝の初の doctor カバレッジ)。
- 実機 `doctor personal` で INERT 行が MCP-deny 直下に出ることを目視。`doctor work-minimal`(claude-settings inactive)では floor 行が出ない(module gating)ことを確認。
- `test-doctor.sh` / `test-claude-settings.sh` / `validate-policy.sh` 全 green、`chezmoi status` クリーン、`shellcheck -S warning scripts/*.sh`(CI 同一)クリーン。

## レビュー

Claude 実装 → **Codex 相互レビュー**(author≠reviewer)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
