### PR TITLE
test-doctor: AGENT_TOOLS を隔離し fixture が実 checkout を解決しないようにする (#142)

### DIFF
--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -8,6 +8,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
 
+# The doctor resolves the agent-tools checkout from $AGENT_TOOLS (issue #71),
+# so a developer shell that exports it (the documented #71/#73 override)
+# would leak the real checkout into every fixture run below — the agent-tools
+# cases then execute the real status.sh and fail (issue #142). Unset it once
+# here; the AT-override case re-sets it explicitly for its own invocation.
+unset AGENT_TOOLS
+
 status=0
 fixture_home="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-doctor-test.XXXXXX")"
 trap 'rm -rf "$fixture_home"' EXIT


### PR DESCRIPTION
Closes #142

## 変更

`scripts/test-doctor.sh` 冒頭で `unset AGENT_TOOLS`(7 行、コメント含む)。

開発シェルが `AGENT_TOOLS` を export している(#71/#73 で文書化された正規の override)と、fixture の doctor 実行すべてが実 checkout を解決し、**実物の `status.sh` をテストが実行**して agent-tools 系 5 ケースが fail(rc=1)していた。CI は env が無いため緑 = 開発機でだけ常に赤、という状態の解消。AT-override ケース(:266 相当)は呼び出し時に明示 set しているため影響なし。

## 検証

- `AGENT_TOOLS=~/dev/agent-tools` が export された実機で: 修正前 rc=1(5 fail、2026-07-02 監査で実測)→ 修正後 all pass(実測)
- shellcheck -S warning 通過

## 対応しなかったこと(意図的)

付随所見の「catalog drift 実 probe による遅さ・マシン依存」(実測 93s)は本 PR では触らない(fixture PATH スタブ化は変更面が広く、テスト基盤 #149 / カバレッジ #150 の作業と重なるため別途)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
