### PR TITLE
docs: directory-convention に sandbox 意味論・昇格ルール・命名規約 (#140)

### DIFF
--- a/docs/directory-convention.md
+++ b/docs/directory-convention.md
@@ -73,6 +73,12 @@ doctor / preflight は標準 root の不在を中立に報告し(警告ではな
 - 個人 project と会社 project を同じ階層に置かない。
 - client project は client ごとの下位階層に分ける。
 - agent project は `~/src/agent` に分離する。
+- `~/src/sandbox` は「project 未満」の作業スペース。git 管理外の実験・企画メモを
+  置いてもよいが、消しても痛くないものに限る(企画メモの正本は外部ナレッジツール)。
+- 昇格ルール: sandbox の中身が remote 付きの git repo に育ったら、本来の context
+  (通常は `~/src/personal/<repo>`)へ移す。
+- 新規 repo のディレクトリ名は kebab-case とし、remote の repo 名に一致させる
+  (既存 repo の rename はしない)。
 - `~/src` の外(unknown directory)では Git identity が解決されず commit が fail-closed に
   なる(意図した安全側の挙動)。標準 root の不在自体は doctor が中立に報告する(警告ではない)。
   非標準配置で運用する場合の解除方法は上の「許容された非標準配置」を参照。


### PR DESCRIPTION
## Summary

#140(directory-convention と実態の乖離)の裁定 = **案 B(実 repo を `~/src` 階層へ移管)**。移管は実機で完了済み(詳細は issue コメント)。この PR は裁定過程で決めた規約 3 点を directory-convention.md に追記する:

- `~/src/sandbox` = 「project 未満」の作業スペース(git 管理外の実験・企画メモ可、消しても痛くないものに限る。企画メモの正本は外部ナレッジツール)
- 昇格ルール: sandbox の中身が remote 付き git repo に育ったら本来の context へ移す
- 新規 repo のディレクトリ名は kebab-case で remote 名に一致(既存 rename はしない)

## Linked Issue

#140(close は移管記録コメントとともに手動で行う)

## Validation

- docs のみ・render 不変(`docs` は `.chezmoiignore` で home 適用外)。`git diff --check` クリーン。
- 実機側の移管検証は実施済み: 全 5 repo が includeIf 由来で identity 解決(`--show-origin`)、doctor personal で project roots(personal/sandbox/agent)exists・credential scan 6 repo・violation ゼロ。

## Side Effects

repo 変更としては無し。実機側では別途: `~/dev`・`~/work`(ai-agent-plan 除く)廃止、`AGENT_TOOLS` override 削除、Codex config path 更新、暗号化バックアップ再実行。

## Residual Risk

- 「許容された非標準配置」節は機構の説明として残置(dotfiles 本体 `~/dotfiles` が該当し続ける)。
- 旧 path のセッション履歴(Claude Code / Codex)は追従しない(許容済み)。

## Next

- Codex 相互レビュー → must0 で merge → #140 close。