### PR TITLE
directory-convention: 非標準配置(~/src 外)を許容と明文化し standard-root missing を中立化 (#134)

### DIFF
--- a/docs/directory-convention.md
+++ b/docs/directory-convention.md
@@ -59,9 +59,10 @@ Git config では `user.useConfigOnly = true` を使い、known directory 外で
 - **agent-tools の監視**: doctor が探す checkout path は `AGENT_TOOLS` env で実体を指す
   (override 機構は Issue #71、root pin は Issue #73)。具体 path は tracked file に焼かず、
   非追跡の `~/.zshrc.local` に置く。
-- **doctor / preflight の検査範囲**: remote URL の credential scan と standard root の
-  presence check は `~/src` を前提とする。非標準配置の repo はこれらの自動検査の対象外に
-  なる(どちらも report-only なので実害はないが、網羅性は下がる)。
+- **doctor / preflight の検査範囲**: standard root の presence check と remote URL の
+  credential scan は `~/src` を前提とする(ただし credential scan は dotfiles repo 自身を
+  常に対象に含む)。dotfiles 以外の非標準配置 repo はこれらの自動検査の対象外になる
+  (どちらも report-only なので実害はないが、網羅性は下がる)。
 
 doctor / preflight は標準 root の不在を中立に報告し(警告ではない)、非標準配置を妨げない。
 ただし標準の `~/src/<context>/` 構造の方が identity 判定・secret access・policy の自動適用を

--- a/docs/directory-convention.md
+++ b/docs/directory-convention.md
@@ -46,9 +46,32 @@ Git config では `user.useConfigOnly = true` を使い、known directory 外で
 
 既存 host で `~/.config` が 0755 の場合、初回 apply で 0700 に変わる。これは仕様。`chezmoi diff` に mode 変更として表示され、`preflight` も apply 前にこの差分を warning で知らせる。0700 を望まない場合は、その host で apply しないか、profile 構成を見直す。
 
+## 許容された非標準配置
+
+標準は上記の `~/src/<context>/` だが、project を `~/src` の外(例: 単一の作業 directory に
+まとめる運用)に置くことも許容する。その場合は以下を理解した上で運用する。
+
+- **Git identity**: `includeIf "gitdir:~/src/<context>/"` は当たらないため identity が
+  自動解決されず、`user.useConfigOnly = true` により commit は fail-closed で失敗する。
+  意図的に非標準配置で運用するなら、repo ごとに `git config user.name` / `user.email` を
+  設定して解除する(personal は remote URL による二次判定(Issue #52)が当たれば設定不要)。
+  この場合、identity の安全装置は「置き場所」ではなく repo-local 設定が担う。
+- **agent-tools の監視**: doctor が探す checkout path は `AGENT_TOOLS` env で実体を指す
+  (override 機構は Issue #71、root pin は Issue #73)。具体 path は tracked file に焼かず、
+  非追跡の `~/.zshrc.local` に置く。
+- **doctor / preflight の検査範囲**: remote URL の credential scan と standard root の
+  presence check は `~/src` を前提とする。非標準配置の repo はこれらの自動検査の対象外に
+  なる(どちらも report-only なので実害はないが、網羅性は下がる)。
+
+doctor / preflight は標準 root の不在を中立に報告し(警告ではない)、非標準配置を妨げない。
+ただし標準の `~/src/<context>/` 構造の方が identity 判定・secret access・policy の自動適用を
+受けられるので、特段の理由がなければ標準配置を推奨する。
+
 ## Rules
 
 - 個人 project と会社 project を同じ階層に置かない。
 - client project は client ごとの下位階層に分ける。
 - agent project は `~/src/agent` に分離する。
-- unknown directory では doctor が警告する。
+- `~/src` の外(unknown directory)では Git identity が解決されず commit が fail-closed に
+  なる(意図した安全側の挙動)。標準 root の不在自体は doctor が中立に報告する(警告ではない)。
+  非標準配置で運用する場合の解除方法は上の「許容された非標準配置」を参照。

--- a/docs/git-identity.md
+++ b/docs/git-identity.md
@@ -81,6 +81,11 @@ fatal: no email was given and auto-detection is disabled
 
 これは意図した挙動。誤った identity で commit するより、commit できない方を選ぶ。
 
+意図的に `~/src` の外で運用する project では、repo ごとに `git config user.name` /
+`user.email` を設定して fail-closed を解除する(承知の上で「置き場所」による自動分離を
+使わない選択。personal は remote URL による二次判定(Issue #52)が当たれば設定不要)。
+非標準配置の扱いは [directory-convention](directory-convention.md) を参照。
+
 ## 検査
 
 - `scripts/doctor.sh` は report-only で以下を確認する。

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -350,10 +350,13 @@ section "AI policy"
 if [[ "$(capability_value "$profile" enableAiPolicy)" == "true" ]]; then
   ok "enableAiPolicy=true (policy docs + report-only checks; see docs/ai-policy.md)"
   item "boundary today: directory convention + Git identity separation + policy docs"
+  # The standard agent root is optional: agent repos may live outside ~/src (a
+  # non-standard placement) resolved via AGENT_TOOLS / repo-local identity, so a
+  # missing standard root is reported neutrally, not as a warning (#134).
   if [[ -d "$HOME/src/agent" ]]; then
     ok "agent project root exists: $HOME/src/agent"
   else
-    warn "agent project root missing: $HOME/src/agent"
+    item "agent project root not present (standard root, optional): $HOME/src/agent"
   fi
 else
   ok "AI policy checks disabled for profile"
@@ -543,11 +546,14 @@ if [[ "$tunnel_tools_found" -eq 0 ]]; then
 fi
 
 section "project roots"
+# Standard roots (docs/directory-convention.md). They are optional: repos may
+# live outside ~/src (a non-standard placement) with repo-local identity, so a
+# missing standard root is reported neutrally, not as a warning (#134).
 for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/sandbox" "$HOME/src/agent"; do
   if [[ -d "$dir" ]]; then
     ok "exists: $dir"
   else
-    warn "missing: $dir"
+    item "not present (standard root, optional): $dir"
   fi
 done
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -158,11 +158,14 @@ else
 fi
 
 section "known project roots"
+# Standard roots (docs/directory-convention.md). Optional: repos may live
+# outside ~/src (a non-standard placement) with repo-local identity, so a
+# missing standard root is reported neutrally, not as a warning (#134).
 for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/sandbox" "$HOME/src/agent"; do
   if [[ -d "$dir" ]]; then
     ok "exists: $dir"
   else
-    warn "missing: $dir"
+    item "not present (standard root, optional): $dir"
   fi
 done
 

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -354,6 +354,26 @@ else
   status=1
 fi
 
+# project roots / agent root (#134): a missing STANDARD root is reported
+# neutrally (an item), not as a warning, so a non-standard placement (repos kept
+# outside ~/src) is not nagged. The fixture HOME has no ~/src/personal, so it
+# must surface as a neutral "not present (standard root, optional)" item and
+# never as a "missing: .../src/personal" warning.
+if pr_out="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "not present (standard root, optional): $fixture_home/src/personal" <<< "$pr_out" \
+    && ! grep -Fq "missing: $fixture_home/src/personal" <<< "$pr_out"; then
+    ok "test passed: missing standard project root reported neutrally, not as a warning (#134)"
+  else
+    printf '%s\n' "$pr_out" >&2
+    fail "test failed: standard project root missing must be neutral (#134), not a warning"
+    status=1
+  fi
+else
+  printf '%s\n' "$pr_out" >&2
+  fail "test failed: doctor must stay exit 0 (project roots neutral)"
+  status=1
+fi
+
 # Git signing report (enableGitSigning, issue #85). doctor stays report-only /
 # exit 0 and must reflect both the active and the dangling (capability true but
 # git-signing module inactive) cases. Throwaway repo copy so the edits do not


### PR DESCRIPTION
## 概要
#134 (c) ハイブリッド追認。`~/src/<context>/` 規約を**標準として維持**しつつ、`~/src` の外(`~/dev` 等)への配置を「許容された非標準配置」として明文化し、doctor/preflight の standard-root missing を `warn` → 中立報告に整合させる。

## 背景
棚卸しで判明: 開発 repo は実際には全て `~/src` の外にフラット配置され、identity は repo-local `.git/config` 直書きで稼働している(`includeIf gitdir` は未発火・`hasconfig` fallback も repo-local に上書きされ不可視)。実害はほぼゼロ(全て report-only)だが、**文書 vs 実態の食い違い**と**identity 安全装置の形骸化**という負債があった。(c) は最小変更でこの認知/設計負債を解消する。

## 変更
- **docs/directory-convention.md**: 「許容された非標準配置」節を追加(非標準配置時の identity・agent-tools 監視・検査範囲の帰結)。Rules の「unknown directory では doctor が警告する」を honest に更新(fail-closed は commit 側、standard root の不在は doctor が中立報告)。
- **docs/git-identity.md**: `~/src` 外での repo-local identity 運用を追記。
- **scripts/doctor.sh / preflight.sh**: standard root の missing を `warn` → 中立 `item` に(report-only / exit 0 維持・非標準配置を妨げない)。
- **scripts/test-doctor.sh**: standard root missing が warn でなく中立 item になることを回帰固定。

## 設計判断 / 非スコープ
- `~/dev` 等の**具体 path はハードコードしない**(public-safety / #73 の local-path-not-in-tracked-file 教訓)。override は既存 `AGENT_TOOLS` 機構に委譲。
- `Git identity contexts` section の `project root exists but identity file missing` warn は**対象外**(「root を作ったなら identity も設定せよ」を咎める妥当な別ロジック)。
- 現環境の `~/src/<ctx>` 空ディレクトリの掃除(上記 warn の実環境での解消)は home 操作のため**別途**。

## 検証
test-doctor 25/25・test-policy・shellcheck -S warning・bash -n・whitespace・chezmoi status クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)