### PR TITLE
doctor+lib: npm broken 時も report-only を維持・pushurl credential スキャン (#144)

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -114,8 +114,12 @@ if [[ "$npm_mode" == "off" ]]; then
   ok "npm hardening intentionally unmanaged"
 elif ! command -v npm >/dev/null 2>&1; then
   warn "npm not found"
+elif ! npm_version="$(npm --version 2>/dev/null)" || [[ -z "$npm_version" ]]; then
+  # A mise shim resolves on PATH even when no node runtime is installed; the
+  # unguarded probe used to kill the whole doctor here via set -e, breaking
+  # the report-only contract (#144).
+  warn "npm on PATH but not runnable (shim without a runtime?); skipping npm checks"
 else
-  npm_version="$(npm --version)"
   ok "npm: $npm_version"
   for key in before ignore-scripts save-exact fund audit userconfig globalconfig; do
     value="$(npm config get "$key" 2>/dev/null || true)"
@@ -123,7 +127,12 @@ else
   done
   npm_major="${npm_version%%.*}"
   npm_minor="$(printf '%s' "$npm_version" | cut -d. -f2)"
-  if [[ "$npm_major" -gt 11 || ( "$npm_major" -eq 11 && "$npm_minor" -ge 10 ) ]] 2>/dev/null; then
+  # Guard before the arithmetic test: [[ -gt ]] evaluates its operands as
+  # arithmetic, so a non-numeric component resolves as a variable name and
+  # aborts the shell under set -u (the old 2>/dev/null hid even that) (#144).
+  if [[ ! "$npm_major" =~ ^[0-9]+$ || ! "$npm_minor" =~ ^[0-9]+$ ]]; then
+    warn "npm version '$npm_version' not recognized; cannot check min-release-age support"
+  elif [[ "$npm_major" -gt 11 || ( "$npm_major" -eq 11 && "$npm_minor" -ge 10 ) ]]; then
     ok "npm supports min-release-age (>= 11.10)"
   else
     warn "npm older than 11.10, min-release-age is not enforced"

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -656,15 +656,18 @@ require_secrets_access() {
 }
 
 # Print names of remotes whose URL embeds password-like userinfo
-# (scheme://user:password@host). URL values are never printed.
+# (scheme://user:password@host). Covers pushurl too — a credential can hide
+# in remote.<name>.pushurl with a clean fetch url (#144). Each remote is
+# printed once even when both url and pushurl are flagged. URL values are
+# never printed.
 git_remotes_with_credentials() {
   local repo="$1"
-  git -C "$repo" config --local --get-regexp '^remote\..*\.url$' 2>/dev/null |
+  git -C "$repo" config --local --get-regexp '^remote\..*\.(url|pushurl)$' 2>/dev/null |
     awk '$2 ~ /:\/\/[^\/@]*:[^\/@]+@/ {
       name = $1
       sub(/^remote\./, "", name)
-      sub(/\.url$/, "", name)
-      print name
+      sub(/\.(url|pushurl)$/, "", name)
+      if (!seen[name]++) print name
     }'
 }
 

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -587,6 +587,51 @@ else
   status=1
 fi
 
+# NPM-A) A broken npm (shim without a runtime) must not kill the doctor:
+# report-only means warn + skip, exit 0 (#144).
+npm_fakebin="$fixture_home/npmfake"
+mkdir -p "$npm_fakebin"
+cat > "$npm_fakebin/npm" <<'SH'
+#!/bin/sh
+exit 1
+SH
+chmod +x "$npm_fakebin/npm"
+if np_out="$(HOME="$fixture_home" PATH="$npm_fakebin:$PATH" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "npm on PATH but not runnable" <<< "$np_out"; then
+    ok "test passed: broken npm is warned and skipped, doctor stays exit 0"
+  else
+    printf '%s\n' "$np_out" >&2
+    fail "test failed: broken npm should be reported as not runnable"
+    status=1
+  fi
+else
+  printf '%s\n' "$np_out" >&2
+  fail "test failed: doctor must stay exit 0 with a broken npm on PATH"
+  status=1
+fi
+
+# NPM-B) A non-numeric npm version must not abort the min-release-age
+# arithmetic ([[ -gt ]] resolves non-numeric operands as variable names and
+# dies under set -u); expect a warn and exit 0 (#144).
+cat > "$npm_fakebin/npm" <<'SH'
+#!/bin/sh
+if [ "$1" = "--version" ]; then printf 'not-a-version\n'; exit 0; fi
+exit 0
+SH
+if np_out="$(HOME="$fixture_home" PATH="$npm_fakebin:$PATH" "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "npm version 'not-a-version' not recognized" <<< "$np_out"; then
+    ok "test passed: unrecognized npm version is warned, doctor stays exit 0"
+  else
+    printf '%s\n' "$np_out" >&2
+    fail "test failed: unrecognized npm version should be warned"
+    status=1
+  fi
+else
+  printf '%s\n' "$np_out" >&2
+  fail "test failed: doctor must stay exit 0 with an unrecognized npm version"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "doctor tests passed"
 fi

--- a/scripts/test-gitconfig.sh
+++ b/scripts/test-gitconfig.sh
@@ -307,6 +307,32 @@ else
   status=1
 fi
 
+# A credential hiding in pushurl with a clean fetch url must be flagged too
+# (#144: the scan matched only remote.*.url and pushurl slipped through).
+mkdir -p "$fixture/src/personal/pushurl-demo"
+run_git "$fixture/src/personal/pushurl-demo" init --quiet --initial-branch=main
+run_git "$fixture/src/personal/pushurl-demo" config remote.origin.url "https://invalid.example/repo.git"
+run_git "$fixture/src/personal/pushurl-demo" config remote.origin.pushurl "https://user:secret-placeholder@invalid.example/repo.git"
+
+flagged="$(git_remotes_with_credentials "$fixture/src/personal/pushurl-demo")"
+if [[ "$flagged" == "origin" ]]; then
+  ok "test passed: credential-like pushurl detected (clean fetch url)"
+else
+  fail "test failed: expected flagged remote 'origin' via pushurl, got: ${flagged:-<none>}"
+  status=1
+fi
+
+# Both url and pushurl carrying credentials still report the remote once.
+run_git "$fixture/src/personal/pushurl-demo" config remote.origin.url "https://user:secret-placeholder@invalid.example/repo.git"
+
+flagged="$(git_remotes_with_credentials "$fixture/src/personal/pushurl-demo")"
+if [[ "$flagged" == "origin" ]]; then
+  ok "test passed: url+pushurl credentials report the remote once"
+else
+  fail "test failed: expected single 'origin', got: ${flagged:-<none>}"
+  status=1
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "gitconfig tests passed"
 fi


### PR DESCRIPTION
Closes #144

## 変更(doctor の report-only 契約を守る堅牢化 3 件)

1. **npm 即死**(medium): mise シムだけ在って runtime が無い環境で、無保護の `npm --version` が `set -e` で doctor 全体を殺していた(「warnings never change the exit code」契約違反)→ probe をガードし warn + skip。
2. **非数値バージョンの算術 abort**(low): `[[ -gt ]]` は被演算子を算術評価するため、非数値だと変数名解決 → `set -u` で shell abort(旧 `2>/dev/null` がそのエラーも隠蔽)→ 数値ガードを前置。
3. **pushurl スキャン漏れ**(low): `git_remotes_with_credentials` が `remote.*.url` のみ match し、pushurl に埋まった credential を見逃していた → `(url|pushurl)` に拡張、両方該当でも remote は 1 回だけ報告。

## テスト(mutation 検証済み)

- broken npm / 非数値 version の doctor ケース: **旧コードで両方 exit 1 → 修正後 exit 0 + warn**(非数値 abort は本機 bash で実再現)
- pushurl のみ credential: **旧コードで検出漏れ(fail)→ 修正後検出**
- url+pushurl 両方 → 単一報告(新実装の dedup ガード)
- test-doctor / test-gitconfig / test-npmrc(doctor ソース整合 grep 含む)all pass、shellcheck 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
