### PR TITLE
tests: preflight を e2e でカバーし zsh -n を CI に配線(#150 2/2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,7 +50,11 @@ jobs:
         run: bash -n scripts/*.sh
 
       # The managed zsh layer had no syntax gate at all — the #96 compinit
-      # glob bug lived exactly here (#150). The runner image ships zsh.
+      # glob bug lived exactly here (#150). ubuntu-latest (24.04) does not
+      # ship zsh, so install it explicitly rather than assume the image.
+      - name: install zsh
+        run: sudo apt-get update && sudo apt-get install -y zsh
+
       - name: zsh syntax check (managed shell files)
         run: zsh -n dot_zshenv dot_zshrc dot_zprofile
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,6 +49,11 @@ jobs:
       - name: bash syntax check
         run: bash -n scripts/*.sh
 
+      # The managed zsh layer had no syntax gate at all — the #96 compinit
+      # glob bug lived exactly here (#150). The runner image ships zsh.
+      - name: zsh syntax check (managed shell files)
+        run: zsh -n dot_zshenv dot_zshrc dot_zprofile
+
       - name: shellcheck (warning and above)
         run: shellcheck -S warning scripts/*.sh
 
@@ -75,6 +80,9 @@ jobs:
 
       - name: catalog install gate tests
         run: ./scripts/test-install-packages.sh
+
+      - name: preflight report-only tests
+        run: ./scripts/test-preflight.sh
 
       - name: whitespace check (committed tree)
         run: git diff --check "$(git hash-object -t tree /dev/null)" HEAD

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -115,7 +115,9 @@ main 直 commit は例外扱いにする。
 ./scripts/test-git-signing.sh
 ./scripts/test-starship.sh
 ./scripts/test-ssh.sh
+./scripts/test-preflight.sh
 bash -n scripts/*.sh
+zsh -n dot_zshenv dot_zshrc dot_zprofile
 shellcheck -S warning scripts/*.sh
 git diff --check
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -74,6 +74,13 @@ remote URL scan の方針は `docs/supply-chain-git.md`、npm hardening の検�
 
 policy validation が失敗した場合は exit 1。
 
+## test-preflight.sh
+
+`preflight.sh` の report-only 契約と apply-impact 警告を fixture HOME で検証する(#150)。
+空 home の exit 0 / shell-extra・ssh-1password の replace 警告と override pointer /
+非管理 profile の left-as-is / `~/.config` 権限分岐 / config.local の中身非表示 /
+policy validation 失敗時のみ非 0、をカバーする。
+
 ## test-lib.sh
 
 test-*.sh が共有する fixture 編集 helper(source 専用、lib-policy.sh の後に source する)。

--- a/scripts/test-preflight.sh
+++ b/scripts/test-preflight.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Behavior tests for preflight.sh (#150 — it had none and never ran in CI).
+# Hermetic: a fixture HOME per case; the repo itself is only copied for the
+# one case that needs broken policy data. Contract under test: report-only
+# (exit 0 whatever the host looks like) except a failing policy validation,
+# plus the apply-impact warnings that protect an existing host from a
+# surprising first apply.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
+
+status=0
+pass() { ok "test passed: $*"; }
+miss() {
+  fail "test failed: $*"
+  status=1
+}
+
+fixture_home="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-preflight-test.XXXXXX")"
+trap 'rm -rf "$fixture_home"' EXIT
+
+# 1. An empty home stays report-only: exit 0, no apply-impact warnings.
+empty_home="$fixture_home/empty"
+mkdir -p "$empty_home"
+if pf_out="$(HOME="$empty_home" "$SCRIPT_DIR/preflight.sh" personal 2>&1)"; then
+  if grep -Fq "preflight profile: personal" <<< "$pf_out" \
+    && ! grep -Fq "replaces it" <<< "$pf_out"; then
+    pass "empty home: exit 0 and no apply-impact warnings"
+  else
+    printf '%s\n' "$pf_out" >&2
+    miss "empty home should report cleanly without replace warnings"
+  fi
+else
+  printf '%s\n' "$pf_out" >&2
+  miss "preflight must exit 0 on an empty home (report-only)"
+fi
+
+# 2. shell-extra apply impact (personal manages the shell files): an existing
+#    ~/.zshrc warns with the .local pointer; .zshenv and starship.toml carry
+#    their special no-local-override wording.
+shell_home="$fixture_home/shell"
+mkdir -p "$shell_home/.config"
+printf '# existing\n' > "$shell_home/.zshrc"
+printf '# existing\n' > "$shell_home/.zshenv"
+printf '# existing\n' > "$shell_home/.config/starship.toml"
+if pf_out="$(HOME="$shell_home" "$SCRIPT_DIR/preflight.sh" personal 2>&1)"; then
+  if grep -Fq ".zshrc — apply (shell-extra) replaces it; move machine-specific lines to ~/.zshrc.local" <<< "$pf_out" \
+    && grep -Fq ".zshenv has no ~/.zshenv.local" <<< "$pf_out" \
+    && grep -Fq "starship has no local override" <<< "$pf_out"; then
+    pass "shell-extra: existing shell files warn with the right override pointers"
+  else
+    printf '%s\n' "$pf_out" >&2
+    miss "shell-extra apply-impact warnings missing or wrong"
+  fi
+else
+  printf '%s\n' "$pf_out" >&2
+  miss "preflight must exit 0 with existing shell files"
+fi
+
+# 3. The same files under a profile without shell-extra (work-minimal) are
+#    left-as-is items, not replace warnings.
+if pf_out="$(HOME="$shell_home" "$SCRIPT_DIR/preflight.sh" work-minimal 2>&1)"; then
+  if grep -Fq "not managed for profile work-minimal (left as-is)" <<< "$pf_out" \
+    && ! grep -Fq "apply (shell-extra) replaces it" <<< "$pf_out"; then
+    pass "unmanaged profile: existing shell files are left-as-is items"
+  else
+    printf '%s\n' "$pf_out" >&2
+    miss "unmanaged profile must not warn about replacing shell files"
+  fi
+else
+  printf '%s\n' "$pf_out" >&2
+  miss "preflight must exit 0 for work-minimal"
+fi
+
+# 4. ssh-1password apply impact: an existing ~/.ssh/config warns with the
+#    config.local pointer; a present config.local is reported by existence
+#    only (its contents never echo).
+ssh_home="$fixture_home/ssh"
+mkdir -p "$ssh_home/.ssh"
+printf 'Host canary-host\n  User canary-user\n' > "$ssh_home/.ssh/config"
+printf 'Host secret-canary\n' > "$ssh_home/.ssh/config.local"
+if pf_out="$(HOME="$ssh_home" "$SCRIPT_DIR/preflight.sh" personal 2>&1)"; then
+  if grep -Fq "apply (ssh-1password) replaces it; move machine-specific hosts to ~/.ssh/config.local" <<< "$pf_out" \
+    && grep -Fq "local override present" <<< "$pf_out" \
+    && ! grep -Fq "secret-canary" <<< "$pf_out"; then
+    pass "ssh: replace warning + local-override presence, contents never echoed"
+  else
+    printf '%s\n' "$pf_out" >&2
+    miss "ssh apply-impact warning wrong, or config.local contents leaked"
+  fi
+else
+  printf '%s\n' "$pf_out" >&2
+  miss "preflight must exit 0 with an existing ssh config"
+fi
+
+# 5. ~/.config permission: 0755 warns about the 0700 change; 0700 is ok.
+perm_home="$fixture_home/perm"
+mkdir -p "$perm_home/.config"
+chmod 755 "$perm_home/.config"
+if pf_out="$(HOME="$perm_home" "$SCRIPT_DIR/preflight.sh" personal 2>&1)"; then
+  if grep -Fq "mode is 755; apply manages it at 0700" <<< "$pf_out"; then
+    pass "config dir at 0755 warns about the 0700 change"
+  else
+    printf '%s\n' "$pf_out" >&2
+    miss "0755 config dir should warn about the mode change"
+  fi
+else
+  printf '%s\n' "$pf_out" >&2
+  miss "preflight must exit 0 with a 0755 config dir"
+fi
+chmod 700 "$perm_home/.config"
+if pf_out="$(HOME="$perm_home" "$SCRIPT_DIR/preflight.sh" personal 2>&1)"; then
+  if grep -Fq "mode already 0700" <<< "$pf_out"; then
+    pass "config dir at 0700 reports ok"
+  else
+    printf '%s\n' "$pf_out" >&2
+    miss "0700 config dir should report ok"
+  fi
+else
+  printf '%s\n' "$pf_out" >&2
+  miss "preflight must exit 0 with a 0700 config dir"
+fi
+
+# 6. The only non-zero path: a failing policy validation aborts (a broken
+#    profiles.yaml in a repo copy — the mutation is fail-closed because the
+#    exit-1 assertion itself would fail on a no-op).
+broken_root="$fixture_home/broken"
+mkdir -p "$broken_root/.chezmoidata"
+cp -R "$DOTFILES_ROOT/scripts" "$broken_root/scripts"
+cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$broken_root/.chezmoidata/"
+printf 'profiles: {}\n' > "$broken_root/.chezmoidata/profiles.yaml"
+if HOME="$empty_home" "$broken_root/scripts/preflight.sh" personal >/dev/null 2>&1; then
+  miss "preflight must exit non-zero when policy validation fails"
+else
+  pass "broken policy data makes preflight exit non-zero (fail-closed)"
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "preflight tests passed"
+fi
+exit "$status"


### PR DESCRIPTION
Closes #150(PR 2/2。優先項目 3・4)

## 変更

**3. preflight のテスト(監査 #15: テストゼロ・CI 未実行)**
- `scripts/test-preflight.sh` 新規(7 ケース): report-only 契約(空/既存ファイルあり/権限 755・700 の home で exit 0、policy 破壊時のみ非 0)、apply-impact 警告(shell-extra / ssh の replace 警告と .local pointer、.zshenv・starship の「local override なし」特別文言)、非管理 profile の left-as-is、**config.local の中身が出力に漏れない**(canary assert)
- validate job に配線

**4. zsh -n の CI gate(監査 #16: zsh 層に構文チェックすら無し)**
- `zsh -n dot_zshenv dot_zshrc dot_zprofile` step を追加(#96 の compinit glob バグが住んでいた層。runner image は zsh 同梱)

docs 追従: github-workflow のコマンド一覧 + scripts/README に test-preflight の節。

## 残り(low、issue クローズと同時に見送りを明記)

private-backup の dir 型は #141 のテスト 21/22 で既にカバー済み。lib-policy の mas 系 drift 分岐等の low は費用対効果が薄く見送り。

## 検証

test-preflight 7 ケース green(実機)、zsh -n ローカル通過、shellcheck 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1
