### PR TITLE
lib+installer: installed-probe を一本化し SIGPIPE 偽陰性を修正 (#143)

### DIFF
--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -36,23 +36,30 @@ EOF
 
 # Whether NAME is already installed for SOURCE. canonical = pkg|name,
 # bincmd = bin|name. Read-only; a present entry is left untouched (no upgrade).
+# Probes via lib-policy's installed_inventory (the same one the doctor drift
+# report reads) and matches against the full capture: the previous
+# `probe | grep -Fxq` shape died of SIGPIPE under pipefail once grep exited
+# on the first hit, so installed casks/apps randomly read as absent and
+# --apply re-ran their installers (#143).
 is_installed() {
-  local source="$1" canonical="$2" bincmd="$3"
+  local source="$1" canonical="$2" bincmd="$3" inv=""
   case "$source" in
     brew_formula)
-      brew list --formula -1 2>/dev/null | grep -Fxq -- "$canonical" && return 0
+      inv="$(installed_inventory brew_formula)"
+      grep -Fxq -- "$canonical" <<< "$inv" && return 0
       command -v "$bincmd" >/dev/null 2>&1 ;;
     brew_cask)
-      brew list --cask -1 2>/dev/null | grep -Fxq -- "$canonical" ;;
+      inv="$(installed_inventory brew_cask)"
+      grep -Fxq -- "$canonical" <<< "$inv" ;;
     npm_global)
-      npm ls -g --depth=0 --json 2>/dev/null \
-        | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null \
-        | grep -Fxq -- "$canonical" && return 0
+      inv="$(installed_inventory npm_global)"
+      grep -Fxq -- "$canonical" <<< "$inv" && return 0
       command -v "$bincmd" >/dev/null 2>&1 ;;
     go_install)
       command -v "$bincmd" >/dev/null 2>&1 ;;
     mas)
-      mas list 2>/dev/null | awk '{print $1}' | grep -Fxq -- "$canonical" ;;
+      inv="$(installed_inventory mas)"
+      grep -Fxq -- "$canonical" <<< "$inv" ;;
     *) return 0 ;;
   esac
 }

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -283,6 +283,45 @@ profile_installs_source() {
 # excludes node-bundled npm globals (npm, corepack: runtime domain, like
 # node/go/uv), and is skipped for mas (the App Store carries many apps
 # unrelated to the dev catalog; flagging them all would be noise).
+
+# The go bin directory: GOBIN, falling back to GOPATH/bin. mise points GOBIN
+# at GOROOT/bin, which is why the toolchain binaries live next to installed
+# packages (see the go|gofmt guard below).
+go_bin_dir() {
+  local gobin
+  gobin="$(go env GOBIN 2>/dev/null || true)"
+  [[ -z "$gobin" ]] && gobin="$(go env GOPATH 2>/dev/null || true)/bin"
+  printf '%s' "$gobin"
+}
+
+# Full installed inventory for SOURCE, one id per line; empty when the
+# manager is absent or the probe fails (read-only, never errors). The single
+# probe implementation shared by the drift report below and the installer's
+# is_installed (#143) — before this they were duplicated and could disagree.
+#
+# Contract for callers: capture the WHOLE list (file or variable) and match
+# against the capture. Matching the producer directly (`probe | grep -q`)
+# dies of SIGPIPE under pipefail once grep exits on the first hit, so an
+# installed entry randomly reads as absent (#143).
+installed_inventory() {
+  local source="$1"
+  case "$source" in
+    brew_formula) brew list --formula -1 2>/dev/null || true ;;
+    brew_leaves) brew leaves 2>/dev/null || true ;;
+    brew_cask) brew list --cask -1 2>/dev/null || true ;;
+    npm_global)
+      npm ls -g --depth=0 --json 2>/dev/null \
+        | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null || true ;;
+    go_install)
+      local dir
+      dir="$(go_bin_dir)"
+      if [[ -n "$dir" && -d "$dir" ]]; then
+        find "$dir" -maxdepth 1 -type f -perm -u+x -exec basename {} \; 2>/dev/null || true
+      fi ;;
+    mas) mas list 2>/dev/null | awk '{print $1}' || true ;;
+  esac
+}
+
 report_catalog_drift() {
   if ! require_yq; then
     warn "yq unavailable; skipping catalog drift"
@@ -311,20 +350,20 @@ report_catalog_drift() {
     "$decl_go_bins"
   )
 
-  # Inventories (read-only). A failing probe leaves the list empty via
-  # `|| true`; per-source availability flags gate whether absence means
-  # "not installed" or "manager not present, skip".
+  # Inventories (read-only), one shared probe per source (installed_inventory
+  # above); a failing probe yields an empty list. Per-source availability
+  # flags gate whether absence means "not installed" or "manager not
+  # present, skip".
   local have_brew=0 have_npm=0 have_go=0 have_mas=0 gobin=""
   if command -v brew >/dev/null 2>&1; then
     have_brew=1
-    brew list --formula -1 2>/dev/null | sort > "$brew_formulae" || true
-    brew leaves 2>/dev/null | sort > "$brew_leaves" || true
-    brew list --cask -1 2>/dev/null | sort > "$brew_casks" || true
+    installed_inventory brew_formula | sort > "$brew_formulae"
+    installed_inventory brew_leaves | sort > "$brew_leaves"
+    installed_inventory brew_cask | sort > "$brew_casks"
   fi
   if command -v npm >/dev/null 2>&1; then
     have_npm=1
-    npm ls -g --depth=0 --json 2>/dev/null \
-      | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null \
+    installed_inventory npm_global \
       | grep -vxE 'npm|corepack' | sort > "$npm_globals" || true
   fi
   # A go-built binary persists in GOPATH/bin even if `go` is later removed,
@@ -333,16 +372,12 @@ report_catalog_drift() {
   # go cannot tell us where it is.
   if command -v go >/dev/null 2>&1; then
     have_go=1
-    gobin="$(go env GOBIN 2>/dev/null || true)"
-    [[ -z "$gobin" ]] && gobin="$(go env GOPATH 2>/dev/null || true)/bin"
-    if [[ -n "$gobin" && -d "$gobin" ]]; then
-      find "$gobin" -maxdepth 1 -type f -perm -u+x -exec basename {} \; 2>/dev/null \
-        | sort > "$go_bins" || true
-    fi
+    gobin="$(go_bin_dir)"
+    installed_inventory go_install | sort > "$go_bins"
   fi
   if command -v mas >/dev/null 2>&1; then
     have_mas=1
-    mas list 2>/dev/null | awk '{print $1}' | sort > "$mas_ids" || true
+    installed_inventory mas | sort > "$mas_ids"
   fi
 
   # Report which inventories were inspected. npm's global root differs by

--- a/scripts/test-install-packages.sh
+++ b/scripts/test-install-packages.sh
@@ -152,6 +152,54 @@ else
   pass "build_install_cmd rejects manual/unknown source"
 fi
 
+# 8. is_installed matches against the full inventory capture. Regression for
+#    the SIGPIPE false negative (#143): with the old `probe | grep -Fxq`
+#    shape, grep exits on the first hit, the still-writing producer takes
+#    SIGPIPE, and pipefail turns a found entry into "not installed" whenever
+#    the inventory is larger than the pipe buffer. The fakes put the target
+#    first and pad far past the buffer (64KiB) to make that deterministic.
+pad_lines="$(mktemp "$fixture_bin/pad.XXXXXX")"
+for _ in $(seq 1 4000); do
+  printf 'padding-entry-000000000000000000000000000000000000\n'
+done > "$pad_lines"
+# exec makes the fake process itself the pipe writer, so it dies of SIGPIPE
+# (141) exactly like the real manager would; a plain `cat` child would take
+# the signal while the sh wrapper still runs its final `exit 0`, masking the
+# failure the regression is about.
+cat > "$fixture_bin/brew" <<SH
+#!/bin/sh
+case "\$*" in
+  "list --cask -1") printf '%s\n' target-cask; exec cat "$pad_lines" ;;
+  "list --formula -1") printf '%s\n' target-formula; exec cat "$pad_lines" ;;
+esac
+exit 0
+SH
+cat > "$fixture_bin/mas" <<SH
+#!/bin/sh
+if [ "\$1" = "list" ]; then
+  printf '%s\n' '123456 Target App (1.0)'
+  exec awk '{print NR+1000000, \$0}' "$pad_lines"
+fi
+exit 0
+SH
+chmod +x "$fixture_bin/brew" "$fixture_bin/mas"
+check_installed() {
+  local src="$1" canonical="$2" label="$3"
+  if (PATH="$fixture_bin:$PATH" is_installed "$src" "$canonical" "no-such-bin"); then
+    pass "is_installed finds $label in a large inventory (no SIGPIPE false negative)"
+  else
+    miss "is_installed lost $label to the SIGPIPE false negative"
+  fi
+}
+check_installed brew_cask target-cask "a cask"
+check_installed brew_formula target-formula "a formula"
+check_installed mas 123456 "a mas app"
+if (PATH="$fixture_bin:$PATH" is_installed brew_cask absent-cask no-such-bin); then
+  miss "is_installed must not report an absent cask as installed"
+else
+  pass "is_installed still reports a genuinely absent cask as not installed"
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "install-packages tests passed"
 fi


### PR DESCRIPTION
Closes #143

## 変更

**バグ**: `is_installed` の `probe | grep -Fxq` は `set -o pipefail` 下で SIGPIPE 偽陰性を起こす(grep が先頭マッチで exit → 書き込み中の producer が 141 → インストール済み cask/mas/npm が「未インストール」扱い → `--apply` が再インストールを実行し「既 install には触れない」契約を破る)。

**構造**: 同じ「install 済みか」probe が installer と doctor drift で二重実装されていた(監査 B-2、Codex 議論で一本化を最優先と合意)。

- `lib-policy.sh`: `installed_inventory(source)` を新設(両者が使う単一 probe。capture-before-match 契約を関数コメントに明記)+ `go_bin_dir()`(drift のラベルと共用)
- `install-packages.sh`: full capture に対して match する形へ
- `report_catalog_drift`: probe を `installed_inventory` 経由に(挙動不変。npm の node-bundled filter と sort は呼び出し側に残す)

## テスト

fake brew/mas が「マッチを先頭に出してから `exec` で 64KiB 超を書く」構成で SIGPIPE を決定的に再現。**mutation 検証済み**: 旧 is_installed で 3 ケースとも fail → 新コードで all pass。`exec` が肝(child の cat が signal を受けると sh wrapper の exit 0 が握りつぶす — fake 自身が pipeline メンバーになる必要がある)。

回帰確認: test-policy(drift 4 ケース含む)/ test-install-packages 全 pass、実機 doctor `no catalog drift`・installer dry-run `27 skipped`、shellcheck 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
