### PR TITLE
catalog: herdr(agent multiplexer)を brew_formula として追加 (#154)

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -56,6 +56,10 @@ packages:
   - { name: eza, source: brew_formula }
   - { name: bat, source: brew_formula }
   - { name: direnv, source: brew_formula }
+  # Agent multiplexer (#154): runs multiple coding agents in one terminal.
+  # homebrew-core formula (bottled); background service is optional and not
+  # managed here (start manually with `herdr server` or `brew services`).
+  - { name: herdr, source: brew_formula }
   - { name: 1password-cli, source: brew_cask, bin: op }
   - { name: copilot-cli, source: brew_cask }
   - { name: iterm2, source: brew_cask }

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -500,9 +500,9 @@ EOF
   done
 
   # Default inventory == the reality-seed catalog (drift-free baseline).
-  printf '%s\n' age chezmoi gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+  printf '%s\n' age chezmoi gh herdr mise shellcheck tmux yq "${shell_env_formulae[@]}" \
     > "$drift_dir/brew_formulae"
-  printf '%s\n' age chezmoi gh mise shellcheck tmux yq "${shell_env_formulae[@]}" \
+  printf '%s\n' age chezmoi gh herdr mise shellcheck tmux yq "${shell_env_formulae[@]}" \
     > "$drift_dir/brew_leaves"
   printf '%s\n' 1password-cli copilot-cli iterm2 swiftbar > "$drift_dir/brew_casks"
   # npm and corepack are node-bundled; including them proves they are


### PR DESCRIPTION
Closes #154

## 変更

- `.chezmoidata/packages.yaml`: `herdr` を brew_formula として catalog に追加(コメントで #154 と「常駐 service は catalog 管理外」を明記)
- `scripts/test-policy.sh`: drift reality-seed(brew_formulae / brew_leaves の 2 行)に herdr を追従(#83 と同型)

## 事前確認

- homebrew-core 公式 formula(bottled)v0.7.1、AGPL-3.0-or-later、Rust 製、no telemetry(README)。`curl | sh` を使わず supply-chain 方針にそのまま乗る

## 検証

- `validate-policy.sh --all` PASS(package: herdr ok)
- `test-policy.sh` PASS(46 tests、drift clean baseline 含む)
- `test-install-packages.sh` PASS
- render 対象外(packages.yaml は managed file を生成しない)

merge 後: `install-packages.sh --apply` で実機 install → doctor で drift なし確認 → #154 close。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
