### PR TITLE
policy: enableMacOSDefaults と placeholder module を削除し「残す基準」を明文化 (#145)

### DIFF
--- a/.chezmoidata/capabilities.schema.yaml
+++ b/.chezmoidata/capabilities.schema.yaml
@@ -3,8 +3,6 @@ capabilities:
     type: boolean
   installGuiApps:
     type: boolean
-  enableMacOSDefaults:
-    type: boolean
   enable1PasswordSSH:
     type: boolean
   enableGitSigning:

--- a/.chezmoidata/modules.yaml
+++ b/.chezmoidata/modules.yaml
@@ -45,8 +45,6 @@ modules:
     description: 自動 upgrade を避ける更新方針。
   gui-apps:
     description: opt-in の GUI app install。
-  macos-defaults:
-    description: opt-in の macOS defaults。
   git-signing:
     description: commit / tag の SSH 署名(1Password op-ssh-sign)。仕組みのみ managed、鍵と opt-in は context 別 local。
     paths:
@@ -56,8 +54,6 @@ modules:
       enableGitSigning: true
   ai-policy:
     description: AI agent 権限方針。
-  ai-tools:
-    description: 後続 module。AI tool install / 設定。
   claude-settings:
     description: Claude Code harness 設定。personal の public-safe な settings.json のみ管理(settings.local.json は管理しない)。
     paths:

--- a/.chezmoidata/profiles.yaml
+++ b/.chezmoidata/profiles.yaml
@@ -22,7 +22,6 @@ profiles:
     capabilities:
       installPackages: true
       installGuiApps: true
-      enableMacOSDefaults: false
       enable1PasswordSSH: true
       enableGitSigning: true
       enableDirenv: true
@@ -64,7 +63,6 @@ profiles:
     capabilities:
       installPackages: false
       installGuiApps: false
-      enableMacOSDefaults: false
       enable1PasswordSSH: false
       enableGitSigning: false
       enableDirenv: false
@@ -99,7 +97,6 @@ profiles:
     capabilities:
       installPackages: false
       installGuiApps: false
-      enableMacOSDefaults: false
       enable1PasswordSSH: false
       enableGitSigning: false
       enableDirenv: true

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ environmentKind は飾りラベルではない。`validate-policy.sh` が、環�
 
 | environmentKind | false 必須の capability |
 | --- | --- |
-| work / client / agent | installPackages, installGuiApps, enableMacOSDefaults, allowSecretsAccess, allowNetworkTunnels, enableAiTools |
+| work / client / agent | installPackages, installGuiApps, allowSecretsAccess, allowNetworkTunnels, enableAiTools |
 | sandbox | allowSecretsAccess |
 | personal | (制約なし) |
 

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -53,7 +53,7 @@ environmentKind は飾りラベルではなく、capability の不変条件を�
 
 | environmentKind | false 必須の capability |
 | --- | --- |
-| work / client / agent | installPackages, installGuiApps, enableMacOSDefaults, allowSecretsAccess, allowNetworkTunnels, enableAiTools |
+| work / client / agent | installPackages, installGuiApps, allowSecretsAccess, allowNetworkTunnels, enableAiTools |
 | sandbox | allowSecretsAccess |
 | personal | (制約なし) |
 
@@ -110,6 +110,33 @@ GitHub runtime prompt-injection 防御(epic #119)の capability 2 本。射程�
   render→diff→実機 dry-run の検証ゲート済み)、work 系=false(`claude-settings` 非 active)。
   `enableGitHubIsolatedReader` は全 profile false(Phase 3)。github MCP は現状未構成なので
   deny は実質 no-op = 将来 MCP を足したとき先回りで deny する defense-in-depth。
+
+## dormant capability の扱い(残す基準)
+
+宣言だけで実装が無い capability を schema に置いてよいのは、次の**両方**を満たすときだけ
+(2026-07-02 監査 + #145 で確定):
+
+1. **owner のある生きた契約**: 実装先が issue で追跡されている接続契約
+   (例: `enableGitHubIsolatedReader` → Phase 3 #131)か、roadmap 上の placeholder
+   (例: `enableAiTools`)であること。
+2. **doctor 開示**: doctor がその「未実装 / 未配線」を warn として開示していること
+   (AGENTS.md「宣言だけで何も駆動しない capability を作らない」の実体)。
+
+**決定済み不使用・doctor 開示なし・owner なしの dormant は削除する**。schema に残すと
+「宣言 = 何かが動く」という読みを裏切り、honest-labeling が信用できなくなる。削除しても
+git 履歴から復元できる(前例: vscode #16/#145、enableMacOSDefaults #145)。
+
+## capability → 実装の gating 方式(規範)
+
+capability が実装を gate する方式は **原則 requires 方式**(module の `requires:` で
+path ごと管理対象を gate。`runtime` / `git-signing` / `supply-chain/npm` が例)。
+ファイル自体は常に管理し**中身だけ**を capability で分岐させたい場合のみ、テンプレート内
+分岐を使ってよい(`claude-settings` / `ssh-1password` が例)。その場合は capability true
+かつ module inactive の組み合わせを doctor が dangling として警告する section を必ず併設する。
+
+`requires:` の意味論は **boolean / enum の等値のみ**に保つ(不変条件)。module 活性判定は
+`.chezmoiignore` の Go template と `lib-policy.sh` の `module_active_for_profile` に
+二重実装されており、意味論を拡張すると両方の同時修正が必要になるため。
 
 ## Capability Modes
 

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -124,7 +124,7 @@ GitHub runtime prompt-injection 防御(epic #119)の capability 2 本。射程�
 
 **決定済み不使用・doctor 開示なし・owner なしの dormant は削除する**。schema に残すと
 「宣言 = 何かが動く」という読みを裏切り、honest-labeling が信用できなくなる。削除しても
-git 履歴から復元できる(前例: vscode #16/#145、enableMacOSDefaults #145)。
+git 履歴から復元できる(削除済みの前例は #16 / #145 を参照)。
 
 ## capability → 実装の gating 方式(規範)
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -359,7 +359,7 @@ else
   ok "AI policy checks disabled for profile"
 fi
 if [[ "$(capability_value "$profile" enableAiTools)" == "true" ]]; then
-  warn "enableAiTools=true but the ai-tools module is not implemented yet (nothing is managed)"
+  warn "enableAiTools=true but no implementation exists yet (nothing is managed; roadmap placeholder)"
 else
   ok "AI tool install/sync not managed (enableAiTools=false)"
 fi

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -193,7 +193,6 @@ environment_kind_forbidden_capabilities() {
       printf '%s\n' \
         installPackages \
         installGuiApps \
-        enableMacOSDefaults \
         allowSecretsAccess \
         allowNetworkTunnels \
         enableAiTools

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -323,14 +323,13 @@ run_fail_contains \
 
 # environmentKind cross-check. Every deny entry for work/client/agent
 # must actually fire: retag personal (already elevated) to work and force
-# the two caps it leaves false to true, then assert all six are flagged.
+# the one cap it leaves false to true, then assert all five are flagged.
 make_fixture
 replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: work"
-replace_once "$fixture/.chezmoidata/profiles.yaml" "      enableMacOSDefaults: false" "      enableMacOSDefaults: true"
 replace_once "$fixture/.chezmoidata/profiles.yaml" "      enableAiTools: false" "      enableAiTools: true"
 ek_output="$("$fixture/scripts/validate-policy.sh" personal 2>&1 || true)"
 ek_missing=""
-for cap in installPackages installGuiApps enableMacOSDefaults allowSecretsAccess allowNetworkTunnels enableAiTools; do
+for cap in installPackages installGuiApps allowSecretsAccess allowNetworkTunnels enableAiTools; do
   grep -Fq "environmentKind work forbids $cap=true" <<< "$ek_output" || ek_missing="$ek_missing $cap"
 done
 if [[ -z "$ek_missing" ]]; then


### PR DESCRIPTION
Closes #145(PR 2/2)

## 変更

**enableMacOSDefaults の削除**: AGENTS.md 自身の「宣言だけで何も駆動しない capability を作らない」ルールに違反していた唯一の完全な穴(schema・全 profile・forbidden 表に居るのに doctor section も実装も無い — 監査 A-1)。schema / profiles×3 / forbidden 表(lib-policy + policy-model・README の表 + test-policy の cross-check、6→5 cap)から除去。

**placeholder module の削除**: `macos-defaults` / `ai-tools`(paths 無し・profile 参照ゼロ)。**`enableAiTools` capability 自体は維持**(doctor が未実装 warn を出す roadmap placeholder = 残す基準を満たす)。doctor の warn 文言だけ「存在しない module 名」を指さない形に修正。

**基準の明文化(policy-model に 2 節追加)**:
- 「dormant capability の扱い(残す基準)」: owner のある生きた契約 + doctor 開示の両方を満たすときだけ残す。決定済み不使用・開示なし・owner なしは削除(vscode / enableMacOSDefaults が前例)
- 「capability→実装の gating 方式(規範)」: 原則 requires 方式、テンプレ内分岐は dangling doctor warn 併設が条件。requires の意味論は boolean/enum 等値のみ(Go template と bash の二重実装のため)— 監査 C-1 / B-3 への対処

## 検証

render 不変(paths 非関与)。validate --all / test-policy(work deny 5 cap cross-check 更新込み)/ test-render / test-doctor green、shellcheck 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
