### PR TITLE
gitignore: .agent-context.local.md を除外(#147 残項目)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .chezmoiignore.local
 .local/
 worklog/
+.agent-context.local.md


### PR DESCRIPTION
#147 の残項目 3(ユーザー承認済み)。

ユーザー正本の `.agent-context.local.md`(運用ルール上 git 管理しない)が ignore されておらず、作成後に `git add .` で private 参照先が public repo に入る経路が開いていた(監査 security の唯一の新規所見・latent)。`.chezmoiignore.local` は登録済みでこれだけ抜けていた。

検証: `git check-ignore -v` で ignore が効くことを確認。ファイル本体はユーザー指示で local に作成済み(untracked)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9GGEVTXr9Mo7kYcPzRDG1