### PR TITLE
policy: implemented フラグの最小 capability registry(dangling 宣言の静的検出) (#151)

### DIFF
--- a/.chezmoidata/capabilities.schema.yaml
+++ b/.chezmoidata/capabilities.schema.yaml
@@ -1,41 +1,64 @@
+# Capability schema. Every capability MUST declare:
+#   type:        boolean | enum (enum also lists values)
+#   implemented: true | false — false marks a declared-not-implemented
+#                capability (a live contract or roadmap placeholder per the
+#                keep-criterion in docs/policy-model.md). validate-policy
+#                requires the flag and, for implemented: false, statically
+#                checks that doctor.sh discloses the capability (#151).
 capabilities:
   installPackages:
     type: boolean
+    implemented: true
   installGuiApps:
     type: boolean
+    implemented: true
   enable1PasswordSSH:
     type: boolean
+    implemented: true
   enableGitSigning:
     type: boolean
+    implemented: true
   enableDirenv:
     type: boolean
+    implemented: true
   enableRuntimeManagement:
     type: boolean
+    implemented: true
   npmHardeningMode:
     type: enum
+    implemented: true
     values:
       - off
       - report
       - enforce
   corepackMode:
     type: enum
+    implemented: true
     values:
       - off
       - report
       - enable
   allowNetworkTunnels:
     type: boolean
+    implemented: true
   allowSecretsAccess:
     type: boolean
+    implemented: true
   enableAiTools:
     type: boolean
+    implemented: false
   enforceAiSandbox:
     type: boolean
+    implemented: true
   enableAgentToolsStatus:
     type: boolean
+    implemented: true
   enableAiPolicy:
     type: boolean
+    implemented: true
   gateGitHubMcp:
     type: boolean
+    implemented: true
   enableGitHubIsolatedReader:
     type: boolean
+    implemented: false

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -126,6 +126,27 @@ GitHub runtime prompt-injection 防御(epic #119)の capability 2 本。射程�
 「宣言 = 何かが動く」という読みを裏切り、honest-labeling が信用できなくなる。削除しても
 git 履歴から復元できる(削除済みの前例は #16 / #145 を参照)。
 
+この基準は #151 で機械検査に接続した: schema の各 capability は `implemented: true|false`
+を必須で持ち(欠落は validate が fail)、`implemented: false` は doctor.sh がその
+capability 名に言及していることを validate が静的に検査する(source-text の proxy であって
+挙動検査ではないが、「schema と profile に居るのに doctor が一度も触れない」型の穴は塞がる)。
+
+### capability 追加チェックリスト
+
+capability を 1 つ追加するときに触る場所(fail-closed の意図的コスト。validate が大半の
+漏れを検出する):
+
+1. `capabilities.schema.yaml` — `type` と `implemented` を宣言。
+2. `profiles.yaml` — **全 profile** に値を記入(欠落は validate fail)。
+3. 危険な権限なら `lib-policy.sh` の `environment_kind_forbidden_capabilities` と
+   本 doc / README の表(3 箇所)+ `test-policy.sh` の cross-check に追加。
+   安全強化型(true ほど締まる)は**入れない**(極性は sandbox 節参照)。
+4. 実装の配線 — 原則 requires 方式(上の規範)。`implemented: false` で land する場合は
+   doctor に未実装/未配線の warn を出す section を追加(AGENTS.md 規約 + #151 検査)。
+5. テスト — render 影響があれば `test-render.sh` の期待 managed set、settings 影響が
+   あれば `test-claude-settings.sh`、極性は `test-policy.sh`。
+6. docs — 対応する docs の節(このファイル・関連 doc)。
+
 ## capability → 実装の gating 方式(規範)
 
 capability が実装を gate する方式は **原則 requires 方式**(module の `requires:` で

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,8 @@ unknown profile / module / capability や capability enum の不正値は policy
 - package catalog(`.chezmoidata/packages.yaml`)の name/source が有効であること。
 - backup path catalog(`.chezmoidata/backup-paths.yaml`)の path が home 相対・glob なし・
   重複なしであること。
+- capability registry(#151): 全 capability が `implemented: true|false` を持ち、
+  `implemented: false` は doctor.sh が言及していること(source-text の静的 proxy)。
 
 ## preflight.sh
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -159,6 +159,15 @@ capability_allowed_values() {
   c="$capability" yq '.capabilities[strenv(c)].values[]?' "$CAPABILITIES_FILE"
 }
 
+# The capability's implemented flag (#151): "true" / "false", or "null" when
+# the schema entry lacks the flag (validate-policy fails closed on it).
+# tostring, not `// ""`: yq's alternative operator treats boolean false as
+# falsy, so `implemented: false` would read as absent.
+capability_implemented() {
+  local capability="$1"
+  c="$capability" yq '.capabilities[strenv(c)].implemented | tostring' "$CAPABILITIES_FILE"
+}
+
 capability_value_is_allowed() {
   local capability="$1"
   local value="$2"

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -410,6 +410,27 @@ if set_capability_all "$fixture" enforceAiSandbox true 2>/dev/null; then
 fi
 ok "test passed: set_capability_all fails closed on an empty profiles map"
 
+# Capability registry (#151): a capability without implemented: true|false
+# fails closed, and implemented: false without a doctor disclosure (the
+# static proxy: doctor.sh mentions the name) fails. The mutations are
+# verified by the failure assertions themselves — a no-op mutation would
+# make validate pass and the test fail loudly.
+make_fixture
+yq -i 'del(.capabilities.enableGitSigning.implemented)' \
+  "$fixture/.chezmoidata/capabilities.schema.yaml"
+run_fail_contains \
+  "capability without an implemented flag fails closed" \
+  "enableGitSigning lacks implemented" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+make_fixture
+yq -i '.capabilities.installGuiApps.implemented = false' \
+  "$fixture/.chezmoidata/capabilities.schema.yaml"
+run_fail_contains \
+  "implemented=false without a doctor mention fails (undisclosed dormant)" \
+  "installGuiApps is implemented=false but doctor.sh never mentions it" \
+  "$fixture/scripts/validate-policy.sh" personal
+
 # Anchor on the LAST capability line so the bogus section lands after the whole
 # capabilities block (update this if a later capability is added below).
 make_fixture

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -105,6 +105,49 @@ validate_modules() {
   return "$status"
 }
 
+# Capability registry (#151): every capability must declare
+# implemented: true|false (fail closed — an unlabeled capability cannot claim
+# honest-labeling). implemented: false additionally requires a doctor
+# disclosure; the static proxy is that doctor.sh mentions the capability name
+# at all. This is a source-text check, not a behavior check (a mention inside
+# a comment would satisfy it), but it catches exactly the failure #145
+# removed: a capability living in schema + profiles with zero doctor
+# references. The keep-criterion for implemented: false entries is in
+# docs/policy-model.md.
+validate_capability_registry() {
+  local status=0 capability impl
+  local doctor_script="$DOTFILES_ROOT/scripts/doctor.sh"
+  while IFS= read -r capability; do
+    [[ -z "$capability" ]] && continue
+    impl="$(capability_implemented "$capability")"
+    case "$impl" in
+      true)
+        ok "capability registry: $capability implemented=true"
+        ;;
+      false)
+        if grep -Fq -- "$capability" "$doctor_script"; then
+          ok "capability registry: $capability implemented=false, doctor discloses it"
+        else
+          fail "capability registry: $capability is implemented=false but doctor.sh never mentions it (undisclosed dormant declaration)"
+          status=1
+        fi
+        ;;
+      *)
+        fail "capability registry: $capability lacks implemented: true|false"
+        status=1
+        ;;
+    esac
+  done < "$known_caps_file"
+
+  if [[ "$status" -eq 0 ]]; then
+    ok "capability registry validation passed"
+  else
+    fail "capability registry validation failed"
+  fi
+
+  return "$status"
+}
+
 # The software catalog (packages.yaml) is profile-independent data, like
 # modules: every entry must name a known source, go_install / mas need an
 # explicit canonical pkg id (a bare name cannot reconstruct a module path
@@ -433,6 +476,8 @@ case "$command" in
     status=0
     section "validating modules"
     validate_modules || status=1
+    section "validating capability registry"
+    validate_capability_registry || status=1
     section "validating packages"
     validate_packages || status=1
     section "validating backup paths"
@@ -458,6 +503,7 @@ case "$command" in
   *)
     status=0
     validate_modules || status=1
+    validate_capability_registry || status=1
     validate_packages || status=1
     validate_backup_paths || status=1
     validate_profile "$command" || status=1


### PR DESCRIPTION
Closes #151

## 変更(Codex 議論で合意した「最小形」— full registry 化はしない)

- **schema**: 全 capability に `implemented: true|false` を必須化(false は `enableAiTools` と `enableGitHubIsolatedReader` の 2 つ)
- **validate-policy**: `validate_capability_registry` を新設。フラグ欠落は fail-closed、`implemented: false` は **doctor.sh がその capability 名に言及していること**を静的検査(source-text proxy であることをコード/docs で正直にラベル)。#145 で塞いだ「schema+profiles に居るのに doctor 参照ゼロ」型の穴が再発したら validate が止める
- **lib-policy**: `capability_implemented()`。**`// ""` でなく `tostring`** — yq の alternative operator は boolean false も falsy 扱いするため、`implemented: false` が「欠落」に化ける(初回実行で negative テストが検出した実バグ)
- **test-policy**: negative 2 件(フラグ欠落 / 未開示の implemented=false)
- **docs**: policy-model に registry の説明 + capability 追加チェックリスト(監査 E-1 対応)、scripts/README に検証内容 1 行

## やらないこと(意図的)

doctorSection / forbiddenByKind / default の data 化はしない(現規模には過剰な制御面 — Codex 議論の結論)。

## 検証

validate --all(registry 16 件 ok・false 2 件は doctor 開示確認済み)/ test-policy(negative 2 件含む)/ test-render / test-doctor green、shellcheck 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
