### PR TITLE
docs: record that permissions.deny is inherited by subagents (#119)

### DIFF
--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -203,6 +203,16 @@ personal の `gateGitHubMcp` を true** に反転し、github MCP deny を live 
   `enableGitHubIsolatedReader` は Phase 3 の隔離 reader 用に **宣言だけ**してある
   (declared, not enforced。doctor が warn)。
 
+**subagent への適用(deny は継承・hook は不発)**: `permissions.deny` は main session だけでなく
+**subagent にも継承される**(Claude Code が subagent に親会話の permission context を引き継がせる)。
+よって `mcp__github` deny と secret 床は **subagent からも効く** ── injection で subagent を spawn
+して回避する経路は塞がっている。これは `PreToolUse` **hook が subagent に発火しない**
+([anthropics/claude-code#21460])のとは別レイヤで、**deny(enforcement)は subagent をカバーし、
+hook(steering)はカバーしない**。一方 `permissions.deny` は session 一律なので、「main は許可・
+subagent だけ非付与」(例: untrusted な GitHub を読む subagent からだけ `WebFetch` を外す)は
+settings.json では表現できない ── それは agent 定義(agent-tools 領分)/ Phase 3 の隔離 reader の
+役割になる。
+
 **token 分離の実態(P0-B・best-effort)**: 「untrusted を読む間 `GH_TOKEN` を env から外せば
 private-token を hard に切れる」は **この環境では成り立たない**。実機の `gh` は `GH_TOKEN`
 未設定でも **keyring 認証**(macOS keychain)で動くため、env を外しても認証は残る = 偽の安心。

--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -203,15 +203,17 @@ personal の `gateGitHubMcp` を true** に反転し、github MCP deny を live 
   `enableGitHubIsolatedReader` は Phase 3 の隔離 reader 用に **宣言だけ**してある
   (declared, not enforced。doctor が warn)。
 
-**subagent への適用(deny は継承・hook は不発)**: `permissions.deny` は main session だけでなく
-**subagent にも継承される**(Claude Code が subagent に親会話の permission context を引き継がせる)。
-よって `mcp__github` deny と secret 床は **subagent からも効く** ── injection で subagent を spawn
-して回避する経路は塞がっている。これは `PreToolUse` **hook が subagent に発火しない**
-([anthropics/claude-code#21460])のとは別レイヤで、**deny(enforcement)は subagent をカバーし、
-hook(steering)はカバーしない**。一方 `permissions.deny` は session 一律なので、「main は許可・
-subagent だけ非付与」(例: untrusted な GitHub を読む subagent からだけ `WebFetch` を外す)は
-settings.json では表現できない ── それは agent 定義(agent-tools 領分)/ Phase 3 の隔離 reader の
-役割になる。
+**subagent への適用(deny は継承・親 hook は subagent 不発)**: `permissions.deny` は main session
+だけでなく **subagent にも継承される**(Claude Code が subagent に親会話の permission context を
+引き継がせる)。よって `mcp__github` deny と secret 床は **subagent からも効く** ── injection で
+subagent を spawn して回避する経路は塞がっている。これは **settings.json(親 session)側の
+`PreToolUse` hook が subagent の個別 tool call に継承発火しない**([anthropics/claude-code#21460])
+のとは別レイヤ:**`permissions.deny`(enforcement)は subagent をカバーするが、親 session 側の
+hook(steering)は subagent の tool call には継承発火しない**(subagent 固有の hook は agent
+frontmatter で別途定義できるが、それは agent-tools 領分)。一方 `permissions.deny` は session 一律
+なので、「main は許可・subagent だけ非付与」(例: untrusted な GitHub を読む subagent からだけ
+`WebFetch` を外す)は settings.json では表現できない ── それは agent 定義(agent-tools 領分)/
+Phase 3 の隔離 reader の役割になる。
 
 **token 分離の実態(P0-B・best-effort)**: 「untrusted を読む間 `GH_TOKEN` を env から外せば
 private-token を hard に切れる」は **この環境では成り立たない**。実機の `gh` は `GH_TOKEN`


### PR DESCRIPTION
## なぜ(#119 Phase 2 task-1 の finding)

「subagent への github MCP/WebFetch 非付与」を調べた結果、**前提が誤りだった**ことが判明(claude-code-guide + 公式 docs で裏取り)。

**subagent は親会話の permission context を継承する**(Sub-agents doc)。よって settings.json の `permissions.deny` は main session だけでなく **subagent の tool 呼び出しにも一律に効く**。これは `PreToolUse` hook が subagent に発火しない([#21460](https://github.com/anthropics/claude-code/issues/21460))のとは**別レイヤ**:

| レイヤ | subagent カバー |
|---|---|
| `permissions.deny`(enforcement) | ✅ 継承で効く |
| `PreToolUse` hook(steering) | ❌ #21460 で不発 |

## 含意

- **subagent の github MCP 非付与 = 既に達成済み**(`mcp__github` deny が継承)。元タスクの「subagent を別途塞ぐ」前提は不要だった。
- **PR #129 の secret 床も subagent に継承される**(injection で subagent を spawn して secret を抜く経路も塞がっている = threat model 上の強み)。
- **WebFetch を「subagent だけ」非付与は settings.json では不可能**(session 一律 deny は main の正規 WebFetch を壊す)。subagent 限定は agent 定義(**agent-tools 領分**)/ Phase 3 の隔離 reader が必要 → **hand-off**。

## 何を

`docs/ai-environment-boundary.md` の injection guard 節に「**subagent への適用(deny は継承・hook は不発)**」段落を追記。deny が subagent をカバーする事実(threat model 上の重要点で今まで docs に無かった)と、subagent-only 制限が settings.json では表現できず agent-tools/Phase 3 の役割であることを明記。

docs-only・render 不変(`chezmoi status` クリーン)。`#119` チェックリストは merge 後に reframe(MCP=継承で達成 / WebFetch-per-subagent=hand-off)。

## レビュー

Claude 実装 → **Codex 相互レビュー**(author≠reviewer)。security 契約の主張(「deny は subagent をカバー」)が一次情報と整合するかを重点に。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
