### PR TITLE
shell: gclone — directory convention に従う clone helper(ghq 不採用) (#177)

### DIFF
--- a/.chezmoidata/backup-paths.yaml
+++ b/.chezmoidata/backup-paths.yaml
@@ -40,6 +40,11 @@ backup_paths:
   # machine restores the served-vault config. Path and vault names are
   # public-safe; no key material is in it. (#89)
   - { path: .config/1Password/ssh/agent.toml, type: file, category: ssh }
+  # gclone owner -> context mapping (#177). Company org names must not enter
+  # the public repo, so the mapping lives machine-local; the encrypted archive
+  # carries it so a new machine keeps the same clone discipline. Absent =>
+  # gclone falls back to ask-or-abort (fail closed).
+  - { path: .config/dotfiles/clone-contexts.local, type: file, category: git }
   # GitHub injection-guard trust list (#119). Holds the self trust basis
   # (GitHub login + numeric id) plus any opt-in trusted collaborators; it is
   # consumed by the isolated reader / safe-gh (Phase 3). Absent ⇒ fail closed

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -58,6 +58,9 @@ jobs:
       - name: zsh syntax check (managed shell files)
         run: zsh -n dot_zshenv dot_zshrc dot_zprofile
 
+      - name: gclone helper tests
+        run: ./scripts/test-gclone.sh
+
       - name: shellcheck (warning and above)
         run: shellcheck -S warning scripts/*.sh
 

--- a/docs/directory-convention.md
+++ b/docs/directory-convention.md
@@ -46,6 +46,20 @@ Git config では `user.useConfigOnly = true` を使い、known directory 外で
 
 既存 host で `~/.config` が 0755 の場合、初回 apply で 0700 に変わる。これは仕様。`chezmoi diff` に mode 変更として表示され、`preflight` も apply 前にこの差分を warning で知らせる。0700 を望まない場合は、その host で apply しないか、profile 構成を見直す。
 
+## clone(gclone)
+
+新しい repo は managed な `~/.zshrc` の `gclone <git-url>` で clone する(#177)。clone 先の
+context を fail-closed に解決して `~/src/<context>/<repo>` に置くので、配置を手で考えない:
+
+1. `github.com/kosako` → `personal`(managed ルール)
+2. 非追跡の `~/.config/dotfiles/clone-contexts.local`(`<owner> <context-path>` 行形式)の
+   マッチ。会社 org はここ(各マシンの local)にだけ書く([local-overrides](local-overrides.md))
+3. どれにも当たらなければ TTY で確認、非対話なら中断(黙って既定に倒さない)
+
+ghq は不採用(2026-07-05、#177): `<root>/<host>/<owner>/<repo>` layout の強制がこの
+context 階層(identity の `includeIf gitdir` が依存)と衝突し、remote を持たない sandbox を
+扱えないため。
+
 ## 許容された非標準配置
 
 標準は上記の `~/src/<context>/` だが、project を `~/src` の外(例: 単一の作業 directory に

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -116,6 +116,7 @@ main 直 commit は例外扱いにする。
 ./scripts/test-starship.sh
 ./scripts/test-ssh.sh
 ./scripts/test-preflight.sh
+./scripts/test-gclone.sh
 bash -n scripts/*.sh
 zsh -n dot_zshenv dot_zshrc dot_zprofile
 shellcheck -S warning scripts/*.sh

--- a/docs/local-overrides.md
+++ b/docs/local-overrides.md
@@ -93,6 +93,17 @@ GitHub injection 防御(epic #119)の trust 基点の local 値は、managed fil
   `baseline present/absent: .config/dotfiles/github-trust.local` として表示し、中身=login /
   id は読まない。injection-guard section にも置き場ポインタを出す)。
 
+## clone context mapping(#177)
+
+`gclone`([directory-convention](directory-convention.md))の owner → context 対応の
+local 値は、managed file に焼かず **`~/.config/dotfiles/clone-contexts.local`**
+(chezmoi 管理外・非コミット)に置く。会社 org 名を public repo に入れないための seam。
+
+- 行形式: `<owner> <context-path>`(例: `<会社org> work/<会社org>`)。`#` 行はコメント。
+- 共通原則どおり managed 側はこの file が無くても壊れない(未マッチは対話確認 or
+  fail-closed 中断に倒れる)。
+- **`backup-paths.yaml`(category `git`)に載せ**、暗号化バックアップ(#60)の対象にする。
+
 ## agent-tools の checkout path(#73)
 
 `dotfiles` の `doctor` は agent-tools の presence を既定 path `~/src/agent/agent-tools`

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -48,6 +48,12 @@
 - autosuggestions(履歴からゴースト表示):`→` / `End` / `Ctrl-E` で全受け入れ、`Alt-F`(または `Ctrl-→`)で 1 単語だけ受け入れ。
 - **行頭にスペース**を付けて実行したコマンドは履歴に残さない(`HIST_IGNORE_SPACE`。秘密の一回限り用。基本は op/direnv 注入で secret をインライン入力しない = [secrets](secrets.md))。履歴はマシン外に同期しない。
 
+### clone(directory convention)
+
+- `gclone <git-url>` … repo を `~/src/<context>/<repo>` に規約どおり clone する
+  (context の解決順・local mapping・ghq 不採用の経緯は
+  [directory-convention](directory-convention.md) の「clone(gclone)」)。
+
 ### 出力のコピー(AI 連携)
 
 - `Ctrl-O` … **Enter の代わりに**押すと、そのコマンドを実行しつつ「`$ コマンド` + 出力 + `[exit status]`」をクリップボードへコピーする(AI チャットに貼って相談する用途)。普段は今までどおり Enter、コピーしたいコマンドだけ Ctrl-O。`&&` 連結 / pipe / 複数行コマンドも行全体を捕捉する。

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -198,6 +198,86 @@ claude-update() {
   command -v claude >/dev/null 2>&1 && claude --version
 }
 
+# Clone into the directory convention (~/src/<context>/<repo>, #140) without
+# deciding placement by hand (#177). Context resolution is fail-closed:
+#   1. github.com/kosako -> personal (managed rule; the owner name is already
+#      public in this repo, same stance as the hasconfig identity rule, #52)
+#   2. ~/.config/dotfiles/clone-contexts.local — "<owner> <context-path>" lines
+#      (machine-local, never committed: company org names stay out of this
+#      public repo; see docs/local-overrides.md)
+#   3. no match: ask on a TTY, abort otherwise (never a silent default)
+# -n resolves and prints the destination without cloning (used by the test).
+# --- gclone begin ---
+gclone() {
+  emulate -L zsh
+  local dry=0
+  if [[ "${1-}" == "-n" ]]; then dry=1; shift; fi
+  local url="${1-}"
+  if [[ -z "$url" ]]; then
+    print -u2 -- "usage: gclone [-n] <git-url>"
+    return 2
+  fi
+  local rest host owner repo
+  case "$url" in
+    git@*:*/*)     rest="${url#git@}";       host="${rest%%:*}"; rest="${rest#*:}" ;;
+    ssh://git@*/*) rest="${url#ssh://git@}"; host="${rest%%/*}"; rest="${rest#*/}" ;;
+    https://*/*)   rest="${url#https://}";   host="${rest%%/*}"; rest="${rest#*/}" ;;
+    *)
+      print -u2 -- "gclone: unsupported url (https / ssh:// / git@host:owner/repo): $url"
+      return 2
+      ;;
+  esac
+  owner="${rest%%/*}"
+  repo="${rest#*/}"
+  repo="${repo%/}"
+  repo="${repo%.git}"
+  if [[ -z "$host" || -z "$owner" || -z "$repo" || "$repo" == */* || "$rest" != */* ]]; then
+    print -u2 -- "gclone: cannot parse owner/repo from: $url"
+    return 2
+  fi
+  local ctx=""
+  local map="$HOME/.config/dotfiles/clone-contexts.local"
+  if [[ "$host" == "github.com" && "$owner" == "kosako" ]]; then
+    ctx="personal"
+  elif [[ -r "$map" ]]; then
+    local m_owner m_ctx
+    while read -r m_owner m_ctx; do
+      [[ -z "$m_owner" || "$m_owner" == \#* ]] && continue
+      if [[ "$m_owner" == "$owner" ]]; then
+        ctx="$m_ctx"
+        break
+      fi
+    done < "$map"
+  fi
+  if [[ -z "$ctx" ]]; then
+    if [[ -t 0 && -t 2 ]]; then
+      print -u2 -- "gclone: no context rule for '$owner' ($host)."
+      print -u2 -- "  convention: personal | work/<org> | client/<name> | sandbox (docs/directory-convention.md)"
+      print -u2 -n -- "  context path (empty aborts): "
+      read -r ctx || ctx=""
+    fi
+    if [[ -z "$ctx" ]]; then
+      print -u2 -- "gclone: aborted — add \"$owner <context-path>\" to $map, or answer interactively"
+      return 1
+    fi
+  fi
+  if [[ "$ctx" == /* || "$ctx" == *..* ]]; then
+    print -u2 -- "gclone: invalid context path: $ctx"
+    return 2
+  fi
+  local dest="$HOME/src/$ctx/$repo"
+  if [[ -e "$dest" ]]; then
+    print -u2 -- "gclone: destination exists: $dest"
+    return 1
+  fi
+  if (( dry )); then
+    print -r -- "$dest"
+    return 0
+  fi
+  mkdir -p -- "${dest:h}" && git clone -- "$url" "$dest"
+}
+# --- gclone end ---
+
 # Local overrides win: machine-specific PATH, tool env, secrets, keybindings.
 # Sourced before the widget-wrapping plugins so any local keybindings are wrapped.
 [ -r "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -227,6 +227,7 @@ gclone() {
       return 2
       ;;
   esac
+  host="${host%%:*}"  # strip :port (ssh://git@host:22/...) so context rules match on the bare host
   owner="${rest%%/*}"
   repo="${rest#*/}"
   repo="${repo%/}"
@@ -240,9 +241,12 @@ gclone() {
   if [[ "$host" == "github.com" && "$owner" == "kosako" ]]; then
     ctx="personal"
   elif [[ -r "$map" ]]; then
-    local m_owner m_ctx
-    while read -r m_owner m_ctx; do
+    local m_owner m_ctx m_extra
+    while read -r m_owner m_ctx m_extra; do
       [[ -z "$m_owner" || "$m_owner" == \#* ]] && continue
+      # Exactly two fields: a malformed line (missing or extra fields) never
+      # resolves a context — it falls through to the fail-closed abort below.
+      [[ -z "$m_ctx" || -n "$m_extra" ]] && continue
       if [[ "$m_owner" == "$owner" ]]; then
         ctx="$m_ctx"
         break
@@ -261,7 +265,7 @@ gclone() {
       return 1
     fi
   fi
-  if [[ "$ctx" == /* || "$ctx" == *..* ]]; then
+  if [[ "$ctx" == /* || "$ctx" == *..* || "$ctx" == *[[:space:]]* ]]; then
     print -u2 -- "gclone: invalid context path: $ctx"
     return 2
   fi

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -315,6 +315,13 @@ managed `~/.ssh/config` に host 名・秘密鍵・`Host *` への agent 付与�
 こと、`Match all` 後の `Include config.local` 構造、`ssh -G` での実挙動(managed-wins と
 config.local の解決)を確認する。chezmoi が必要(render job)。
 
+## test-gclone.sh
+
+dot_zshrc の `gclone` helper(#177)をマーカー抽出 + fixture HOME + `zsh -f` で検証する。
+実 clone はしない(`-n` の解決のみ)。context 解決の順序(managed の kosako ルール →
+local mapping → fail-closed 中断)、URL 3 形式(https / ssh:// / scp)の parse、
+path traversal 拒否、既存 dest の非破壊を固定する。zsh が必要(validate job、apt で導入)。
+
 ## test-starship.sh
 
 starship.toml の render を検証する。TOML として parse できること(tomllib)、

--- a/scripts/test-gclone.sh
+++ b/scripts/test-gclone.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Behavior tests for the gclone helper in dot_zshrc (#177). The function is
+# extracted by its begin/end markers and run under `zsh -f` in a fixture HOME,
+# always with -n (resolve-and-print, no clone), so no network or git is
+# touched. Contract under test: context resolution order (managed kosako rule
+# -> local mapping -> fail-closed abort), URL form parsing, and the
+# destination guards.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
+
+if ! command -v zsh >/dev/null 2>&1; then
+  fail "zsh not found; gclone tests require it (CI installs it, #150)"
+  exit 1
+fi
+
+status=0
+pass() { ok "test passed: $*"; }
+miss() {
+  fail "test failed: $*"
+  status=1
+}
+
+fixture_home="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-gclone-test.XXXXXX")"
+trap 'rm -rf "$fixture_home"' EXIT
+
+# Extract exactly one marker-delimited function body from the managed source.
+fn_file="$fixture_home/gclone.zsh"
+awk '/^# --- gclone begin ---$/,/^# --- gclone end ---$/' \
+  "$DOTFILES_ROOT/dot_zshrc" > "$fn_file"
+if ! grep -q '^gclone()' "$fn_file"; then
+  fail "gclone markers not found in dot_zshrc (extraction broke)"
+  exit 1
+fi
+
+# run_gclone <expected_rc> <stdout-or-empty> <args...>
+run_gclone() {
+  local name="$1" expected_rc="$2" expected_out="$3"
+  shift 3
+  local out rc=0
+  out="$(HOME="$fixture_home" zsh -f -c \
+    "source '$fn_file'; gclone \"\$@\"" gclone "$@" </dev/null 2>/dev/null)" || rc=$?
+  if [[ "$rc" == "$expected_rc" && "$out" == "$expected_out" ]]; then
+    pass "$name"
+  else
+    miss "$name (rc=$rc want $expected_rc; out=$out)"
+  fi
+}
+
+# 1. Managed rule: kosako on github.com resolves to personal, all URL forms.
+run_gclone "https url -> personal" 0 "$fixture_home/src/personal/foo" \
+  -n https://github.com/kosako/foo
+run_gclone "scp url (.git) -> personal" 0 "$fixture_home/src/personal/bar" \
+  -n git@github.com:kosako/bar.git
+run_gclone "ssh:// url -> personal" 0 "$fixture_home/src/personal/baz" \
+  -n ssh://git@github.com/kosako/baz
+
+# 2. Local mapping resolves other owners (the machine-local seam for
+#    company orgs; the org name never enters this repo).
+mkdir -p "$fixture_home/.config/dotfiles"
+printf '# comment line\nacme work/acme\n' \
+  > "$fixture_home/.config/dotfiles/clone-contexts.local"
+run_gclone "mapped owner -> mapped context" 0 "$fixture_home/src/work/acme/tool" \
+  -n https://github.com/acme/tool
+# kosako stays personal even with a mapping file present (managed rule first).
+run_gclone "managed rule wins over mapping" 0 "$fixture_home/src/personal/foo" \
+  -n https://github.com/kosako/foo
+
+# 3. Fail closed: unmapped owner without a TTY aborts, prints nothing.
+run_gclone "unmapped owner aborts (no TTY)" 1 "" \
+  -n https://github.com/stranger/tool
+
+# 4. A mapping that escapes ~/src is rejected (no path traversal).
+printf 'evil ../../etc\n' >> "$fixture_home/.config/dotfiles/clone-contexts.local"
+run_gclone "traversal context rejected" 2 "" \
+  -n https://github.com/evil/tool
+
+# 5. Existing destination aborts (never clobbers).
+mkdir -p "$fixture_home/src/personal/exists"
+run_gclone "existing destination aborts" 1 "" \
+  -n https://github.com/kosako/exists
+
+# 6. Unparseable URLs are usage errors.
+run_gclone "garbage url rejected" 2 "" -n "not-a-url"
+run_gclone "deep https path rejected" 2 "" -n https://github.com/kosako/foo/tree/main
+run_gclone "missing url is usage error" 2 "" -n
+
+if [[ "$status" -eq 0 ]]; then
+  ok "gclone tests passed"
+fi
+exit "$status"

--- a/scripts/test-gclone.sh
+++ b/scripts/test-gclone.sh
@@ -30,11 +30,20 @@ fixture_home="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-gclone-test.XXXXXX")"
 trap 'rm -rf "$fixture_home"' EXIT
 
 # Extract exactly one marker-delimited function body from the managed source.
+# The guards make extraction failures loud instead of vacuous: exactly one
+# begin and one end marker must exist, and the extraction must end at the end
+# marker (a missing end marker would sweep the rest of the file in).
+begin_count="$(grep -c '^# --- gclone begin ---$' "$DOTFILES_ROOT/dot_zshrc")" || true
+end_count="$(grep -c '^# --- gclone end ---$' "$DOTFILES_ROOT/dot_zshrc")" || true
+if [[ "$begin_count" != "1" || "$end_count" != "1" ]]; then
+  fail "expected exactly one gclone marker pair in dot_zshrc (begin=$begin_count end=$end_count)"
+  exit 1
+fi
 fn_file="$fixture_home/gclone.zsh"
 awk '/^# --- gclone begin ---$/,/^# --- gclone end ---$/' \
   "$DOTFILES_ROOT/dot_zshrc" > "$fn_file"
-if ! grep -q '^gclone()' "$fn_file"; then
-  fail "gclone markers not found in dot_zshrc (extraction broke)"
+if ! grep -q '^gclone()' "$fn_file" || [[ "$(tail -n 1 "$fn_file")" != "# --- gclone end ---" ]]; then
+  fail "gclone extraction broke (function or end marker missing)"
   exit 1
 fi
 
@@ -59,6 +68,8 @@ run_gclone "scp url (.git) -> personal" 0 "$fixture_home/src/personal/bar" \
   -n git@github.com:kosako/bar.git
 run_gclone "ssh:// url -> personal" 0 "$fixture_home/src/personal/baz" \
   -n ssh://git@github.com/kosako/baz
+run_gclone "ssh:// url with port -> personal" 0 "$fixture_home/src/personal/qux" \
+  -n ssh://git@github.com:22/kosako/qux
 
 # 2. Local mapping resolves other owners (the machine-local seam for
 #    company orgs; the org name never enters this repo).
@@ -75,10 +86,15 @@ run_gclone "managed rule wins over mapping" 0 "$fixture_home/src/personal/foo" \
 run_gclone "unmapped owner aborts (no TTY)" 1 "" \
   -n https://github.com/stranger/tool
 
-# 4. A mapping that escapes ~/src is rejected (no path traversal).
-printf 'evil ../../etc\n' >> "$fixture_home/.config/dotfiles/clone-contexts.local"
+# 4. A mapping that escapes ~/src is rejected (no path traversal), and a
+#    malformed mapping line (extra fields) never resolves — it falls through
+#    to the fail-closed abort instead of cloning into "work/bad extra".
+printf 'evil ../../etc\nbad work/bad extra\n' \
+  >> "$fixture_home/.config/dotfiles/clone-contexts.local"
 run_gclone "traversal context rejected" 2 "" \
   -n https://github.com/evil/tool
+run_gclone "malformed mapping line falls through to abort" 1 "" \
+  -n https://github.com/bad/tool
 
 # 5. Existing destination aborts (never clobbers).
 mkdir -p "$fixture_home/src/personal/exists"


### PR DESCRIPTION
## Summary

#177(#96 の二軸目・壁打ちで裁定済み)。ghq は layout 主権の衝突(context 階層 = identity 判定の依存先)と sandbox 非対応で不採用とし、`gclone [-n] <git-url>` を dot_zshrc に実装。

- context 解決は fail-closed 3 段: managed ルール(kosako→personal)→ 非追跡 mapping(`~/.config/dotfiles/clone-contexts.local`、会社 org は local にのみ)→ TTY 確認 or 中断
- path traversal 拒否 / 既存 dest 非破壊 / `-n` で解決のみ
- マシン間同一は chezmoi 配布(shell-extra は work profile も保有)+ mapping の暗号化バックアップ継承

## Linked Issue

Closes #177

## Validation

- **test-gclone.sh(新規・11 ケース)**: マーカー抽出 + fixture HOME + `zsh -f`、実 clone なし。URL 3 形式 / mapping 解決 / managed ルール優先 / fail-closed 中断 / traversal 拒否 / 既存 dest 中断 / usage error を固定。validate job に配線(zsh は #150 の apt 導入済み)
- validate-policy --all / test-private-backup / test-render / test-doctor / bash -n / zsh -n / shellcheck / git diff --check すべて PASS

## Side Effects

merge 後の実機 apply で `~/.zshrc` に関数が追加される(既存挙動への影響なし)。clone-contexts.local は存在しなくても壊れない(共通原則)。

## Residual Risk

- 対話 prompt の UX(候補一覧の補完なし)は最小実装。使ってみて摩擦があれば follow-up。
- gh CLI 経由の clone(`gh repo clone`)は gclone を経由しない(規約は README/docs の明文で担保)。

## Next

- Codex 相互レビュー → must0 で merge → 実機 apply + 動作確認。