### PR TITLE
tests: npmrc の rendered content 検査 + doctor npm/Corepack 挙動の固定(#150 1/2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -122,3 +122,8 @@ jobs:
 
       - name: ssh-1password gating and safety tests
         run: ./scripts/test-ssh.sh
+
+      # Also runs in the validate job for its static checks; here chezmoi is
+      # available so the rendered-content section actually executes (#150).
+      - name: npmrc rendered-content tests
+        run: ./scripts/test-npmrc.sh

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -122,6 +122,8 @@ git diff --check
 
 `test-render.sh` / `test-claude-settings.sh` / `test-git-signing.sh` / `test-starship.sh` /
 `test-ssh.sh` は chezmoi を必要とする(CI では version pin して導入する。render job 所属)。
+`test-npmrc.sh` は両 job で走る(静的検査は validate job、chezmoi が要る rendered-content
+検査は render job で実行される。#150)。
 この一覧は `.github/workflows/validate.yml` が正なので、CI にテストを足したらここも更新する。
 
 `preflight` / `doctor` を変更した場合:

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -618,6 +618,111 @@ else
   status=1
 fi
 
+# NPM-C/D) The enforce expectation checks, deterministic via fake npm/node on
+# PATH (#150): a mismatched config value is warned; the min-release-age
+# before-cutoff is honored/warned based on the parsed epoch. The fakes are
+# env-driven so each case pins one branch; doctor stays exit 0 throughout.
+cat > "$npm_fakebin/npm" <<'SH'
+#!/bin/sh
+case "$1" in
+  --version) printf '11.10.0\n' ;;
+  config)
+    case "$3" in
+      ignore-scripts) printf '%s\n' "${FAKE_NPM_IGNORE_SCRIPTS:-true}" ;;
+      save-exact) printf 'true\n' ;;
+      fund) printf 'false\n' ;;
+      audit) printf 'true\n' ;;
+      before) printf '%s\n' "${FAKE_NPM_BEFORE:-null}" ;;
+      *) printf 'null\n' ;;
+    esac ;;
+esac
+exit 0
+SH
+cat > "$npm_fakebin/node" <<'SH'
+#!/bin/sh
+printf '%s' "${FAKE_NODE_EPOCH:-}"
+exit 0
+SH
+chmod +x "$npm_fakebin/npm" "$npm_fakebin/node"
+now_epoch="$(date +%s)"
+
+if np_out="$(HOME="$fixture_home" PATH="$npm_fakebin:$PATH" \
+  FAKE_NPM_IGNORE_SCRIPTS=false FAKE_NPM_BEFORE="fake-date" \
+  FAKE_NODE_EPOCH="$(( now_epoch - 7*86400 ))" \
+  "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "enforce expects npm ignore-scripts=true, current: false" <<< "$np_out" \
+    && grep -Fq "npm min-release-age=7 honored" <<< "$np_out"; then
+    ok "test passed: enforce mismatch warned while a good before-cutoff is honored"
+  else
+    printf '%s\n' "$np_out" >&2
+    fail "test failed: enforce mismatch warn or honored cutoff missing"
+    status=1
+  fi
+else
+  printf '%s\n' "$np_out" >&2
+  fail "test failed: doctor must stay exit 0 on an enforce mismatch"
+  status=1
+fi
+
+if np_out="$(HOME="$fixture_home" PATH="$npm_fakebin:$PATH" \
+  FAKE_NPM_BEFORE="fake-date" FAKE_NODE_EPOCH="$(( now_epoch - 86400 ))" \
+  "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "enforce expects npm min-release-age=7 (before ~= now-7d)" <<< "$np_out"; then
+    ok "test passed: a too-recent before cutoff is warned (cooldown not enforced)"
+  else
+    printf '%s\n' "$np_out" >&2
+    fail "test failed: too-recent before cutoff not warned"
+    status=1
+  fi
+else
+  printf '%s\n' "$np_out" >&2
+  fail "test failed: doctor must stay exit 0 on a too-recent cutoff"
+  status=1
+fi
+
+# COREPACK-A) corepackMode=off says intentionally unmanaged; B) report mode
+# with a corepack on PATH reports its version line (fake for determinism —
+# the CI validate job may or may not ship corepack) (#150).
+cp_root="$fixture_home/.dotfiles-corepack"
+mkdir -p "$cp_root/.chezmoidata"
+cp -R "$DOTFILES_ROOT/scripts" "$cp_root/scripts"
+cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$cp_root/.chezmoidata/"
+set_capability_all "$cp_root" corepackMode off
+if cp_out="$(HOME="$fixture_home" "$cp_root/scripts/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "corepack intentionally unmanaged" <<< "$cp_out"; then
+    ok "test passed: corepackMode=off reports intentionally unmanaged"
+  else
+    printf '%s\n' "$cp_out" >&2
+    fail "test failed: corepackMode=off not reported as unmanaged"
+    status=1
+  fi
+else
+  printf '%s\n' "$cp_out" >&2
+  fail "test failed: doctor must stay exit 0 with corepackMode=off"
+  status=1
+fi
+
+cat > "$npm_fakebin/corepack" <<'SH'
+#!/bin/sh
+[ "$1" = "--version" ] && printf '0.0-fake\n'
+exit 0
+SH
+chmod +x "$npm_fakebin/corepack"
+if cp_out="$(HOME="$fixture_home" PATH="$npm_fakebin:$PATH" \
+  "$SCRIPT_DIR/doctor.sh" personal 2>&1)"; then
+  if grep -Fq "corepack: 0.0-fake" <<< "$cp_out"; then
+    ok "test passed: corepackMode=report shows the corepack version"
+  else
+    printf '%s\n' "$cp_out" >&2
+    fail "test failed: corepack version line missing under report mode"
+    status=1
+  fi
+else
+  printf '%s\n' "$cp_out" >&2
+  fail "test failed: doctor must stay exit 0 under corepackMode=report"
+  status=1
+fi
+
 # DRIFT-A) A token-shaped line in ~/.npmrc is warned by name only (the value
 # never appears in the output), doctor stays exit 0 (#148).
 dr_home="$fixture_home/drift"

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 require_yq || exit 1
 
@@ -157,6 +159,72 @@ check_window "non-numeric tolerance is rejected"    1 $(( now - 7*day ))      "$
 # Honored: leading zeros are read base-10, not octal (no arithmetic error).
 check_window "leading-zero before is honored"       0 "0$(( now - 7*day ))"   "$now" 7 "$tol"
 check_window "leading-zero days=07 is honored"      0 $(( now - 7*day ))      "$now" 07 "$tol"
+
+# Rendered content (#150): the static grep above pins the template SOURCE,
+# not what a profile actually renders — a flipped gate condition would keep
+# every static check green. Render for real when chezmoi is available (the
+# render job runs this; the validate job has no chezmoi and skips).
+section "rendered content (chezmoi)"
+if ! command -v chezmoi >/dev/null 2>&1; then
+  warn "chezmoi not found; skipping rendered-content checks (the CI render job runs them)"
+else
+  tmp_roots=()
+  cleanup() {
+    for dir in "${tmp_roots[@]:-}"; do
+      [[ -n "$dir" ]] && rm -rf "$dir"
+    done
+  }
+  trap cleanup EXIT
+
+  # Apply personal from SOURCE_DIR into a throwaway home; print the home path.
+  render_personal_home() {
+    local source_dir="$1" root
+    root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-npmrc-render.XXXXXX")"
+    tmp_roots+=("$root")
+    mkdir -p "$root/home"
+    printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
+    if ! chezmoi --config "$root/chezmoi.toml" \
+        --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1; then
+      return 1
+    fi
+    printf '%s\n' "$root/home"
+  }
+
+  # enforce (personal default): every hardening line renders, tokens never do.
+  if home_dir="$(render_personal_home "$DOTFILES_ROOT")" \
+    && [[ -f "$home_dir/.npmrc" ]]; then
+    for line in "ignore-scripts=true" "save-exact=true" "fund=false" "audit=true" "min-release-age=7"; do
+      check_file_has_line "rendered enforce npmrc has: $line" "$home_dir/.npmrc" "$line"
+    done
+    if grep -Eq '_authToken|registry=|^//' "$home_dir/.npmrc"; then
+      fail "test failed: rendered npmrc contains token or registry configuration"
+      status=1
+    else
+      ok "test passed: rendered npmrc carries no token or registry configuration"
+    fi
+  else
+    fail "test failed: personal (enforce) did not render ~/.npmrc"
+    status=1
+  fi
+
+  # report: the supply-chain/npm module requires enforce, so ~/.npmrc must
+  # leave the managed set entirely (not render as an empty file).
+  flip_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-npmrc-flip.XXXXXX")"
+  tmp_roots+=("$flip_root")
+  cp -R "$DOTFILES_ROOT/." "$flip_root/repo"
+  set_capability_all "$flip_root/repo" npmHardeningMode report
+  if home_dir="$(render_personal_home "$flip_root/repo")"; then
+    if [[ -e "$home_dir/.npmrc" ]]; then
+      fail "test failed: npmHardeningMode=report must not manage ~/.npmrc"
+      status=1
+    else
+      ok "test passed: npmHardeningMode=report leaves ~/.npmrc unmanaged"
+    fi
+  else
+    fail "test failed: apply failed with npmHardeningMode=report"
+    status=1
+  fi
+fi
 
 if [[ "$status" -eq 0 ]]; then
   ok "npmrc tests passed"

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -176,27 +176,28 @@ else
   }
   trap cleanup EXIT
 
-  # Apply personal from SOURCE_DIR into a throwaway home; print the home path.
-  render_personal_home() {
-    local source_dir="$1" root
-    root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-npmrc-render.XXXXXX")"
-    tmp_roots+=("$root")
+  # Apply personal from SOURCE_DIR into ROOT/home. ROOT is created by the
+  # CALLER and registered in tmp_roots there: a helper that mktemps and
+  # returns via command substitution would append to tmp_roots only inside
+  # the substitution subshell, so the cleanup trap would never see it and
+  # the render roots would leak (Codex review, #150).
+  render_personal_into() {
+    local source_dir="$1" root="$2"
     mkdir -p "$root/home"
     printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
-    if ! chezmoi --config "$root/chezmoi.toml" \
-        --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1; then
-      return 1
-    fi
-    printf '%s\n' "$root/home"
+    chezmoi --config "$root/chezmoi.toml" \
+      --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1
   }
 
   # enforce (personal default): every hardening line renders, tokens never do.
-  if home_dir="$(render_personal_home "$DOTFILES_ROOT")" \
-    && [[ -f "$home_dir/.npmrc" ]]; then
+  enforce_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-npmrc-render.XXXXXX")"
+  tmp_roots+=("$enforce_root")
+  if render_personal_into "$DOTFILES_ROOT" "$enforce_root" \
+    && [[ -f "$enforce_root/home/.npmrc" ]]; then
     for line in "ignore-scripts=true" "save-exact=true" "fund=false" "audit=true" "min-release-age=7"; do
-      check_file_has_line "rendered enforce npmrc has: $line" "$home_dir/.npmrc" "$line"
+      check_file_has_line "rendered enforce npmrc has: $line" "$enforce_root/home/.npmrc" "$line"
     done
-    if grep -Eq '_authToken|registry=|^//' "$home_dir/.npmrc"; then
+    if grep -Eq '_authToken|registry=|^//' "$enforce_root/home/.npmrc"; then
       fail "test failed: rendered npmrc contains token or registry configuration"
       status=1
     else
@@ -213,8 +214,10 @@ else
   tmp_roots+=("$flip_root")
   cp -R "$DOTFILES_ROOT/." "$flip_root/repo"
   set_capability_all "$flip_root/repo" npmHardeningMode report
-  if home_dir="$(render_personal_home "$flip_root/repo")"; then
-    if [[ -e "$home_dir/.npmrc" ]]; then
+  report_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-npmrc-render.XXXXXX")"
+  tmp_roots+=("$report_root")
+  if render_personal_into "$flip_root/repo" "$report_root"; then
+    if [[ -e "$report_root/home/.npmrc" ]]; then
       fail "test failed: npmHardeningMode=report must not manage ~/.npmrc"
       status=1
     else


### PR DESCRIPTION
#150 の PR 1/2(優先項目 1・2)。

## 変更

**1. npmrc rendered content テスト(監査 #9: grep だけで挙動未検証)**
- test-npmrc に chezmoi-gated の rendered-content 節を追加。enforce(personal 既定)で全 hardening 行が render され token/registry が混入しないこと、report flip で `~/.npmrc` が managed set から消える(空 render でない)ことを assert
- **mutation 検証済み**: テンプレの gate 条件を壊すと静的検査と rendered 検査の両方が fail
- CI 配線: render job にも test-npmrc を追加(validate job は chezmoi 無しで静的半分のみ → rendered 節が CI で実行されない罠を回避。#165 の Codex 指摘と同型の予防)

**2. doctor npm/Corepack section の挙動テスト(監査 #11: 挙動テストゼロ)**
- env 駆動の fake npm/node/corepack で 4 分岐を決定的に固定: enforce 不一致 warn / before cutoff の honored / too-recent warn / corepackMode=off の unmanaged / report の version 表示。全て exit 0(report-only 契約)

## 残り(PR 2/2)

preflight テスト + zsh -n の CI 配線。

## 検証

test-npmrc(rendered 7 assert 含む)/ test-doctor(37 ケース)green、shellcheck 通過、github-workflow の一覧追従済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
