### PR TITLE
profiles: work-minimal 削除 + work-dev → work 統合 (#146)

### DIFF
--- a/.chezmoidata/profiles.yaml
+++ b/.chezmoidata/profiles.yaml
@@ -47,37 +47,7 @@ profiles:
       gateGitHubMcp: true
       enableGitHubIsolatedReader: false
 
-  work-minimal:
-    environmentKind: work
-    modules:
-      - base
-      - git-profile
-      - supply-chain-git
-      - supply-chain-npm
-      - supply-chain-corepack
-      - doctor
-      - preflight
-      - update-policy
-      - ai-policy
-    capabilities:
-      installPackages: false
-      installGuiApps: false
-      enable1PasswordSSH: false
-      enableGitSigning: false
-      enableDirenv: false
-      enableRuntimeManagement: false
-      npmHardeningMode: report
-      corepackMode: report
-      allowNetworkTunnels: false
-      allowSecretsAccess: false
-      enableAiTools: false
-      enforceAiSandbox: false
-      enableAgentToolsStatus: false
-      enableAiPolicy: true
-      gateGitHubMcp: false
-      enableGitHubIsolatedReader: false
-
-  work-dev:
+  work:
     environmentKind: work
     modules:
       - base

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ personal project として段階的に作っている。現時点の実装状況
 profile + environmentKind + modules + capabilities + policy
 ```
 
-- **profile**: 用途別プリセット(`personal` / `work-minimal` / `work-dev`)。選びやすさのための入口で、権限そのものではない。
+- **profile**: 用途別プリセット(`personal` / `work`)。選びやすさのための入口で、権限そのものではない。
 - **environmentKind**: `personal` / `work` / `client` / `sandbox` / `agent` の環境種別。許可される capability に制約をかける(下記)。
 - **modules**: 機能単位。`paths:` で管理対象 file を宣言し、`.chezmoiignore` の生成を駆動する。
 - **capabilities**: 実際に許可する操作・副作用(install、secret access、npm hardening mode など)。**何が起きるかは最終的に capabilities が決める**。

--- a/docs/claude-settings.md
+++ b/docs/claude-settings.md
@@ -63,7 +63,7 @@ permission 承認は対象外。
 
 `claude-settings` module(`.chezmoidata/modules.yaml`)が `.claude` /
 `.claude/settings.json` を宣言し、`personal` profile にのみ登録する。`.chezmoiignore` の
-module loop が、module を持たない profile(work-minimal / work-dev)では `.claude` を
+module loop が、module を持たない profile(work)では `.claude` を
 **ディレクトリごと** ignore する。`scripts/test-render.sh` が profile 別の managed set で
 この gate を回帰固定している。
 

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -131,8 +131,8 @@ git diff --check
 `preflight` / `doctor` を変更した場合:
 
 ```sh
-./scripts/preflight.sh work-minimal
-./scripts/doctor.sh work-minimal
+./scripts/preflight.sh work
+./scripts/doctor.sh work
 ```
 
 Git config source(`dot_gitconfig`)を変更した場合:

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -176,8 +176,7 @@ corepackMode:
 ## Initial Profiles
 
 - `personal`: 個人Mac向け。副作用のある capability は明示的に許可する。
-- `work-minimal`: 会社Mac向け最小構成。install 系は無効。
-- `work-dev`: 会社Mac向け開発構成。runtime / shell は許可し、install 系は無効。
+- `work`: 会社Mac向け開発構成。runtime / shell は許可し、install 系は無効(#146 で work-minimal / work-dev を統合)。
 
 ## Core に入れてよいもの
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -27,7 +27,7 @@ global の mise config(`~/.config/mise/config.toml`)と project の `.mise.toml`
 
 `enableRuntimeManagement` が制御するのは **mise config file の chezmoi 管理**であって、runtime を実際に install することではない。
 
-- `work-dev` は `enableRuntimeManagement=true`(config 管理は可)だが `installPackages=false`。実際の `mise install`(runtime を取得する install 操作)は **本人の明示手動操作に限定**し、repo が work 環境で自動実行することはしない。
+- `work` は `enableRuntimeManagement=true`(config 管理は可)だが `installPackages=false`。実際の `mise install`(runtime を取得する install 操作)は **本人の明示手動操作に限定**し、repo が work 環境で自動実行することはしない。
 - environmentKind の制約上、work / client / agent では install 系 capability が false 必須(`docs/policy-model.md`)。mise config を管理することと runtime を install することは別レイヤだと理解する。
 
 ## capability との対応

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -68,7 +68,7 @@ secret 全般は op + direnv で供給してよいが、**Git identity は対象
 
 direnv には 2 つの用途がある。本 doc が扱うのは後者(secret 供給)だけ。
 
-- **project env(PATH / runtime 切り替え等、secret 無関係)**: `enableDirenv` capability が制御する([runtime](runtime.md))。`work-dev` のように `enableDirenv=true` かつ `allowSecretsAccess=false` の構成があり得る(direnv は使うが secret 注入はしない)。
+- **project env(PATH / runtime 切り替え等、secret 無関係)**: `enableDirenv` capability が制御する([runtime](runtime.md))。`work` のように `enableDirenv=true` かつ `allowSecretsAccess=false` の構成があり得る(direnv は使うが secret 注入はしない)。
 - **secret 供給**: 本 doc の規約。`allowSecretsAccess` で別途 gate する。
 
 `direnv allow` / `mise trust` は自動化しない([runtime](runtime.md))。direnv の有効化と secret 供給の許可は独立した判断とする。

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -95,7 +95,7 @@
 ## 管理対象と gate
 
 - `shell-extra` module の `paths:` に `.zshenv` / `.zshrc` / `.zprofile` / `.config/starship.toml` を宣言している(`.chezmoidata/modules.yaml`)。
-- `shell-extra` module を持つ profile(`personal` / `work-dev`)でのみ管理対象になる。持たない `work-minimal` ではいずれも `.chezmoiignore` の生成によって除外され、既存ファイルはそのまま残る。
+- `shell-extra` module を持つ profile(`personal` / `work`)でのみ管理対象になる。持たない profile ではいずれも `.chezmoiignore` の生成によって除外され、既存ファイルはそのまま残る。
 
 ## local override(repo に入れない)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -241,7 +241,7 @@ gate profile を与える・throwaway age 鍵)。実 home には触れない。`
 - verify が正アーカイブを受理し、wrong identity / 改竄アーカイブを拒否すること。
 - `--identity-command`(op seam)経由でも verify できること。
 - manifest 不整合(checksum mismatch / 台帳外ファイル / symlink 混入)を検出すること。
-- 拒否 profile(work-minimal)では backup が実行拒否し、アーカイブを書かないこと。
+- 拒否 profile(work)では backup が実行拒否し、アーカイブを書かないこと。
 - 非コミットの local 補足にある unsafe path(`..` 等)を skip し、baseline は捕捉すること。
 - recipient 未指定は usage error(exit 2)になること。
 - restore が dry-run では何も書かず、`--apply` で原文どおり復元すること。
@@ -262,7 +262,7 @@ profile を解決できない・未知の profile・`true` 以外の値はすべ
 検証内容:
 
 - `profile_allows_secrets_access` が `allowSecretsAccess=true` の profile(personal)だけ許可し、
-  `false` の profile(work-minimal / work-dev)と未知 profile を拒否すること(vacuously true にしない)。
+  `false` の profile(work)と未知 profile を拒否すること(vacuously true にしない)。
 - chezmoi が見つからないとき `resolve_runtime_profile` / `require_secrets_access` が fail-closed で
   拒否すること(default profile に倒さない)。
 - chezmoi が profile を解決できる環境では、gate の判定が profiles.yaml の

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -311,7 +311,7 @@ fi
 section "managed-path orphans"
 # A file that carries the managed-by header but whose path is not
 # managed for this profile is likely left over from another profile
-# (e.g. ~/.npmrc after switching personal -> work-minimal). Report
+# (e.g. ~/.npmrc after switching personal -> work). Report
 # only; nothing is removed. Only the header line is inspected.
 orphan_count=0
 while IFS= read -r module; do

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -21,23 +21,23 @@ status=0
 fixture_home="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-doctor-test.XXXXXX")"
 trap 'rm -rf "$fixture_home"' EXIT
 
-# A leftover enforce-mode .npmrc, as after switching personal -> work-minimal.
+# A leftover enforce-mode .npmrc, as after switching personal -> work.
 printf '# Managed by chezmoi from kosako/dotfiles (npmHardeningMode=enforce).\nignore-scripts=true\n' \
   > "$fixture_home/.npmrc"
 
 orphan_marker="orphan from another profile"
 
-# work-minimal does not manage .npmrc (npmHardeningMode=report): orphan.
-if ! output="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" work-minimal 2>&1)"; then
+# work does not manage .npmrc (npmHardeningMode=report): orphan.
+if ! output="$(HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" work 2>&1)"; then
   printf '%s\n' "$output" >&2
-  fail "test failed: doctor must stay exit 0 for work-minimal"
+  fail "test failed: doctor must stay exit 0 for work"
   status=1
 fi
 if grep -F "$orphan_marker" <<< "$output" | grep -Fq ".npmrc"; then
-  ok "test passed: orphan .npmrc reported for work-minimal"
+  ok "test passed: orphan .npmrc reported for work"
 else
   printf '%s\n' "$output" >&2
-  fail "test failed: orphan .npmrc not reported for work-minimal"
+  fail "test failed: orphan .npmrc not reported for work"
   status=1
 fi
 
@@ -57,7 +57,7 @@ fi
 
 # A file without the managed-by header is never an orphan.
 printf 'registry-noise=1\n' > "$fixture_home/.npmrc"
-if HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" work-minimal 2>&1 | grep -Fq "$orphan_marker"; then
+if HOME="$fixture_home" "$SCRIPT_DIR/doctor.sh" work 2>&1 | grep -Fq "$orphan_marker"; then
   fail "test failed: headerless file must not be reported as orphan"
   status=1
 else

--- a/scripts/test-install-packages.sh
+++ b/scripts/test-install-packages.sh
@@ -42,20 +42,18 @@ else
 fi
 
 # 2. profile_installs_source: personal installs every installable source;
-#    work-minimal / work-dev install none (installPackages/GuiApps are false).
+#    work installs none (installPackages/GuiApps are false).
 for src in brew_formula npm_global go_install brew_cask mas; do
   if profile_installs_source personal "$src"; then
     pass "personal installs $src"
   else
     miss "personal should install $src"
   fi
-  for denied in work-minimal work-dev; do
-    if profile_installs_source "$denied" "$src"; then
-      miss "$denied must not install $src"
-    else
-      pass "$denied does not install $src"
-    fi
-  done
+  if profile_installs_source work "$src"; then
+    miss "work must not install $src"
+  else
+    pass "work does not install $src"
+  fi
 done
 
 # 3. Fail-closed: unknown profile and manual source never install.
@@ -105,13 +103,13 @@ fi
 
 # 5b. A resolved work profile plans zero installs (everything gates out before
 #     any probing, so this is deterministic and has no side effects).
-fake_chezmoi '{"profile":"work-minimal"}' 0
+fake_chezmoi '{"profile":"work"}' 0
 if out="$(PATH="$fixture_bin:$PATH" "$SCRIPT_DIR/install-packages.sh" 2>&1)"; then
   if grep -Fq "dry-run: 0 would be installed" <<< "$out"; then
-    pass "work-minimal plans zero installs (gated out)"
+    pass "work plans zero installs (gated out)"
   else
     printf '%s\n' "$out" >&2
-    miss "work-minimal should plan zero installs"
+    miss "work should plan zero installs"
   fi
 else
   printf '%s\n' "$out" >&2

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -132,7 +132,7 @@ run_fail_contains() {
 fixture=""
 make_fixture
 run_ok "validates all profiles" "$fixture/scripts/validate-policy.sh" --all
-run_ok_contains "lists profiles" "work-dev" "$fixture/scripts/validate-policy.sh" --list-profiles
+run_ok_contains "lists profiles" "work" "$fixture/scripts/validate-policy.sh" --list-profiles
 
 make_fixture
 replace_once "$fixture/.chezmoidata/profiles.yaml" "      corepackMode: report" "      corepackMode: off"

--- a/scripts/test-preflight.sh
+++ b/scripts/test-preflight.sh
@@ -62,19 +62,24 @@ else
   miss "preflight must exit 0 with existing shell files"
 fi
 
-# 3. The same files under a profile without shell-extra (work-minimal) are
-#    left-as-is items, not replace warnings.
-if pf_out="$(HOME="$shell_home" "$SCRIPT_DIR/preflight.sh" work-minimal 2>&1)"; then
-  if grep -Fq "not managed for profile work-minimal (left as-is)" <<< "$pf_out" \
-    && ! grep -Fq "apply (shell-extra) replaces it" <<< "$pf_out"; then
-    pass "unmanaged profile: existing shell files are left-as-is items"
+# 3. A path whose module the profile does not carry is a left-as-is item,
+#    not a replace warning. work has no ssh-1password module, so an existing
+#    ~/.ssh/config exercises the unmanaged branch (shell files are managed by
+#    work since the #146 profile merge, so they no longer fit this case).
+unmanaged_home="$fixture_home/unmanaged"
+mkdir -p "$unmanaged_home/.ssh"
+printf 'Host canary-host\n' > "$unmanaged_home/.ssh/config"
+if pf_out="$(HOME="$unmanaged_home" "$SCRIPT_DIR/preflight.sh" work 2>&1)"; then
+  if grep -Fq "not managed for profile work (left as-is)" <<< "$pf_out" \
+    && ! grep -Fq "apply (ssh-1password) replaces it" <<< "$pf_out"; then
+    pass "unmanaged module path: existing ssh config is a left-as-is item"
   else
     printf '%s\n' "$pf_out" >&2
-    miss "unmanaged profile must not warn about replacing shell files"
+    miss "unmanaged module path must not warn about replacing ssh config"
   fi
 else
   printf '%s\n' "$pf_out" >&2
-  miss "preflight must exit 0 for work-minimal"
+  miss "preflight must exit 0 for work"
 fi
 
 # 4. ssh-1password apply impact: an existing ~/.ssh/config warns with the

--- a/scripts/test-private-backup.sh
+++ b/scripts/test-private-backup.sh
@@ -220,11 +220,11 @@ else
 fi
 
 # 9. Runtime gate: a denied profile refuses to back up.
-set_profile work-minimal
+set_profile work
 if run backup --out "$fixture_home/out/denied.age" --recipient "$recipient" --yes >/dev/null 2>&1; then
   miss "backup must refuse under a denied profile"
 else
-  pass "backup refuses under a denied profile (work-minimal)"
+  pass "backup refuses under a denied profile (work)"
 fi
 [[ -f "$fixture_home/out/denied.age" ]] && miss "denied backup must not write an archive"
 set_profile personal
@@ -341,11 +341,11 @@ else
 fi
 
 # 18. Runtime gate: a denied profile refuses to restore.
-set_profile work-minimal
+set_profile work
 if run restore --in "$archive" --identity "$fixture_home/keys/id.txt" --target-home "$rdst" --apply >/dev/null 2>&1; then
   miss "restore must refuse under a denied profile"
 else
-  pass "restore refuses under a denied profile (work-minimal)"
+  pass "restore refuses under a denied profile (work)"
 fi
 set_profile personal
 

--- a/scripts/test-render.sh
+++ b/scripts/test-render.sh
@@ -55,10 +55,7 @@ expected_managed() {
     personal)
       printf '%s\n' .claude .claude/settings.json .config .config/git .config/git/signing.gitconfig .config/mise .config/mise/config.toml .config/starship.toml .gitconfig .npmrc .ssh .ssh/config .zprofile .zshenv .zshrc
       ;;
-    work-minimal)
-      printf '%s\n' .config .gitconfig
-      ;;
-    work-dev)
+    work)
       printf '%s\n' .config .config/mise .config/mise/config.toml .config/starship.toml .gitconfig .zprofile .zshenv .zshrc
       ;;
     *)
@@ -140,9 +137,9 @@ section "non-interactive init"
 
 make_root
 if output="$(env HOME="$root/home" XDG_CONFIG_HOME="$root/config" XDG_DATA_HOME="$root/data" \
-  chezmoi init --source "$DOTFILES_ROOT" --promptString profile=work-minimal 2>&1)"; then
+  chezmoi init --source "$DOTFILES_ROOT" --promptString profile=work 2>&1)"; then
   config_file="$root/config/chezmoi/chezmoi.toml"
-  if grep -Fxq 'profile = "work-minimal"' "$config_file"; then
+  if grep -Fxq 'profile = "work"' "$config_file"; then
     ok "test passed: non-interactive init writes the chosen profile"
   else
     fail "test failed: init config does not contain the chosen profile"

--- a/scripts/test-secrets-gate.sh
+++ b/scripts/test-secrets-gate.sh
@@ -20,19 +20,17 @@ miss() {
 }
 
 # 1. profile_allows_secrets_access: only allowSecretsAccess=true profiles
-#    pass. personal grants it; work-minimal / work-dev do not.
+#    pass. personal grants it; work does not.
 if profile_allows_secrets_access personal; then
   pass "personal grants secret access"
 else
   miss "personal should grant secret access"
 fi
-for denied in work-minimal work-dev; do
-  if profile_allows_secrets_access "$denied"; then
-    miss "$denied must not grant secret access"
-  else
-    pass "$denied denied secret access"
-  fi
-done
+if profile_allows_secrets_access work; then
+  miss "work must not grant secret access"
+else
+  pass "work denied secret access"
+fi
 
 # 2. An unknown profile must not pass (fail-closed, never vacuously true).
 if profile_allows_secrets_access no-such-profile; then
@@ -108,11 +106,11 @@ else
 fi
 
 # 4c. Healthy chezmoi resolving a denied profile -> refused.
-fake_chezmoi '{"profile":"work-minimal"}' 0
+fake_chezmoi '{"profile":"work"}' 0
 if with_fixture require_secrets_access; then
-  miss "gate must refuse for resolved work-minimal profile"
+  miss "gate must refuse for resolved work profile"
 else
-  pass "gate refuses for resolved work-minimal profile"
+  pass "gate refuses for resolved work profile"
 fi
 
 # 4d. Healthy chezmoi but no profile key -> fail closed (empty profile).


### PR DESCRIPTION
## Summary

#146 の裁定(ユーザー・2026-07-05)を実装。会社 Mac の実 profile を実機確認(`chezmoi data` = work-dev)したうえで、**work-minimal を削除し、work-dev を `work` に rename して 1 本化**する。

- 監査の「work 未使用」は誤認(会社 Mac が work-dev で稼働中)→ 実態に合わせ work-dev 相当を残す
- work の capability セット・managed set は旧 work-dev と**完全同一**(名前の付け替えのみ)
- environmentKind 制約の強制機構は不変
- tests: 拒否系 fixture の参照 profile を work へ。test-preflight の「module を持たない profile の left-as-is」契約は shell-extra(統合後は work が保有)から ssh-1password 非搭載ケースへ書き換えて維持
- docs 8 ファイルを work 1 本に追従

## Linked Issue

#146(**merge では close しない** — 会社 Mac の profile 切替完了後に close)

## Validation

- ローカルで validate-policy --all + 全テスト 13 本 PASS、bash -n / shellcheck -S warning / git diff --check クリーン
- `work-minimal` / `work-dev` の残存参照ゼロ(policy-model.md の統合経緯 1 行のみ意図的残置)
- render: work の managed set = 旧 work-dev と同一を test-render で固定

## Side Effects

このマシン(personal)への影響ゼロ。**会社 Mac は merge 後、profile 値を切り替えるまで `chezmoi apply` が fail-closed で停止する**(稼働中の設定は無傷)。移行手順は issue #146 に記載。

## Residual Risk

- 会社 Mac の切替が完了するまで、会社 Mac 側は dotfiles の更新を取り込めない(意図した安全側の挙動)

## Next

- Codex 相互レビュー → must0 で merge → issue に会社 Mac 移行手順を記載 → ユーザーが会社 Mac で切替 → close