### PR TITLE
docs: 2026-07-02 監査で検出した陳腐化の一括修正 (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,20 @@ personal project として段階的に作っている。現時点の実装状況
 | Git identity 分離(context 別、fail-closed) | 実装済み・実機適用済み |
 | policy / capabilities / profile 検証(fail-closed) | 実装済み |
 | environmentKind による capability 制約の強制 | 実装済み |
-| supply-chain(git credential scan / npm hardening / Corepack policy) | 実装済み(npm は未適用) |
-| project templates / mise runtime | 実装済み(未適用) |
+| supply-chain(git credential scan / npm hardening / Corepack policy) | 実装済み・実機適用済み(#91) |
+| project templates / mise runtime | 実装済み・実機適用済み(mise) |
 | doctor / preflight(report-only の健康診断) | 実装済み |
-| agent-tools との report-only 連携 | 実装済み(opt-in) |
-| zsh(shell-extra)の管理 | 実装済み(未適用) |
-| Claude Code settings(personal の public-safe な settings.json) | 実装済み(personal のみ) |
+| software catalog + install action(dry-run 既定) | 実装済み・運用中(#53) |
+| private backup(age 暗号化・verify/restore) | 実装済み・運用中(#60) |
+| agent-tools との report-only 連携 | 実装済み(personal で opt-in 済み、#73) |
+| zsh(shell-extra)+ starship の管理 | 実装済み・実機適用済み(#96) |
+| Claude Code settings(personal の public-safe な settings.json) | 実装済み・実機適用済み(personal のみ) |
+| Git signing(SSH 署名 + 1Password、opt-in) | 実装済み・実機適用済み(#85/#97) |
 | VS Code settings の管理 | 管理しない(VS Code 未使用のため見送り、#16) |
-| SSH(ssh-1password)の管理 | 実装済み(未適用、personal のみ) |
+| SSH(ssh-1password)の管理 | 実装済み・実機適用済み(personal のみ、#17/#121) |
+| GitHub injection 防御(secret floor / MCP deny、steering) | Phase 2 まで実機適用済み(hard 層は #131) |
 
-「実機適用済み」は、現時点でこの author の Mac 上で `~/.gitconfig` が稼働しているという意味。zsh は chezmoi 管理に載せたが未適用。VS Code は未使用のため管理しない(capability OFF・配線は dormant、#16)。SSH は public-safe な骨格を personal で管理する形で実装したが未適用(既存 `~/.ssh/config` からの移行手順は [docs/ssh.md](docs/ssh.md)、#17)。
+「実機適用済み」は、現時点でこの author の Mac 上で managed file が実際に稼働しているという意味(managed-by header を doctor が確認できる)。VS Code は未使用のため管理しない(capability OFF・配線は dormant、#16)。SSH の移行手順は [docs/ssh.md](docs/ssh.md)。
 
 ## 考え方
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ personal project として段階的に作っている。現時点の実装状況
 | SSH(ssh-1password)の管理 | 実装済み・実機適用済み(personal のみ、#17/#121) |
 | GitHub injection 防御(secret floor / MCP deny、steering) | Phase 2 まで実機適用済み(hard 層は #131) |
 
-「実機適用済み」は、現時点でこの author の Mac 上で managed file が実際に稼働しているという意味(managed-by header を doctor が確認できる)。VS Code は未使用のため管理しない(capability OFF・配線は dormant、#16)。SSH の移行手順は [docs/ssh.md](docs/ssh.md)。
+「実機適用済み」は、現時点でこの author の Mac 上で managed file が実際に稼働しているという意味(実機の状態は repo からは検証できないので、この列は運用記録。repo 側で機械検証されるのは managed template と render / test の整合まで)。VS Code は未使用のため管理しない(capability OFF・配線は dormant、#16)。SSH の移行手順は [docs/ssh.md](docs/ssh.md)。
 
 ## 考え方
 

--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -200,8 +200,8 @@ personal の `gateGitHubMcp` を true** に反転し、github MCP deny を live 
   read path・別経路の MCP・subagent のギャップ(PreToolUse 不発 [anthropics/claude-code#21460])
   で迂回しうる。
 - context-gated な write(他人由来の untrusted が無い clean なときだけ comment / label /
-  PR create / push を自律許可)は **Phase 2 の PreToolUse hook** が要るため Phase 1 には
-  **無い**(意図的)。
+  PR create / push を自律許可)は **PreToolUse hook 本体**が要るため、まだ**無い**(意図的。
+  hook 本体は Phase 2 から Phase 3 [#131] へ hand-off 済み)。
 - egress は `enforceAiSandbox` の network allowlist = **hostname best-effort**(TLS 終端せず、
   DNS exfil は素通り。上の sandbox 節)。
 - **Phase 1 には trifecta(untrusted 読取 × secret × egress)を構造的に断つ hard 層が無い**。

--- a/docs/ai-policy.md
+++ b/docs/ai-policy.md
@@ -53,8 +53,10 @@ trust の基点は `is_self`(自分の login + id)のみで、collaborator / bot
 untrusted。
 
 下記の read / write 規則は **目標方針(policy intent)であって、現状の enforcement ではない**。
-Phase 1 で実際に効くのは末尾が指す best-effort / steering 層だけで、context-gated な write は
-Phase 2、trifecta を断つ hard 層は Phase 2 / 3(射程と限界は
+Phase 1 / 2 で実際に効いているのは steering 層と、Phase 2 で live 化した secret floor
+(never-legit な secret 読取の無条件 hard deny)+ `gateGitHubMcp` の `mcp__github` deny まで。
+context-gated な write(PreToolUse hook 本体)と trifecta を断つ hard 層(隔離 reader /
+token 隔離 / OS egress)は Phase 3(#131)へ hand-off 済み(射程と限界は
 [ai-environment-boundary](ai-environment-boundary.md))。
 
 - **read**: 自分の本文 = allow / 他人 = metadata only(title も入れない)/ 他人のコメント =

--- a/docs/claude-settings.md
+++ b/docs/claude-settings.md
@@ -14,6 +14,7 @@ tool-specific config template(agent-tools 側の責務)とは別物
 | 対象 | 置き場所 | 管理 |
 | --- | --- | --- |
 | personal・public-safe な `settings.json`(model / effort / public plugin / 通知 / statusLine / tui / workflow 警告抑止 等の global preference) | public repo(`dot_claude/settings.json.tmpl`) | ✅ chezmoi(**personal profile のみ**) |
+| permission ブロック(#119): secret floor の無条件 deny 9 件(`~/.ssh` 読取 / env dump / gh secret 系)、`gateGitHubMcp` の `mcp__github` deny、`allow: mcp__pencil`、`enforceAiSandbox` 連動の human-legit gate | 同上(template が capability で gate して出力) | ✅ chezmoi(内容の回帰は `test-claude-settings.sh` が exact-set で固定) |
 | personal・機密(secret を含む設定など) | `~/.claude/settings.local.json` | ❌ 非コミット・管理外 |
 | work / client の settings | 暗号化バックアップ(#60)か各マシン手設定 | ❌ public repo に生値を置かない |
 | skill / instruction(`skills/`、`agent-tools/CLAUDE.md`) | agent-tools が配布 | ❌ 別 repo の責務 |
@@ -65,6 +66,18 @@ permission 承認は対象外。
 module loop が、module を持たない profile(work-minimal / work-dev)では `.claude` を
 **ディレクトリごと** ignore する。`scripts/test-render.sh` が profile 別の managed set で
 この gate を回帰固定している。
+
+## permissions(#119: secret floor / GitHub guard)
+
+`permissions.deny` には capability 非依存の **secret floor**(never-legit な secret 読取
+9 件: `Read(~/.ssh/**)` / `Bash(cat ~/.ssh/*)` / `gh secret` / `gh api *secrets*` /
+`env` / `printenv` 系)を常時出力する。`gateGitHubMcp=true`(personal 既定)で
+`mcp__github`(server 全体)の deny、`enforceAiSandbox=true` で human-legit gate
+(`.env` 読取 / main・master への push の deny、release / branch-protection の ask)を
+追加する。`permissions.allow` は `mcp__pencil` のみ。これらは **steering であって
+enforcement boundary ではない**(射程と限界は
+[ai-environment-boundary](ai-environment-boundary.md))。deny の内容と順序は
+`scripts/test-claude-settings.sh` が exact-set で回帰固定している。
 
 ## sandbox(`enforceAiSandbox`)
 

--- a/docs/claude-settings.md
+++ b/docs/claude-settings.md
@@ -14,7 +14,7 @@ tool-specific config template(agent-tools 側の責務)とは別物
 | 対象 | 置き場所 | 管理 |
 | --- | --- | --- |
 | personal・public-safe な `settings.json`(model / effort / public plugin / 通知 / statusLine / tui / workflow 警告抑止 等の global preference) | public repo(`dot_claude/settings.json.tmpl`) | ✅ chezmoi(**personal profile のみ**) |
-| permission ブロック(#119): secret floor の無条件 deny 9 件(`~/.ssh` 読取 / env dump / gh secret 系)、`gateGitHubMcp` の `mcp__github` deny、`allow: mcp__pencil`、`enforceAiSandbox` 連動の human-legit gate | 同上(template が capability で gate して出力) | ✅ chezmoi(内容の回帰は `test-claude-settings.sh` が exact-set で固定) |
+| permission ブロック(#119): secret floor の無条件 deny 8 件(`~/.ssh` 読取 / env dump / gh secret 系)、`gateGitHubMcp` の `mcp__github` deny(personal 既定 true で計 9 件)、`allow: mcp__pencil`、`enforceAiSandbox` 連動の human-legit gate | 同上(template が capability で gate して出力) | ✅ chezmoi(内容の回帰は `test-claude-settings.sh` が exact-set で固定) |
 | personal・機密(secret を含む設定など) | `~/.claude/settings.local.json` | ❌ 非コミット・管理外 |
 | work / client の settings | 暗号化バックアップ(#60)か各マシン手設定 | ❌ public repo に生値を置かない |
 | skill / instruction(`skills/`、`agent-tools/CLAUDE.md`) | agent-tools が配布 | ❌ 別 repo の責務 |
@@ -70,9 +70,9 @@ module loop が、module を持たない profile(work-minimal / work-dev)では 
 ## permissions(#119: secret floor / GitHub guard)
 
 `permissions.deny` には capability 非依存の **secret floor**(never-legit な secret 読取
-9 件: `Read(~/.ssh/**)` / `Bash(cat ~/.ssh/*)` / `gh secret` / `gh api *secrets*` /
+8 件: `Read(~/.ssh/**)` / `Bash(cat ~/.ssh/*)` / `gh secret` / `gh api *secrets*` /
 `env` / `printenv` 系)を常時出力する。`gateGitHubMcp=true`(personal 既定)で
-`mcp__github`(server 全体)の deny、`enforceAiSandbox=true` で human-legit gate
+`mcp__github`(server 全体)の deny を足して計 9 件、`enforceAiSandbox=true` で human-legit gate
 (`.env` 読取 / main・master への push の deny、release / branch-protection の ask)を
 追加する。`permissions.allow` は `mcp__pencil` のみ。これらは **steering であって
 enforcement boundary ではない**(射程と限界は

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -116,6 +116,7 @@ main 直 commit は例外扱いにする。
 ./scripts/test-starship.sh
 ./scripts/test-ssh.sh
 bash -n scripts/*.sh
+shellcheck -S warning scripts/*.sh
 git diff --check
 ```
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -107,14 +107,21 @@ main 直 commit は例外扱いにする。
 ./scripts/test-gitconfig.sh
 ./scripts/test-npmrc.sh
 ./scripts/test-doctor.sh
+./scripts/test-secrets-gate.sh
+./scripts/test-private-backup.sh
+./scripts/test-install-packages.sh
 ./scripts/test-render.sh
 ./scripts/test-claude-settings.sh
 ./scripts/test-git-signing.sh
+./scripts/test-starship.sh
+./scripts/test-ssh.sh
 bash -n scripts/*.sh
 git diff --check
 ```
 
-`test-render.sh` / `test-claude-settings.sh` / `test-git-signing.sh` は chezmoi を必要とする(CI では version pin して導入する)。
+`test-render.sh` / `test-claude-settings.sh` / `test-git-signing.sh` / `test-starship.sh` /
+`test-ssh.sh` は chezmoi を必要とする(CI では version pin して導入する。render job 所属)。
+この一覧は `.github/workflows/validate.yml` が正なので、CI にテストを足したらここも更新する。
 
 `preflight` / `doctor` を変更した場合:
 

--- a/docs/local-overrides.md
+++ b/docs/local-overrides.md
@@ -1,7 +1,8 @@
 # Local Overrides
 
 managed な設定 file と、host 固有の local 上書きの境界規約。
-Phase 7 以降の zsh(#15)、VS Code(#16)、SSH(#17)はこの規約に従って実装する。
+zsh(#96 で実装・適用済み)と SSH(#17 で実装・適用済み)はこの規約に従って実装した。
+VS Code は未使用のため管理しない(#16。将来採用する場合の手順は下記)。
 
 ## 共通原則
 
@@ -78,7 +79,7 @@ GitHub injection 防御(epic #119)の trust 基点の local 値は、managed fil
 **`~/.config/dotfiles/github-trust.local`**(chezmoi 管理外・非コミット)に置く。trust の
 基点は `is_self`(自分の login + numeric id)で、collaborator / bot は既定 untrusted(方針は
 [ai-policy](ai-policy.md))。egress allowlist の local 値も同じ `~/.config/dotfiles/*.local`
-規約に従う(具体ファイル名は egress を per-host 化する Phase 2 / 3 で pin する)。
+規約に従う(具体ファイル名は OS egress firewall を実装する Phase 3(#131)で pin する)。
 
 - 共通原則どおり managed 側は trust list が無くても壊れないように書く(fail closed で
   「自分以外は untrusted」に倒す)。

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -81,5 +81,6 @@ direnv には 2 つの用途がある。本 doc が扱うのは後者(secret 供
 
 - `op://` 参照の repo 保持、`op run` / `op read` の repo 内実行(実 fetch は利用者側)。
 - 平文 secret のディスク・repo 配置。
-- マシンローカルに置かざるを得ない秘密素材の暗号化(age 等)は別 Issue で扱う。
+- マシンローカルに置かざるを得ない秘密素材の暗号化(age)は [private-backup](private-backup.md)
+  が担う(#60 で実装済み)。
 - 会社・クライアント固有の vault 名・item 名・参照を repo / docs に入れない。例の `op://` 参照は placeholder。

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -18,7 +18,7 @@
 - **補完**: zsh-completions を fpath に足し、compinit はキャッシュ(dump が無い/24h 超で再生成、通常は `-C` の高速パス)。fzf-tab で TAB 補完を fzf 化。
 - **入力補助**: zsh-autosuggestions(履歴ベース)+ zsh-syntax-highlighting。**syntax-highlighting は必ず最後に source**(直前までに定義した全 widget を wrap するため)。
 - **履歴**: 大容量・重複除去・セッション共有・タイムスタンプ。`HIST_IGNORE_SPACE` で行頭スペースのコマンドは記録しない(secret の手動オプトアウト。secret は op/direnv 供給でインライン入力しない = [docs/secrets.md](secrets.md))。off-machine 同期はしない。
-- **modern CLI**: eza(`ls` 系 alias)/ bat(`cat` alias、pager 無しで cat 風)。**alias は対話シェル限定**でスクリプトに影響せず、`command ls` / `command cat` で原本に届く。ripgrep / fd は fzf の裏方。
+- **modern CLI**: eza(`ls` 系 alias)/ bat(`cat` alias、pager 無しで cat 風)。**alias は対話シェル限定**でスクリプトに影響せず、`command ls` / `command cat` で原本に届く。ripgrep / fd は単体で使う検索ツール(fzf の既定 walker は内蔵のもの。詳細は後述の fzf 節)。
 - **runtime/env(別レイヤを compose)**: mise activate(対話)+ direnv hook。mise = runtime version、direnv = project env / op secret 注入([docs/runtime.md](runtime.md) / [docs/secrets.md](secrets.md))。新しい version スイッチャ(nvm/pyenv 等)は入れない(mise と競合)。
 
 読み込み順序は widget の wrap 関係に従う: compinit → fzf-tab → fzf / zoxide / starship / direnv / mise → alias → local override → zsh-autosuggestions → zsh-syntax-highlighting(最後)。

--- a/docs/update-policy.md
+++ b/docs/update-policy.md
@@ -10,6 +10,14 @@
 - `doctor` は状態を報告するだけにする。
 - 更新は明示コマンドとして実行する。
 
+## 例外: claude-code(native installer の自己更新)
+
+claude-code は catalog 外の native installer(`claude.ai/install.sh` → `~/.local/bin`)で
+管理し、**バックグラウンドの自己更新を意図的に受け入れている**(#112)。npm 経由の
+auto-update が hardened `~/.npmrc`(ignore-scripts=true)と両立しないための採用で、
+「npm hardening を維持したまま自動更新も動く」ことを優先した唯一の例外。経緯と詳細は
+[supply-chain-npm](supply-chain-npm.md)。
+
 ## Rationale
 
 勝手に全体を最新版へ上げることは、再現性とサプライチェーン安全性の両方を弱める。

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -20,7 +20,8 @@
           so they ride on enforceAiSandbox — which personal keeps false because its
           egress block is unusable on a daily driver (a restricted context is the
           Phase 3 home for these). The context-gated writes (merge/PR/comment/
-          label/push ai/*) need the Phase 2 hook and are intentionally absent. */ -}}
+          label/push ai/*) need the PreToolUse hook that Phase 2 handed off to
+          Phase 3 (#131) and are intentionally absent. */ -}}
 {{- $deny := list "Read(~/.ssh/**)" "Bash(cat ~/.ssh/*)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(env)" "Bash(env *)" "Bash(printenv)" "Bash(printenv *)" -}}
 {{- if index $caps "gateGitHubMcp" -}}{{- $deny = concat $deny (list "mcp__github") -}}{{- end -}}
 {{- $ask := list -}}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,7 +1,12 @@
 # scripts
 
-この directory の script は、dotfiles を host に適用する前後の policy 検証を担当する。
-package install、GUI app install、macOS defaults、secret fetch、Git remote mutation は行わない。
+この directory の script は、dotfiles を host に適用する前後の policy 検証と、catalog に
+宣言された運用アクション(手動起動のみ)を担当する。検証系(validate / preflight / doctor /
+test-*)は read-only で、host を変更しない。host に書き込むのは明示的に起動した
+`install-packages.sh --apply`(catalog 宣言の package install)と
+`private-backup.sh backup / restore --apply`(暗号化バックアップと復元)だけで、どちらも
+dry-run が既定・`chezmoi apply` には結合しない。macOS defaults、secret fetch、
+Git remote mutation は行わない。
 
 ## 終了コード方針
 
@@ -38,6 +43,9 @@ unknown profile / module / capability や capability enum の不正値は policy
 - module の `paths:` が home 相対であること。同一 path を複数 module が宣言していないこと。
 - module の `requires:` の capability が定義済みで、値が schema の型に適合すること。
 - `requires:` があるのに `paths:` がない module は fail(条件が何も駆動しないため)。
+- package catalog(`.chezmoidata/packages.yaml`)の name/source が有効であること。
+- backup path catalog(`.chezmoidata/backup-paths.yaml`)の path が home 相対・glob なし・
+  重複なしであること。
 
 ## preflight.sh
 
@@ -52,7 +60,7 @@ policy validation が失敗した場合は exit 1。
 
 ## doctor.sh
 
-導入後または現状環境の健康診断を行う。chezmoi、Git、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。URL の値は表示しない)、npm、Corepack、runtime、VS Code、1Password、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、agent-tools(report-only。`~/src/agent/agent-tools`(既定。`AGENT_TOOLS` env で override 可)の presence を表示し、`enableAgentToolsStatus=true` の opt-in 時のみ status contract(`scripts/status.sh --root <checkout> --json`。root を pin しないと status.sh は cwd を検査して空 repo を偽報告する)を実行して安全な summary を出す。clone / pull / sync はしない)、private-backup(report-only。public baseline の各 target の存在と marker からのバックアップ有無/最終日時を表示。local 補足は **存在のみ**で中身・件数は出さない。アーカイブや captured file の中身は読まない)、project root の状態を表示する。
+導入後または現状環境の健康診断を行う。chezmoi、Git、Git signing(`enableGitSigning` の SSH 署名 mechanism が managed か、capability true で module inactive の dangling か)、Git identity context(各 context の identity file が存在するか、意図的に未設定か)、Git remote URL(credential らしき userinfo の有無。url と pushurl を見る。URL の値は表示しない)、npm、Corepack、software catalog drift(catalog 宣言 vs 実機の brew/npm/go/mas。declared-missing / undeclared-sprawl / source-mismatch を report-only で表示)、runtime、VS Code、1Password、SSH(`enable1PasswordSSH` の managed `~/.ssh/config` が active か dangling か)、managed-path orphan(managed-by header があるのに現 profile で管理対象でない file。profile 切替の残骸検出)、AI policy(`enableAiPolicy` / `enableAiTools` の現状)、enforceAiSandbox(sandbox ブロックと human-legit write gate の live state)、GitHub injection guard(secret floor は常時 deny、`gateGitHubMcp` の MCP deny の wired 状態、`enableGitHubIsolatedReader` は Phase 3 まで未配線であることの開示)、network tunnels(`allowNetworkTunnels` と tunnel tool の存在)、agent-tools(report-only。`~/src/agent/agent-tools`(既定。`AGENT_TOOLS` env で override 可)の presence を表示し、`enableAgentToolsStatus=true` の opt-in 時のみ status contract(`scripts/status.sh --root <checkout> --json`。root を pin しないと status.sh は cwd を検査して空 repo を偽報告する)を実行して安全な summary を出す。clone / pull / sync はしない)、private-backup(report-only。public baseline の各 target の存在と marker からのバックアップ有無/最終日時を表示。local 補足は **存在のみ**で中身・件数は出さない。アーカイブや captured file の中身は読まない)、project root の状態を表示する。
 副作用は持たない。設定不足や未導入 command の warning は report-only として exit 0 のままにする。
 remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検査は `docs/supply-chain-npm.md`、Corepack の検査は `docs/supply-chain-corepack.md` に従う。
 `npmHardeningMode=enforce` の profile では、期待する npm config 値と現在値の不一致を `[warn]` で報告する(apply 前は不一致が正常)。
@@ -174,8 +182,8 @@ manager が PATH に無ければ skip + warn(runtime は mise の領分)。
 ## private-backup.sh
 
 private な設定(`.local` 上書き + curated アプリ設定)を **age identity 鍵**で単一アーカイブに
-退避し(`backup`)、そのアーカイブを検証する(`verify`)。災害復旧用の単方向 backup→restore で、
-restore は後続段。手動起動のみ・`chezmoi apply` 非結合。冒頭で runtime secrets gate
+退避し(`backup`)、アーカイブを検証し(`verify`)、検証済みのものだけを復元する(`restore`。
+既定 dry-run、`--apply` で実行)。手動起動のみ・`chezmoi apply` 非結合。冒頭で runtime secrets gate
 (`require_secrets_access`)を通り、`allowSecretsAccess != true` の profile では実行拒否。
 
 ```sh
@@ -247,7 +255,8 @@ profile を解決できない・未知の profile・`true` 以外の値はすべ
   `false` の profile(work-minimal / work-dev)と未知 profile を拒否すること(vacuously true にしない)。
 - chezmoi が見つからないとき `resolve_runtime_profile` / `require_secrets_access` が fail-closed で
   拒否すること(default profile に倒さない)。
-- chezmoi が profile を解決できる環境では、gate の判定が実 profile の純検査と一致すること
+- chezmoi が profile を解決できる環境では、gate の判定が profiles.yaml の
+  `allowSecretsAccess` 宣言値(yq 直読みの独立期待値)と一致すること
   (より緩くならない。chezmoi 不在の CI では skip)。
 
 実 profile は `chezmoi data` から取得し、CLI 引数では渡さない(呼び出し側が gate を
@@ -271,6 +280,34 @@ chezmoi で各 profile を throwaway destination に render(apply)し、managed 
 - profile 無回答の init が fail すること(default を持たない)。
 
 chezmoi が必要(CI では version pin して導入する)。
+
+## test-claude-settings.sh
+
+managed `~/.claude/settings.json` の rendered content を検証する。throwaway repo copy で
+capability(`enforceAiSandbox` / `gateGitHubMcp`)を flip し、secret floor の deny 9 件が
+順序込みで常時出力されること、gate 系 deny/ask ブロックが capability に応じて出る/出ない
+こと(既定 false では byte-identical)、#93 で取り込んだ global preference キーの保持を
+確認する。chezmoi が必要(render job)。
+
+## test-git-signing.sh
+
+git-signing module の gating を検証する。`enableGitSigning` の on/off で
+`~/.config/git/signing.gitconfig` が管理される/されないこと、signing mechanism
+(gpg.format=ssh + op-ssh-sign)が public-safe な骨格のみであることを render で確認する。
+chezmoi が必要(render job)。
+
+## test-ssh.sh
+
+ssh-1password module の gating と安全契約を検証する。`enable1PasswordSSH` の on/off gating、
+managed `~/.ssh/config` に host 名・秘密鍵・`Host *` への agent 付与・forwarding が混入しない
+こと、`Match all` 後の `Include config.local` 構造、`ssh -G` での実挙動(managed-wins と
+config.local の解決)を確認する。chezmoi が必要(render job)。
+
+## test-starship.sh
+
+starship.toml の render を検証する。TOML として parse できること(tomllib)、
+git-identity context の色分けが runtime 照合で行われ、identity の実値(email 等)が
+managed file に混入しないことを確認する。chezmoi が必要(render job)。
 
 ## lib-policy.sh
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,9 +3,10 @@
 この directory の script は、dotfiles を host に適用する前後の policy 検証と、catalog に
 宣言された運用アクション(手動起動のみ)を担当する。検証系(validate / preflight / doctor /
 test-*)は read-only で、host を変更しない。host に書き込むのは明示的に起動した
-`install-packages.sh --apply`(catalog 宣言の package install)と
-`private-backup.sh backup / restore --apply`(暗号化バックアップと復元)だけで、どちらも
-dry-run が既定・`chezmoi apply` には結合しない。macOS defaults、secret fetch、
+`install-packages.sh --apply`(catalog 宣言の package install。dry-run 既定)と
+`private-backup.sh`(`backup` は確認後に `--out` のアーカイブと state marker を書く。
+`restore` は dry-run 既定で `--apply` のときだけ復元する)だけで、いずれも
+`chezmoi apply` には結合しない。macOS defaults、secret fetch、
 Git remote mutation は行わない。
 
 ## 終了コード方針
@@ -284,10 +285,10 @@ chezmoi が必要(CI では version pin して導入する)。
 ## test-claude-settings.sh
 
 managed `~/.claude/settings.json` の rendered content を検証する。throwaway repo copy で
-capability(`enforceAiSandbox` / `gateGitHubMcp`)を flip し、secret floor の deny 9 件が
-順序込みで常時出力されること、gate 系 deny/ask ブロックが capability に応じて出る/出ない
-こと(既定 false では byte-identical)、#93 で取り込んだ global preference キーの保持を
-確認する。chezmoi が必要(render job)。
+capability(`enforceAiSandbox` / `gateGitHubMcp`)を flip し、secret floor の無条件 deny
+8 件が順序込みで常時出力されること(personal 既定では `gateGitHubMcp` の `mcp__github` を
+足して計 9 件)、gate 系 deny/ask ブロックが capability に応じて出る/出ないこと、#93 で
+取り込んだ global preference キーの保持を確認する。chezmoi が必要(render job)。
 
 ## test-git-signing.sh
 


### PR DESCRIPTION
Closes #152

## 変更(docs のみ、render 不変)

2026-07-02 監査の docs 陳腐化所見の一括修正。実装が正・prose だけが古いことを個別に確認してから修正。

- **scripts/README**(high): 冒頭「install は行わない」宣言が同 README 内の `--apply` 系と自己矛盾 → 「検証系は read-only 既定 + 明示アクション 2 つ」の実態に書き換え。doctor セクション一覧の追従(catalog drift / signing / SSH / injection guard / enforceAiSandbox)、「restore は後続段」除去、validate-policy の packages/backup-paths 検査追記、render job 4 テスト(claude-settings / git-signing / ssh / starship)の節を新設。#149 で変えた test-secrets-gate case5 の記述も追従
- **README**: 実装状況テーブルの「未適用」4 領域を実態(実機適用済み)に修正 + catalog/backup/signing/GitHub guard の行を追加
- **github-workflow**: CI 一覧に欠落していた 5 テストを追加(AGENTS.md が正本として参照する一覧)
- **ai-policy / settings.json.tmpl コメント / ai-environment-boundary / local-overrides**: #119 の Phase 表記を Phase 2 close 後の実態に(secret floor live・hook 本体は #131 へ hand-off)
- **update-policy**: claude-code native の自己更新例外(#112)を明文化
- **shell / secrets / claude-settings**: fzf walker の overclaim、stale pointer(→ private-backup #60)、permissions ブロック(#119)の欠落を解消

## 検証

- template 変更はコメントのみ → test-render / test-claude-settings green(render 不変)
- `git diff --check` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
