### PR TITLE
claude-settings: secret floor に credential-store 読取を追加 + Read 主軸設計の明文化 (#136)

### DIFF
--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -180,9 +180,13 @@ personal の `gateGitHubMcp` を true** に反転し、github MCP deny を live 
   profile のみ実効。dangling は doctor が report)。
 - GitHub 由来の deny は **3 tier**(#119 Phase 2 task B。専用 capability は作らない):
   - **(1) never-legit secret floor は無条件**(常時 render)。SSH 秘密鍵読取(`~/.ssh`)・
-    全 env dump(`printenv` / `env`)・GitHub Actions secret(`gh secret` / `gh api *secrets*`)は
-    誰も Claude に正規に頼まず、deny は Claude の Bash tool にしか効かない(人間のターミナル
-    非影響)ので、`enforceAiSandbox` を待たず常時 deny する(personal で今日 live)。
+    credential-store 読取(`~/.aws` / `~/.config/gh` の OAuth token / `~/.netrc` /
+    `~/.codex/auth.json`。#136)・全 env dump(`printenv` / `env`)・GitHub Actions secret
+    (`gh secret` / `gh api *secrets*`)は誰も Claude に正規に頼まず、deny は Claude の
+    tool call にしか効かない(人間のターミナル非影響)ので、`enforceAiSandbox` を待たず
+    常時 deny する(personal で今日 live)。file 系は **Read 側 deny を主軸**とし、Bash
+    matcher の path 列挙はしない(等価経路で迂回できる leaky steering。tier 全体が
+    boundary でない点は下記)。
   - **(2)** `gateGitHubMcp`(上記の MCP deny)。
   - **(3) human-legit な write は `enforceAiSandbox` に相乗り**。main / master への直 push と
     `.env` 読取(`cat *.env*` / `Read(//**/.env*)`)を deny、release 操作と branch protection /

--- a/docs/claude-settings.md
+++ b/docs/claude-settings.md
@@ -14,7 +14,7 @@ tool-specific config template(agent-tools 側の責務)とは別物
 | 対象 | 置き場所 | 管理 |
 | --- | --- | --- |
 | personal・public-safe な `settings.json`(model / effort / public plugin / 通知 / statusLine / tui / workflow 警告抑止 等の global preference) | public repo(`dot_claude/settings.json.tmpl`) | ✅ chezmoi(**personal profile のみ**) |
-| permission ブロック(#119): secret floor の無条件 deny 8 件(`~/.ssh` 読取 / env dump / gh secret 系)、`gateGitHubMcp` の `mcp__github` deny(personal 既定 true で計 9 件)、`allow: mcp__pencil`、`enforceAiSandbox` 連動の human-legit gate | 同上(template が capability で gate して出力) | ✅ chezmoi(内容の回帰は `test-claude-settings.sh` が exact-set で固定) |
+| permission ブロック(#119): secret floor の無条件 deny 12 件(`~/.ssh` 読取 / credential-store 読取 / env dump / gh secret 系)、`gateGitHubMcp` の `mcp__github` deny(personal 既定 true で計 13 件)、`allow: mcp__pencil`、`enforceAiSandbox` 連動の human-legit gate | 同上(template が capability で gate して出力) | ✅ chezmoi(内容の回帰は `test-claude-settings.sh` が exact-set で固定) |
 | personal・機密(secret を含む設定など) | `~/.claude/settings.local.json` | ❌ 非コミット・管理外 |
 | work / client の settings | 暗号化バックアップ(#60)か各マシン手設定 | ❌ public repo に生値を置かない |
 | skill / instruction(`skills/`、`agent-tools/CLAUDE.md`) | agent-tools が配布 | ❌ 別 repo の責務 |
@@ -70,9 +70,13 @@ module loop が、module を持たない profile(work)では `.claude` を
 ## permissions(#119: secret floor / GitHub guard)
 
 `permissions.deny` には capability 非依存の **secret floor**(never-legit な secret 読取
-8 件: `Read(~/.ssh/**)` / `Bash(cat ~/.ssh/*)` / `gh secret` / `gh api *secrets*` /
-`env` / `printenv` 系)を常時出力する。`gateGitHubMcp=true`(personal 既定)で
-`mcp__github`(server 全体)の deny を足して計 9 件、`enforceAiSandbox=true` で human-legit gate
+12 件: `Read(~/.ssh/**)` と credential-store 読取 `Read(~/.aws/**)` / `Read(~/.config/gh/**)`
+(gh の OAuth token)/ `Read(~/.netrc)` / `Read(~/.codex/auth.json)`、`Bash(cat ~/.ssh/*)` /
+`gh secret` / `gh api *secrets*` / `env` / `printenv` 系)を常時出力する。**Read 側 deny を
+主軸**とする(Read tool はコマンド経由でない読取にも効く。Bash matcher は `head` / `xxd` /
+`python open()` 等の等価経路で迂回できる leaky steering なので、path ごとの Bash 列挙は
+意図的にしない。#136)。`gateGitHubMcp=true`(personal 既定)で
+`mcp__github`(server 全体)の deny を足して計 13 件、`enforceAiSandbox=true` で human-legit gate
 (`.env` 読取 / main・master への push の deny、release / branch-protection の ask)を
 追加する。`permissions.allow` は `mcp__pencil` のみ。これらは **steering であって
 enforcement boundary ではない**(射程と限界は

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -96,8 +96,10 @@ GitHub runtime prompt-injection 防御(epic #119)の capability 2 本。射程�
 - `enableGitHubIsolatedReader`(boolean): Phase 3(#131)の隔離 reader 用。**宣言のみで未配線**
   (declared, not enforced)。true でも enforcement は無く doctor が warn する。
 - GitHub 由来の deny は専用 capability を作らず **3 tier**(#119 Phase 2 task B): never-legit な
-  secret 読取(`~/.ssh` / `printenv` / `env` / `gh secret` / `gh api *secrets*`)は **無条件 deny**
-  (`enforceAiSandbox` を待たず常時)、main / master 直 push と `.env` 読取 deny + release /
+  secret 読取(`~/.ssh` と credential-store の `~/.aws` / `~/.config/gh` / `~/.netrc` /
+  `~/.codex/auth.json`(#136)/ `printenv` / `env` / `gh secret` / `gh api *secrets*`)は
+  **無条件 deny**(`enforceAiSandbox` を待たず常時)。file 系は **Read 側 deny を主軸**とし、
+  Bash matcher の path 列挙はしない(等価経路で迂回できる leaky steering。#136)。main / master 直 push と `.env` 読取 deny + release /
   branch-protection ask は **`enforceAiSandbox` に相乗り**(human-legit ゆえ常時 ON にしない)。
 - tier3 の main-push deny(`git push * main|master`)は **leaky steering**: ` main` 末尾の explicit
   形しか拾わず bare `git push` / `git push origin HEAD` / refspec(`HEAD:main`)は抜ける(Claude Code

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -7,13 +7,18 @@
        ask = always needs approval.
 
        Three deny tiers (#119 Phase 2 task B):
-       1. never-legit secret floor (UNCONDITIONAL): reading SSH private keys,
-          dumping the whole env, or touching GitHub Actions secrets is never
-          something the human legitimately asks Claude (the AI tool) to do, and a
-          deny binds only Claude's own Bash tool calls — never the human's own
-          terminal, and not env calls nested inside a script Claude runs. So this
-          floor is always on at ~zero human friction, making the decision-6 secret
-          floor live on personal WITHOUT enforceAiSandbox's egress block.
+       1. never-legit secret floor (UNCONDITIONAL): reading SSH private keys or
+          credential-store files (gh OAuth token, AWS keys, ~/.netrc, Codex
+          auth.json), dumping the whole env, or touching GitHub Actions secrets
+          is never something the human legitimately asks Claude (the AI tool) to
+          do, and a deny binds only Claude's own Bash tool calls — never the
+          human's own terminal, and not env calls nested inside a script Claude
+          runs. So this floor is always on at ~zero human friction, making the
+          decision-6 secret floor live on personal WITHOUT enforceAiSandbox's
+          egress block. Read() denies are the PRIMARY axis (they bind the Read
+          tool regardless of which command would print the file); the Bash
+          matchers are bypassable steering (head/xxd/python open() slip through),
+          so per-path Bash enumeration is deliberately NOT attempted (#136).
        2. gateGitHubMcp: deny the github MCP server.
        3. enforceAiSandbox (human-legit, stays gated): git push to main/master and
           reading .env are things the human does legitimately direct Claude to do,
@@ -22,7 +27,7 @@
           Phase 3 home for these). The context-gated writes (merge/PR/comment/
           label/push ai/*) need the PreToolUse hook that Phase 2 handed off to
           Phase 3 (#131) and are intentionally absent. */ -}}
-{{- $deny := list "Read(~/.ssh/**)" "Bash(cat ~/.ssh/*)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(env)" "Bash(env *)" "Bash(printenv)" "Bash(printenv *)" -}}
+{{- $deny := list "Read(~/.ssh/**)" "Read(~/.aws/**)" "Read(~/.config/gh/**)" "Read(~/.netrc)" "Read(~/.codex/auth.json)" "Bash(cat ~/.ssh/*)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(env)" "Bash(env *)" "Bash(printenv)" "Bash(printenv *)" -}}
 {{- if index $caps "gateGitHubMcp" -}}{{- $deny = concat $deny (list "mcp__github") -}}{{- end -}}
 {{- $ask := list -}}
 {{- if index $caps "enforceAiSandbox" -}}{{- $deny = concat $deny (list "Bash(cat *.env*)" "Read(//**/.env*)" "Bash(git push * main)" "Bash(git push * master)") -}}{{- $ask = concat $ask (list "Bash(gh release create *)" "Bash(gh release delete *)" "Bash(gh release edit *)" "Bash(gh api *protection*)" "Bash(gh api *rulesets*)") -}}{{- end -}}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -297,8 +297,8 @@ chezmoi が必要(CI では version pin して導入する)。
 
 managed `~/.claude/settings.json` の rendered content を検証する。throwaway repo copy で
 capability(`enforceAiSandbox` / `gateGitHubMcp`)を flip し、secret floor の無条件 deny
-8 件が順序込みで常時出力されること(personal 既定では `gateGitHubMcp` の `mcp__github` を
-足して計 9 件)、gate 系 deny/ask ブロックが capability に応じて出る/出ないこと、#93 で
+12 件が順序込みで常時出力されること(personal 既定では `gateGitHubMcp` の `mcp__github` を
+足して計 13 件。#136 で credential-store 読取 4 件を追加)、gate 系 deny/ask ブロックが capability に応じて出る/出ないこと、#93 で
 取り込んだ global preference キーの保持を確認する。chezmoi が必要(render job)。
 
 ## test-git-signing.sh

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -451,10 +451,12 @@ fi
 # meaningful where claude-settings manages the file at all.
 if module_active_for_profile "$profile" claude-settings; then
   # Tier 1 — never-legit secret floor: unconditional in the managed
-  # settings.json (SSH-key / env-dump / gh-secret reads). The human never
-  # legitimately asks Claude to do these and the deny binds only Claude's Bash
-  # tool, so it is always on. Live on personal today, no enforceAiSandbox needed.
-  ok "secret floor active: SSH-key / env-dump / gh-secret reads denied unconditionally (best-effort, not a boundary)"
+  # settings.json (SSH-key / credential-store / env-dump / gh-secret reads;
+  # credential stores — aws, gh OAuth, netrc, codex auth — joined in #136).
+  # The human never legitimately asks Claude to do these and the deny binds
+  # only Claude's own tool calls, so it is always on. Live on personal today,
+  # no enforceAiSandbox needed.
+  ok "secret floor active: SSH-key / credential-store / env-dump / gh-secret reads denied unconditionally (best-effort, not a boundary)"
   # Tier 2 — human-legit write gate: main-push deny, .env read deny, and the
   # release/branch-protection ask still ride on enforceAiSandbox, which personal
   # keeps false (its egress block is unusable on a daily driver). A restricted

--- a/scripts/test-claude-settings.sh
+++ b/scripts/test-claude-settings.sh
@@ -124,17 +124,19 @@ fi
 section "claude settings GitHub injection guard (#119)"
 
 # 4) Committed personal render: the never-legit secret floor is UNCONDITIONAL
-#    (8 entries: ssh-key / env-dump / gh-secret reads) and gateGitHubMcp is ON
-#    (Phase 2), so the deny is exactly those 9 (the floor present even with
-#    enforceAiSandbox off is the core of Phase 2 task B) with no ask block. We pin
-#    the EXACT ordered array, not length + a few representatives: this is a
-#    security-boundary regression test, so it must catch a floor matcher being
-#    swapped for another (which would keep the length at 9).
-expected_deny=$'Read(~/.ssh/**)\nBash(cat ~/.ssh/*)\nBash(gh secret *)\nBash(gh api *secrets*)\nBash(env)\nBash(env *)\nBash(printenv)\nBash(printenv *)\nmcp__github'
+#    (12 entries: ssh-key / credential-store / env-dump / gh-secret reads; the
+#    credential-store files — gh OAuth token, AWS keys, ~/.netrc, Codex
+#    auth.json — joined in #136) and gateGitHubMcp is ON (Phase 2), so the deny
+#    is exactly those 13 (the floor present even with enforceAiSandbox off is
+#    the core of Phase 2 task B) with no ask block. We pin the EXACT ordered
+#    array, not length + a few representatives: this is a security-boundary
+#    regression test, so it must catch a floor matcher being swapped for
+#    another (which would keep the length at 13).
+expected_deny=$'Read(~/.ssh/**)\nRead(~/.aws/**)\nRead(~/.config/gh/**)\nRead(~/.netrc)\nRead(~/.codex/auth.json)\nBash(cat ~/.ssh/*)\nBash(gh secret *)\nBash(gh api *secrets*)\nBash(env)\nBash(env *)\nBash(printenv)\nBash(printenv *)\nmcp__github'
 actual_deny="$(yq -p json '.permissions.deny[]' "$off_file")"
 ask_default="$(yq -p json '.permissions.ask // "absent"' "$off_file")"
 if [[ "$actual_deny" == "$expected_deny" && "$ask_default" == "absent" ]]; then
-  ok "test passed: committed personal deny is exactly the secret floor + github MCP (9, ordered), no ask (enforceAiSandbox off)"
+  ok "test passed: committed personal deny is exactly the secret floor + github MCP (13, ordered), no ask (enforceAiSandbox off)"
 else
   fail "test failed: committed personal deny/ask unexpected (ask=$ask_default); deny was:"
   printf '%s\n' "$actual_deny" >&2


### PR DESCRIPTION
## Summary

#136 の 2 論点に対応:

1. **deny 網羅の穴**: 無条件 secret floor に credential-store 読取 4 件を追加 — `Read(~/.aws/**)` / `Read(~/.config/gh/**)`(gh OAuth token)/ `Read(~/.netrc)` / `Read(~/.codex/auth.json)`。floor 8→12 件(gateGitHubMcp 込み 9→13 件)。
2. **設計の明文化**: file 系は **Read 側 deny を主軸**(Read tool はコマンド非経由の読取にも効く)。Bash matcher は等価経路(head/xxd/python open())で迂回できる leaky steering なので path ごとの Bash 列挙はしない(#119 の enumeration アンチパターンの適用)。template コメント + docs 2 本に記載。

**effortLevel は non-issue と判定**(issue の所見 2): template と運用ルール文書は既に xhigh で一致。live の high は `/effort` の動的上書きで、#93 の「apply までの一時 drift」運用の対象。基準線変更なし = agent-tools への連絡不要。model(fable-5 お試し中)も同様に保留継続(ユーザー確認済み: 来週 opus 復帰予定)。

## Linked Issue

Closes #136

## Validation

- test-claude-settings(exact-set 13 件に更新)/ test-render PASS、git diff --check クリーン
- `op read` / `security` 等の Bash deny は**追加していない**(private-backup の `--identity-command 'op read …'` 等の正規経路を壊す + enumeration アンチパターン)

## Side Effects

merge 後に実機 apply で live の deny が 13 件になる(このセッション内で実施予定)。apply は model / effortLevel の動的値も template 値に戻すため、apply 後にユーザーの現行値(fable-5 お試し)を復元する。

## Residual Risk

- deny は依然 steering であって enforcement boundary ではない(docs の既存の限界記述どおり)。credential-store の Read deny も Bash `cat ~/.aws/credentials` は塞がない(Read 主軸の設計判断として明文化済み)。

## Next

- Codex 相互レビュー → must0 で merge → 実機 apply(動的 pref 復元込み)。