### PR TITLE
private-backup: tar -p 展開 + confirm/dedup/unreadable の correctness 修正 (#141)

### DIFF
--- a/docs/private-backup.md
+++ b/docs/private-backup.md
@@ -67,7 +67,12 @@ private-backup.sh restore --in PATH (--identity PATH | --identity-command CMD) \
   を想定)。後者は出力を /dev/fd 経由で age に渡し、秘密鍵をディスクに置かない。
 - archive は `tar | age` を pipe して平文 tar をディスクに残さない。アーカイブ内のパスは
   home 相対(`-C` で絶対パスを含めない)。
-- backup は捕捉 0 件なら空アーカイブを書かず fail。symlink / 不在 / 非正規ファイルは skip(warn)。
+- backup は捕捉 0 件なら空アーカイブを書かず fail。symlink / 不在 / 非正規 / 読取不可の
+  ファイルは skip(warn)。重複宣言(dir とその配下 file)は 1 回だけ捕捉する。
+- 書き込み前の確認は `--yes` で省略できる。`--yes` なしでは TTY での対話確認が必須:
+  TTY が無い(cron / CI など無人実行)場合は明示エラーで **exit 非 0**、対話で decline
+  した場合も **exit 非 0**(アーカイブを書かなかった実行は成功を返さない。無人実行での
+  バックアップ欠落が exit 0 で監視をすり抜けるのを防ぐ)。無人実行は `--yes` を明示する。
 - restore は verify を通った後のみ復元する(整合 NG なら拒否)。**既定 dry-run**(何も書かない)、
   `--apply` で実行。既存ファイルは上書き前に **timestamp 付き退避 dir**(`~/.local/state/dotfiles/
   restore-backup-<ts>/`)へ move。`--skip-existing` で既存は触らない。**symlink 化した親ディレクトリ

--- a/scripts/private-backup.sh
+++ b/scripts/private-backup.sh
@@ -311,6 +311,19 @@ cmd_backup() {
             continue
             ;;
         esac
+        # Deduplicate against paths already captured (a declared file inside
+        # this dir, or an overlapping dir declaration) so the manifest never
+        # lists the same file twice; restore would otherwise process it
+        # twice and misreport created/displaced counts.
+        if grep -Fxq -- "$rel" "$seen_paths"; then
+          continue
+        fi
+        printf '%s\n' "$rel" >> "$seen_paths"
+        if [[ ! -r "$f" ]]; then
+          warn "skip unreadable file under $path: $rel"
+          skipped=$((skipped + 1))
+          continue
+        fi
         mode="$(file_mode "$f")"
         size="$(wc -c < "$f" | tr -d ' ')"
         hash="$(sha256_of "$f")"
@@ -323,6 +336,11 @@ cmd_backup() {
     else
       if [[ ! -f "$target" ]]; then
         warn "declared file is not a regular file (skipped): $path"
+        skipped=$((skipped + 1))
+        continue
+      fi
+      if [[ ! -r "$target" ]]; then
+        warn "unreadable (skipped): $path"
         skipped=$((skipped + 1))
         continue
       fi
@@ -356,10 +374,17 @@ cmd_backup() {
   if [[ "$assume_yes" -ne 1 ]]; then
     printf '[info] - proceed and write the encrypted archive? [y/N] ' >&2
     local reply=""
-    read -r reply < /dev/tty || reply=""
+    # Both no-TTY and a declined prompt return non-zero: a run that wrote no
+    # archive must not exit 0, or unattended runs (cron/CI without --yes)
+    # would report success while backups silently never happen.
+    if ! read -r reply < /dev/tty 2>/dev/null; then
+      printf '\n' >&2
+      fail "no TTY for confirmation; pass --yes for unattended runs"
+      return 1
+    fi
     case "$reply" in
       y | Y | yes | YES) ;;
-      *) warn "aborted by user; nothing written"; return 0 ;;
+      *) warn "aborted by user; nothing written"; return 1 ;;
     esac
   fi
 
@@ -429,7 +454,10 @@ decrypt_and_extract() {
   ok "decrypted to 0700 temp"
 
   validate_tar_members "$cipher_tar" || return 1
-  if ! tar -xf "$cipher_tar" -C "$extract" 2>/dev/null; then
+  # -p: restore the modes recorded in the archive. Without it bsdtar applies
+  # the umask on extraction, so group/other-writable files (664/775) come out
+  # as 644/755 and the manifest mode comparison below rejects a good archive.
+  if ! tar -xpf "$cipher_tar" -C "$extract" 2>/dev/null; then
     fail "could not extract archive"
     return 1
   fi

--- a/scripts/test-private-backup.sh
+++ b/scripts/test-private-backup.sh
@@ -424,10 +424,13 @@ if HOME="$dup_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
   age -d -i "$fixture_home/keys/id.txt" "$dup_home/d.age" | tar -xpf - -C "$dup_extract"
   dup_total="$(yq -p=json -o=tsv '.files | length' "$dup_extract/manifest.json")"
   dup_unique="$(yq -p=json -o=tsv '[.files[].path] | unique | length' "$dup_extract/manifest.json")"
-  if [[ "$dup_total" == "$dup_unique" ]]; then
-    pass "overlapping dir+file declarations do not duplicate manifest entries"
+  # Exactly once: dedup must not drop the file either (an ordering bug that
+  # skipped capture entirely would also show zero duplicates).
+  dup_inner="$(yq -p=json -o=tsv '[.files[].path | select(. == "nest/inner")] | length' "$dup_extract/manifest.json")"
+  if [[ "$dup_total" == "$dup_unique" && "$dup_inner" == "1" ]]; then
+    pass "overlapping dir+file declarations capture the file exactly once"
   else
-    miss "manifest lists duplicate paths ($dup_total entries, $dup_unique unique)"
+    miss "manifest should list nest/inner exactly once ($dup_total entries, $dup_unique unique, nest/inner x$dup_inner)"
   fi
 else
   miss "backup with overlapping declarations failed"
@@ -437,23 +440,27 @@ fi
 #     and captures the readable files (issue #141: set -e aborted the whole
 #     run mid-archive before).
 unr_home="$fixture_home/unr"
-mkdir -p "$unr_home/.ssh" "$unr_home/.config/dotfiles"
+mkdir -p "$unr_home/.ssh" "$unr_home/.config/dotfiles" "$unr_home/box"
 printf 'a\n' > "$unr_home/.zshrc.local"
 printf 'b\n' > "$unr_home/.ssh/config.local"
 printf 'locked\n' > "$unr_home/locked"
 chmod 000 "$unr_home/locked"
-printf 'backup_paths:\n  - { path: "locked", type: file }\n' \
+printf 'ok\n' > "$unr_home/box/readable"
+printf 'locked\n' > "$unr_home/box/locked-in-dir"
+chmod 000 "$unr_home/box/locked-in-dir"
+printf 'backup_paths:\n  - { path: "locked", type: file }\n  - { path: "box", type: dir }\n' \
   > "$unr_home/.config/dotfiles/backup-paths.local"
 unr_rc=0
 unr_out="$(HOME="$unr_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
   backup --out "$unr_home/u.age" --recipient "$recipient" --yes 2>&1)" || unr_rc=$?
-chmod 600 "$unr_home/locked" # so the EXIT trap can clean up
+chmod 600 "$unr_home/locked" "$unr_home/box/locked-in-dir" # so the EXIT trap can clean up
 if [[ "$unr_rc" -eq 0 && -f "$unr_home/u.age" ]] \
-  && grep -Fq "unreadable (skipped): locked" <<< "$unr_out"; then
-  pass "unreadable file is skipped with a warning, backup still succeeds"
+  && grep -Fq "unreadable (skipped): locked" <<< "$unr_out" \
+  && grep -Fq "skip unreadable file under box: box/locked-in-dir" <<< "$unr_out"; then
+  pass "unreadable files (declared file and inside a dir) are skipped with a warning, backup still succeeds"
 else
   printf '%s\n' "$unr_out" >&2
-  miss "unreadable file should be skipped without aborting, got rc=$unr_rc"
+  miss "unreadable files should be skipped without aborting, got rc=$unr_rc"
 fi
 
 if [[ "$status" -eq 0 ]]; then

--- a/scripts/test-private-backup.sh
+++ b/scripts/test-private-backup.sh
@@ -349,6 +349,113 @@ else
 fi
 set_profile personal
 
+# Octal mode of a path (same OS branch as file_mode in private-backup.sh,
+# which the test cannot source: running the script under test executes main).
+mode_of() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+# 19. A group-writable file (664) round-trips: capture, verify, and restore
+#     keep the recorded mode. Regression for the umask bug: extraction
+#     without -p turned 664 into 644 and the manifest mode check rejected
+#     every archive containing such a file (issue #141).
+gw_home="$fixture_home/gw"
+mkdir -p "$gw_home/.ssh"
+printf 'a\n' > "$gw_home/.zshrc.local"
+printf 'b\n' > "$gw_home/.ssh/config.local"
+chmod 664 "$gw_home/.zshrc.local"
+gw_rc=0
+HOME="$gw_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+  backup --out "$gw_home/gw.age" --recipient "$recipient" --yes >/dev/null 2>&1 || gw_rc=$?
+if [[ "$gw_rc" -eq 0 ]] && HOME="$gw_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+  verify --in "$gw_home/gw.age" --identity "$fixture_home/keys/id.txt" >/dev/null 2>&1; then
+  gw_dst="$fixture_home/gw-restore"
+  mkdir -p "$gw_dst"
+  if HOME="$gw_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+    restore --in "$gw_home/gw.age" --identity "$fixture_home/keys/id.txt" \
+    --target-home "$gw_dst" --apply >/dev/null 2>&1 \
+    && [[ "$(mode_of "$gw_dst/.zshrc.local")" == "664" ]]; then
+    pass "group-writable file (664) survives backup/verify/restore with its mode"
+  else
+    miss "restored group-writable file lost its mode (want 664, got $(mode_of "$gw_dst/.zshrc.local" 2>/dev/null))"
+  fi
+else
+  miss "verify rejected an archive containing a group-writable file (umask regression)"
+fi
+
+# 20. Without --yes and without a TTY, backup must fail (non-zero) instead of
+#     reporting success while writing nothing (issue #141: unattended runs
+#     would otherwise silently never back up).
+ntty_home="$fixture_home/ntty"
+mkdir -p "$ntty_home/.ssh"
+printf 'a\n' > "$ntty_home/.zshrc.local"
+printf 'b\n' > "$ntty_home/.ssh/config.local"
+ntty_rc=0
+# perl setsid detaches from the controlling terminal so `read < /dev/tty`
+# inside the script fails; macOS ships no setsid(1), perl is on both OSes.
+ntty_out="$(HOME="$ntty_home" PATH="$fixture_home/fakebin:$PATH" \
+  perl -e 'use POSIX (); POSIX::setsid() != -1 or die "setsid: $!"; exec @ARGV or die "exec: $!"' \
+  -- "$PB" backup --out "$ntty_home/n.age" --recipient "$recipient" 2>&1 < /dev/null)" || ntty_rc=$?
+if [[ "$ntty_rc" -ne 0 && ! -f "$ntty_home/n.age" ]] \
+  && grep -Fq "no TTY for confirmation" <<< "$ntty_out"; then
+  pass "backup without --yes and without a TTY fails (no silent success)"
+else
+  printf '%s\n' "$ntty_out" >&2
+  miss "non-TTY backup without --yes should fail, got rc=$ntty_rc"
+fi
+
+# 21. Overlapping declarations (a dir and a file inside it) capture the file
+#     once: the manifest lists no duplicate paths (issue #141).
+dup_home="$fixture_home/dup"
+mkdir -p "$dup_home/.ssh" "$dup_home/.config/dotfiles" "$dup_home/nest"
+printf 'a\n' > "$dup_home/.zshrc.local"
+printf 'b\n' > "$dup_home/.ssh/config.local"
+printf 'c\n' > "$dup_home/nest/inner"
+printf 'backup_paths:\n  - { path: "nest", type: dir }\n  - { path: "nest/inner", type: file }\n' \
+  > "$dup_home/.config/dotfiles/backup-paths.local"
+if HOME="$dup_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+  backup --out "$dup_home/d.age" --recipient "$recipient" --yes >/dev/null 2>&1; then
+  dup_extract="$fixture_home/dup-extract"
+  mkdir -p "$dup_extract"
+  age -d -i "$fixture_home/keys/id.txt" "$dup_home/d.age" | tar -xpf - -C "$dup_extract"
+  dup_total="$(yq -p=json -o=tsv '.files | length' "$dup_extract/manifest.json")"
+  dup_unique="$(yq -p=json -o=tsv '[.files[].path] | unique | length' "$dup_extract/manifest.json")"
+  if [[ "$dup_total" == "$dup_unique" ]]; then
+    pass "overlapping dir+file declarations do not duplicate manifest entries"
+  else
+    miss "manifest lists duplicate paths ($dup_total entries, $dup_unique unique)"
+  fi
+else
+  miss "backup with overlapping declarations failed"
+fi
+
+# 22. An unreadable file is skipped with a warning; the backup still succeeds
+#     and captures the readable files (issue #141: set -e aborted the whole
+#     run mid-archive before).
+unr_home="$fixture_home/unr"
+mkdir -p "$unr_home/.ssh" "$unr_home/.config/dotfiles"
+printf 'a\n' > "$unr_home/.zshrc.local"
+printf 'b\n' > "$unr_home/.ssh/config.local"
+printf 'locked\n' > "$unr_home/locked"
+chmod 000 "$unr_home/locked"
+printf 'backup_paths:\n  - { path: "locked", type: file }\n' \
+  > "$unr_home/.config/dotfiles/backup-paths.local"
+unr_rc=0
+unr_out="$(HOME="$unr_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+  backup --out "$unr_home/u.age" --recipient "$recipient" --yes 2>&1)" || unr_rc=$?
+chmod 600 "$unr_home/locked" # so the EXIT trap can clean up
+if [[ "$unr_rc" -eq 0 && -f "$unr_home/u.age" ]] \
+  && grep -Fq "unreadable (skipped): locked" <<< "$unr_out"; then
+  pass "unreadable file is skipped with a warning, backup still succeeds"
+else
+  printf '%s\n' "$unr_out" >&2
+  miss "unreadable file should be skipped without aborting, got rc=$unr_rc"
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "private-backup tests passed"
 fi


### PR DESCRIPTION
Closes #141

## 変更(監査所見 4 件の correctness 修正)

1. **tar 展開に `-p`**(high): `-p` なしだと bsdtar が umask を適用し、group/other-writable(664/775)が 644/755 に化けて `check_manifest` のモード比較が正当なアーカイブを拒否(verify/restore 不能)。
2. **非 TTY confirm の偽成功**: `--yes` なし・TTY なしの backup が「aborted by user」で return 0 していた → 明示エラー + 非 0 に。対話で decline した場合も非 0 に変更(**意図的な契約変更**: アーカイブを書かなかった実行が成功を返さない。無人実行でバックアップ欠落が監視をすり抜けるのを防ぐ)。
3. **重複宣言の二重登録**: dir 配下でキャプチャしたファイルを `seen_paths` に登録し、dir+file の重なりで manifest `.files` が二重にならないように(restore の二重処理・カウント不正を解消)。
4. **読めないファイルで全体 abort**: `set -e` による途中 abort をやめ、skip+warn で他ファイルの backup を続行。

## テスト

新規 4 ケース(19〜22)。**mutation 検証済み**: 修正を stash した旧コードで 4 件とも fail、修正後 all pass(27 tests)。macOS(setsid なし → perl POSIX::setsid)と Linux CI の両対応。shellcheck -S warning 通過。

## 契約への影響

- exit code: backup の「確認で書かなかった」経路が 0 → 1 に(上記 2。report-only の doctor とは無関係)。
- verify/restore・manifest 形式・fail-closed 方針は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
