### PR TITLE
tests: fail-closed な fixture helper を抽出し awk flip の vacuous-pass を解消 (#149)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,6 +63,13 @@ remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検�
 
 policy validation が失敗した場合は exit 1。
 
+## test-lib.sh
+
+test-*.sh が共有する fixture 編集 helper(source 専用、lib-policy.sh の後に source する)。
+`set_capability_all` / `remove_module_all` が fixture の profiles.yaml を yq で構造的に
+編集し、対象が存在しなければ fail する(行形式一致の awk 直書きが無言で no-op 化して
+テストが vacuous pass する事故の再発防止。#149)。
+
 ## test-policy.sh
 
 外部 test framework を使わずに policy validation の fail-closed 挙動を検証する。

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 # The doctor resolves the agent-tools checkout from $AGENT_TOOLS (issue #71),
 # so a developer shell that exports it (the documented #71/#73 override)
@@ -103,9 +105,7 @@ optout_root="$fixture_home/.dotfiles-optout"
 mkdir -p "$optout_root/.chezmoidata"
 cp -R "$DOTFILES_ROOT/scripts" "$optout_root/scripts"
 cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$optout_root/.chezmoidata/"
-awk '$0 == "      enableAgentToolsStatus: true" { print "      enableAgentToolsStatus: false"; next } { print }' \
-  "$optout_root/.chezmoidata/profiles.yaml" > "$optout_root/.chezmoidata/profiles.yaml.tmp"
-mv "$optout_root/.chezmoidata/profiles.yaml.tmp" "$optout_root/.chezmoidata/profiles.yaml"
+set_capability_all "$optout_root" enableAgentToolsStatus false
 rm -f "$agent_marker"
 if at_out="$(HOME="$fixture_home" "$optout_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "status read disabled" <<< "$at_out" && [[ ! -e "$agent_marker" ]]; then
@@ -127,9 +127,7 @@ optin_root="$fixture_home/.dotfiles-optin"
 mkdir -p "$optin_root/.chezmoidata"
 cp -R "$DOTFILES_ROOT/scripts" "$optin_root/scripts"
 cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$optin_root/.chezmoidata/"
-awk '$0 == "      enableAgentToolsStatus: false" { print "      enableAgentToolsStatus: true"; next } { print }' \
-  "$optin_root/.chezmoidata/profiles.yaml" > "$optin_root/.chezmoidata/profiles.yaml.tmp"
-mv "$optin_root/.chezmoidata/profiles.yaml.tmp" "$optin_root/.chezmoidata/profiles.yaml"
+set_capability_all "$optin_root" enableAgentToolsStatus true
 
 # B) Opt-in enabled: status.sh runs, summary shown, conflict flagged.
 rm -f "$agent_marker"
@@ -391,9 +389,7 @@ cp -R "$DOTFILES_ROOT/scripts" "$sign_root/scripts"
 cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$sign_root/.chezmoidata/"
 
 # L) enableGitSigning=true with the git-signing module active -> managed mechanism.
-awk '$0 == "      enableGitSigning: false" { print "      enableGitSigning: true"; next } { print }' \
-  "$sign_root/.chezmoidata/profiles.yaml" > "$sign_root/.chezmoidata/profiles.yaml.tmp"
-mv "$sign_root/.chezmoidata/profiles.yaml.tmp" "$sign_root/.chezmoidata/profiles.yaml"
+set_capability_all "$sign_root" enableGitSigning true
 if sg_out="$(HOME="$fixture_home" "$sign_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "SSH signing mechanism managed" <<< "$sg_out"; then
     ok "test passed: enableGitSigning=true reports the managed signing mechanism"
@@ -410,9 +406,7 @@ fi
 
 # M) enableGitSigning=true but the git-signing module removed -> dangling warning,
 #    still exit 0.
-awk '$0 == "      - git-signing" { next } { print }' \
-  "$sign_root/.chezmoidata/profiles.yaml" > "$sign_root/.chezmoidata/profiles.yaml.tmp"
-mv "$sign_root/.chezmoidata/profiles.yaml.tmp" "$sign_root/.chezmoidata/profiles.yaml"
+remove_module_all "$sign_root" git-signing
 if sg_out="$(HOME="$fixture_home" "$sign_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "git-signing module is inactive" <<< "$sg_out"; then
     ok "test passed: enableGitSigning=true with module inactive is reported as dangling"
@@ -454,9 +448,7 @@ fi
 
 # O) enable1PasswordSSH=true but the ssh-1password module removed -> dangling
 #    warning, still exit 0.
-awk '$0 == "      - ssh-1password" { next } { print }' \
-  "$ssh_root/.chezmoidata/profiles.yaml" > "$ssh_root/.chezmoidata/profiles.yaml.tmp"
-mv "$ssh_root/.chezmoidata/profiles.yaml.tmp" "$ssh_root/.chezmoidata/profiles.yaml"
+remove_module_all "$ssh_root" ssh-1password
 if ss_out="$(HOME="$fixture_home" "$ssh_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "ssh-1password module is inactive" <<< "$ss_out"; then
     ok "test passed: enable1PasswordSSH=true with module inactive is reported as dangling"
@@ -543,11 +535,8 @@ rm -f "$fixture_home/.config/dotfiles/github-trust.local"
 # Q) gateGitHubMcp=true (claude-settings active for personal) -> reported as
 #    enforced (MCP deny in managed settings), NOT as not-wired. enableGitHubIsolatedReader
 #    flipped too -> still reported as Phase 3 / not enforced. exit 0.
-awk '$0 == "      gateGitHubMcp: false" { print "      gateGitHubMcp: true"; next }
-     $0 == "      enableGitHubIsolatedReader: false" { print "      enableGitHubIsolatedReader: true"; next }
-     { print }' \
-  "$gh_root/.chezmoidata/profiles.yaml" > "$gh_root/.chezmoidata/profiles.yaml.tmp"
-mv "$gh_root/.chezmoidata/profiles.yaml.tmp" "$gh_root/.chezmoidata/profiles.yaml"
+set_capability_all "$gh_root" gateGitHubMcp true
+set_capability_all "$gh_root" enableGitHubIsolatedReader true
 if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "denies the github MCP server" <<< "$gh_out" \
     && grep -Fq "isolated reader is not wired yet" <<< "$gh_out"; then
@@ -568,10 +557,7 @@ fi
 #    floor active too. Covers the other branch; case P covered the inert
 #    (enforceAiSandbox=false) branch. Builds on case Q's mutated copy
 #    (claude-settings active for personal). exit 0.
-awk '$0 == "      enforceAiSandbox: false" { print "      enforceAiSandbox: true"; next }
-     { print }' \
-  "$gh_root/.chezmoidata/profiles.yaml" > "$gh_root/.chezmoidata/profiles.yaml.tmp"
-mv "$gh_root/.chezmoidata/profiles.yaml.tmp" "$gh_root/.chezmoidata/profiles.yaml"
+set_capability_all "$gh_root" enforceAiSandbox true
 if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "human-legit write gate active" <<< "$gh_out" \
     && grep -Fq "secret floor active" <<< "$gh_out"; then

--- a/scripts/test-lib.sh
+++ b/scripts/test-lib.sh
@@ -27,9 +27,16 @@ set_capability_all() {
     fail "set_capability_all: missing $file"
     return 1
   fi
-  local declared
+  # Two separate probes on purpose: combining them with yq's `and` mis-parses
+  # (pipe binds loosest, the has-check leaks out of the conjunction). The
+  # count probe guards the vacuous-true case — `[] | all` is true, so an
+  # empty/missing profiles map would otherwise pass the has-check and the
+  # assignment below would silently no-op, the same failure mode this helper
+  # exists to prevent (Codex review, #149).
+  local count declared
+  count="$(yq '.profiles // {} | length' "$file")"
   declared="$(C="$cap" yq '[.profiles[].capabilities | has(strenv(C))] | all' "$file")"
-  if [[ "$declared" != "true" ]]; then
+  if [[ -z "$count" || "$count" == "0" || "$declared" != "true" ]]; then
     fail "set_capability_all: capability '$cap' is not declared by every profile in $file"
     return 1
   fi

--- a/scripts/test-lib.sh
+++ b/scripts/test-lib.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+# Shared helpers for the scripts/test-*.sh suite. Source this AFTER
+# lib-policy.sh (it uses the ok/fail reporters). Source-only, not executable.
+#
+# Why these exist (#149): capability flips previously used raw
+# `awk '$0 == "      cap: false" ...'` full-line matching copied into each
+# test. Unlike insert_once/replace_once, those copies had no
+# `END { if (!done) exit 1 }` guard, so any change to the profiles.yaml line
+# shape (indent, key rename) silently turned the flip into a no-op — and the
+# following assertion kept passing against the UNFLIPPED fixture (vacuous
+# pass). Notably the "must not be forbidden" polarity regressions for
+# enforceAiSandbox / gateGitHubMcp were in that fail-open shape. These
+# helpers edit the YAML structurally via yq and fail closed when the target
+# does not exist.
+
+# set_capability_all ROOT CAP VALUE
+# Set CAP to VALUE for every profile in ROOT/.chezmoidata/profiles.yaml.
+# All-profiles on purpose: the flip sites want fixtures independent of any
+# profile's real default (and of which profile is listed first). VALUE is
+# parsed as YAML, so true/false stay booleans and enum values stay strings.
+# Fails when any profile does not declare CAP (a typo'd capability would
+# otherwise no-op silently — the exact failure mode this replaces).
+set_capability_all() {
+  local root="$1" cap="$2" value="$3"
+  local file="$root/.chezmoidata/profiles.yaml"
+  if [[ ! -f "$file" ]]; then
+    fail "set_capability_all: missing $file"
+    return 1
+  fi
+  local declared
+  declared="$(C="$cap" yq '[.profiles[].capabilities | has(strenv(C))] | all' "$file")"
+  if [[ "$declared" != "true" ]]; then
+    fail "set_capability_all: capability '$cap' is not declared by every profile in $file"
+    return 1
+  fi
+  C="$cap" V="$value" yq -i '.profiles[].capabilities[strenv(C)] = env(V)' "$file"
+}
+
+# remove_module_all ROOT MODULE
+# Remove MODULE from every profile's modules list in
+# ROOT/.chezmoidata/profiles.yaml. Fails when no profile lists MODULE (a
+# typo would otherwise no-op silently).
+remove_module_all() {
+  local root="$1" module="$2"
+  local file="$root/.chezmoidata/profiles.yaml"
+  if [[ ! -f "$file" ]]; then
+    fail "remove_module_all: missing $file"
+    return 1
+  fi
+  local count
+  count="$(M="$module" yq '[.profiles[].modules[] | select(. == strenv(M))] | length' "$file")"
+  if [[ -z "$count" || "$count" == "0" ]]; then
+    fail "remove_module_all: module '$module' is not listed by any profile in $file"
+    return 1
+  fi
+  M="$module" yq -i 'del(.profiles[].modules[] | select(. == strenv(M)))' "$file"
+}

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 tmp_roots=()
 
@@ -369,9 +371,7 @@ run_fail_contains \
 # profiles) still validates; a regression that forbade it would hard-fail the
 # work profiles here.
 make_fixture
-awk '$0 == "      enforceAiSandbox: false" { print "      enforceAiSandbox: true"; next } { print }' \
-  "$fixture/.chezmoidata/profiles.yaml" > "$fixture/.chezmoidata/profiles.yaml.tmp"
-mv "$fixture/.chezmoidata/profiles.yaml.tmp" "$fixture/.chezmoidata/profiles.yaml"
+set_capability_all "$fixture" enforceAiSandbox true
 run_ok \
   "enforceAiSandbox=true is allowed for every environmentKind (not forbidden)" \
   "$fixture/scripts/validate-policy.sh" --all
@@ -381,14 +381,26 @@ run_ok \
 # either: a restrictive kind (work) may set them true. Flip both across every
 # profile and assert --all still validates.
 make_fixture
-awk '$0 == "      gateGitHubMcp: false" { print "      gateGitHubMcp: true"; next }
-     $0 == "      enableGitHubIsolatedReader: false" { print "      enableGitHubIsolatedReader: true"; next }
-     { print }' \
-  "$fixture/.chezmoidata/profiles.yaml" > "$fixture/.chezmoidata/profiles.yaml.tmp"
-mv "$fixture/.chezmoidata/profiles.yaml.tmp" "$fixture/.chezmoidata/profiles.yaml"
+set_capability_all "$fixture" gateGitHubMcp true
+set_capability_all "$fixture" enableGitHubIsolatedReader true
 run_ok \
   "GitHub guard capabilities are allowed for every environmentKind (not forbidden)" \
   "$fixture/scripts/validate-policy.sh" --all
+
+# The fixture helpers themselves must fail closed: a typo'd capability or
+# module silently no-oped in the old awk shape, leaving the following
+# assertion to pass against an unflipped fixture (#149).
+make_fixture
+if set_capability_all "$fixture" noSuchCapability true 2>/dev/null; then
+  fail "test failed: set_capability_all must reject an undeclared capability"
+  exit 1
+fi
+ok "test passed: set_capability_all fails closed on an undeclared capability"
+if remove_module_all "$fixture" no-such-module 2>/dev/null; then
+  fail "test failed: remove_module_all must reject an unlisted module"
+  exit 1
+fi
+ok "test passed: remove_module_all fails closed on an unlisted module"
 
 # Anchor on the LAST capability line so the bogus section lands after the whole
 # capabilities block (update this if a later capability is added below).

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -401,6 +401,15 @@ if remove_module_all "$fixture" no-such-module 2>/dev/null; then
   exit 1
 fi
 ok "test passed: remove_module_all fails closed on an unlisted module"
+# An empty profiles map must fail too: `[] | all` is vacuously true in yq,
+# so without the length guard the helper would "succeed" while setting
+# nothing (Codex review, #149).
+printf 'profiles: {}\n' > "$fixture/.chezmoidata/profiles.yaml"
+if set_capability_all "$fixture" enforceAiSandbox true 2>/dev/null; then
+  fail "test failed: set_capability_all must reject an empty profiles map"
+  exit 1
+fi
+ok "test passed: set_capability_all fails closed on an empty profiles map"
 
 # Anchor on the LAST capability line so the bogus section lands after the whole
 # capabilities block (update this if a later capability is added below).

--- a/scripts/test-secrets-gate.sh
+++ b/scripts/test-secrets-gate.sh
@@ -125,21 +125,19 @@ fi
 rm -f "$fixture_bin/chezmoi"
 
 # 5. Consistency with the live host, only when chezmoi can resolve a
-#    profile (skipped in CI). The gate's verdict must match the pure check
-#    for whatever profile the machine actually runs — never more permissive.
+#    profile (skipped in CI). The gate's verdict must match the declared
+#    allowSecretsAccess literal read straight from profiles.yaml — an
+#    expectation independent of the lib's own check. (The previous version
+#    compared require_secrets_access against profile_allows_secrets_access,
+#    which the gate calls internally: f(x)==f(x), it could never fail. #149)
 if resolved="$(resolve_runtime_profile 2>/dev/null)"; then
-  if require_secrets_access >/dev/null 2>&1; then
-    if profile_allows_secrets_access "$resolved"; then
-      pass "gate agrees with profile '$resolved' (granted)"
-    else
-      miss "gate granted access but profile '$resolved' should be denied"
-    fi
+  declared="$(P="$resolved" yq '.profiles[strenv(P)].capabilities.allowSecretsAccess' "$PROFILES_FILE")"
+  if require_secrets_access >/dev/null 2>&1; then verdict="granted"; else verdict="denied"; fi
+  if { [[ "$declared" == "true" && "$verdict" == "granted" ]]; } \
+    || { [[ "$declared" != "true" && "$verdict" == "denied" ]]; }; then
+    pass "gate $verdict matches declared allowSecretsAccess=$declared for live profile '$resolved'"
   else
-    if profile_allows_secrets_access "$resolved"; then
-      miss "gate refused but profile '$resolved' should be granted"
-    else
-      pass "gate agrees with profile '$resolved' (denied)"
-    fi
+    miss "gate $verdict but profiles.yaml declares allowSecretsAccess=$declared for '$resolved'"
   fi
 else
   item "chezmoi did not resolve a profile; skipping live consistency check"


### PR DESCRIPTION
Closes #149

## 変更

**問題**: capability flip が素の awk 完全一致行置換で 8 サイトにコピペされ、`insert_once`/`replace_once` が持つ `END { if (!done) exit 1 }` の fail-closed が無かった。profiles.yaml の行形式が変わると flip が**無言で no-op** になり、後続 assert は未 flip の fixture に対して恒久 pass(vacuous pass)。enforceAiSandbox / gateGitHubMcp の「forbidden 表に入れてはいけない」security 回帰テストがこの形だった。

- **`scripts/test-lib.sh`(新規、source 専用)**: `set_capability_all` / `remove_module_all`。yq で構造的に編集し、対象の capability/module が存在しなければ fail(typo が no-op でなくテスト失敗になる)。全 profile 一括のセマンティクスは意図的(置換した全サイトが「実デフォルト非依存の fixture」を求めていた — 各サイトのコメントで確認済み)
- **test-policy(2)+ test-doctor(6)**: awk サイトを 1:1 置換。helper 自体の fail-closed 契約を自己テスト 2 本で回帰固定
- **test-secrets-gate case 5**: `require_secrets_access` を、それが内部で呼ぶ `profile_allows_secrets_access` と比較する f(x)==f(x) トートロジーだった → profiles.yaml の `allowSecretsAccess` リテラルを yq で直読みした独立期待値との比較に変更
- **scripts/README.md**: test-lib.sh の項を追加

## 検証

test-policy(48 tests、新自己テスト 2 本含む)/ test-doctor(全ケース)/ test-secrets-gate すべて green。yq 式(dynamic key set / has 検査 / module del)は単体で動作確認済み。shellcheck 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
