### PR TITLE
policy: environmentKind の enum 禁止値制約 — work/client/agent で npmHardeningMode=off を hard fail (#45)

### DIFF
--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -57,10 +57,22 @@ environmentKind は飾りラベルではなく、capability の不変条件を�
 | sandbox | allowSecretsAccess |
 | personal | (制約なし) |
 
-- 表は `scripts/lib-policy.sh` の `environment_kind_forbidden_capabilities` が持つ。
+enum capability には**禁止値**の制約を同じ仕組みで当てる(#45、2026-07-07 決定)。boolean の
+「false 必須」と違い、enum は特定の 1 値だけを禁止し、残りの選択は profile に委ねる:
+
+| environmentKind | 禁止値 |
+| --- | --- |
+| work / client / agent | `npmHardeningMode=off`(floor は report。off は install-script 防御の全停止で、制限環境でこれになるのは事故のみ) |
+| personal / sandbox | (制約なし) |
+
+- 表は `scripts/lib-policy.sh` の `environment_kind_forbidden_capabilities`(boolean)と
+  `environment_kind_forbidden_enum_values`(enum 禁止値)が持つ。
 - `personal` は明示許可前提なので無制約。`agent` は profile がまだ無いが、最小権限を明示するため先行定義してある(agent profile 追加時に即発効)。
-- enum capability(`npmHardeningMode` など)への制約は今回の対象外(必要なら別 follow-up)。
-- 将来 work 等で禁止 capability を正当に許したくなった場合は、warning で迂回せず、この表自体を見直す。
+- **required 値の制約(「work は enforce 必須」)は作らない**(#45 裁定): 会社 Mac の work は
+  会社 npm 設定との兼ね合いで report 稼働([supply-chain-npm](supply-chain-npm.md))であり、
+  required にすると稼働中のマシンが hard fail する。`corepackMode` も制約対象外
+  (off は「意図的非管理」の正当な選択で、security downgrade ではない。doctor が中立報告)。
+- 将来 work 等で禁止 capability / 禁止値を正当に許したくなった場合は、warning で迂回せず、この表自体を見直す。
 
 ## Claude Code sandbox (`enforceAiSandbox`)
 
@@ -80,7 +92,8 @@ sandbox ブロックを出して Claude Code に内部適用させる」意)。�
 - **既定は全 profile で false**(配線のみ・opt-in)。有効化は allowlist を詰め、push /
   install が壊れないか検証してから cap を反転する別ステップ。
 - 将来 agent profile を足すときは「特定 kind で true 必須」(forbidden の逆の不変条件)の
-  候補になるが、enum / required 制約は別 follow-up(#45)。今は作らない。
+  候補になるが、required 制約は今は作らない(#45 で enum の**禁止値**制約のみ導入し、
+  required 方式は不採用とした。上記「environmentKind の制約」)。
 
 ## GitHub injection guard (`gateGitHubMcp` / `enableGitHubIsolatedReader`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,6 +41,9 @@ unknown profile / module / capability や capability enum の不正値は policy
 - すべての定義済み capability が profile に存在すること。
 - boolean capability が `true` または `false` であること。
 - enum capability が schema の `values` に含まれること。
+- environmentKind cross-check: kind が禁止する boolean capability が `true`(#43)、または
+  enum capability が禁止値(work / client / agent の `npmHardeningMode=off`、#45)だと
+  hard fail すること。
 - module の `paths:` が home 相対であること。同一 path を複数 module が宣言していないこと。
 - module の `requires:` の capability が定義済みで、値が schema の型に適合すること。
 - `requires:` があるのに `paths:` がない module は fail(条件が何も駆動しないため)。

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -193,9 +193,10 @@ is_allowed_environment_kind() {
 # Encodes the policy that work / client / agent environments do not carry
 # elevated permissions (install, system mutation, secrets, network, AI
 # tooling) by default, and that sandbox forbids secret access. personal
-# is unconstrained; enum capabilities are out of scope here. See
-# docs/policy-model.md. agent has no profile yet; the row is defined so
-# the constraint takes effect the moment an agent profile is added.
+# is unconstrained; enum capabilities have their own forbidden-VALUE table
+# below (#45). See docs/policy-model.md. agent has no profile yet; the row
+# is defined so the constraint takes effect the moment an agent profile is
+# added.
 environment_kind_forbidden_capabilities() {
   case "$1" in
     work | client | agent)
@@ -208,6 +209,26 @@ environment_kind_forbidden_capabilities() {
       ;;
     sandbox)
       printf '%s\n' allowSecretsAccess
+      ;;
+  esac
+}
+
+# Enum capability VALUES that are forbidden for a given environmentKind
+# (#45, the enum counterpart of the boolean table above). An enum row
+# forbids exactly one value and leaves the rest to the profile: work /
+# client / agent must not turn npm supply-chain hardening fully off
+# (npmHardeningMode=off drops the install-script defenses; report is the
+# floor). A required value (e.g. "work must be enforce") is deliberately
+# NOT modeled — work runs report because of company npm constraints
+# (docs/supply-chain-npm.md), so requiring enforce would hard-fail a
+# working machine. corepackMode is deliberately unconstrained: off means
+# "intentionally unmanaged", a legitimate stance doctor reports neutrally,
+# not a security downgrade. personal / sandbox are unconstrained.
+# Output format: one capability=forbidden_value pair per line.
+environment_kind_forbidden_enum_values() {
+  case "$1" in
+    work | client | agent)
+      printf '%s\n' 'npmHardeningMode=off'
       ;;
   esac
 }

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -365,15 +365,18 @@ run_fail_contains \
 
 # enum cross-check (#45): work / client / agent forbid npmHardeningMode=off
 # (report is the floor; off drops the install-script defenses). Retag
-# personal (npmHardeningMode: enforce) to work and force off to prove the
-# enum row fires with the same message shape as the boolean rows.
-make_fixture
-replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: work"
-replace_once "$fixture/.chezmoidata/profiles.yaml" "      npmHardeningMode: enforce" "      npmHardeningMode: off"
-run_fail_contains \
-  "work environmentKind forbids npmHardeningMode=off" \
-  "environmentKind work forbids npmHardeningMode=off" \
-  "$fixture/scripts/validate-policy.sh" personal
+# personal (npmHardeningMode: enforce) to each kind and force off to prove
+# the enum row fires for every constrained kind with the same message shape
+# as the boolean rows.
+for ek_kind in work client agent; do
+  make_fixture
+  replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: $ek_kind"
+  replace_once "$fixture/.chezmoidata/profiles.yaml" "      npmHardeningMode: enforce" "      npmHardeningMode: off"
+  run_fail_contains \
+    "$ek_kind environmentKind forbids npmHardeningMode=off" \
+    "environmentKind $ek_kind forbids npmHardeningMode=off" \
+    "$fixture/scripts/validate-policy.sh" personal
+done
 
 # Only the off value is forbidden — a required value ("work must be enforce")
 # is deliberately not modeled (the committed work profile runs report for
@@ -384,6 +387,28 @@ set_capability_all "$fixture" npmHardeningMode enforce
 run_ok \
   "npmHardeningMode=enforce is allowed for every environmentKind (only off is forbidden)" \
   "$fixture/scripts/validate-policy.sh" --all
+
+# The forbidden-enum table itself is validated fail-closed: a row naming a
+# value the schema does not declare (a typo would otherwise be a silently
+# dead constraint) and a row without '=' both hard-fail. Mutate the fixture's
+# lib-policy table to prove each branch fires.
+make_fixture
+replace_once "$fixture/scripts/lib-policy.sh" \
+  "      printf '%s\\\\n' 'npmHardeningMode=off'" \
+  "      printf '%s\\\\n' 'npmHardeningMode=typo'"
+run_fail_contains \
+  "a forbidden-enum row with an undeclared value fails closed" \
+  "forbidden-enum row invalid" \
+  "$fixture/scripts/validate-policy.sh" work
+
+make_fixture
+replace_once "$fixture/scripts/lib-policy.sh" \
+  "      printf '%s\\\\n' 'npmHardeningMode=off'" \
+  "      printf '%s\\\\n' 'npmHardeningMode off'"
+run_fail_contains \
+  "a forbidden-enum row without = fails closed" \
+  "forbidden-enum row malformed" \
+  "$fixture/scripts/validate-policy.sh" work
 
 # enforceAiSandbox is a safety-hardening capability (opposite polarity to the
 # install / secret / network / AI-tool capabilities), so it must NOT be in the

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -363,6 +363,28 @@ run_fail_contains \
   "environmentKind agent forbids" \
   "$fixture/scripts/validate-policy.sh" personal
 
+# enum cross-check (#45): work / client / agent forbid npmHardeningMode=off
+# (report is the floor; off drops the install-script defenses). Retag
+# personal (npmHardeningMode: enforce) to work and force off to prove the
+# enum row fires with the same message shape as the boolean rows.
+make_fixture
+replace_once "$fixture/.chezmoidata/profiles.yaml" "    environmentKind: personal" "    environmentKind: work"
+replace_once "$fixture/.chezmoidata/profiles.yaml" "      npmHardeningMode: enforce" "      npmHardeningMode: off"
+run_fail_contains \
+  "work environmentKind forbids npmHardeningMode=off" \
+  "environmentKind work forbids npmHardeningMode=off" \
+  "$fixture/scripts/validate-policy.sh" personal
+
+# Only the off value is forbidden — a required value ("work must be enforce")
+# is deliberately not modeled (the committed work profile runs report for
+# company-npm reasons and must keep validating). enforce must also pass for
+# every kind: flip all profiles to enforce and assert --all still validates.
+make_fixture
+set_capability_all "$fixture" npmHardeningMode enforce
+run_ok \
+  "npmHardeningMode=enforce is allowed for every environmentKind (only off is forbidden)" \
+  "$fixture/scripts/validate-policy.sh" --all
+
 # enforceAiSandbox is a safety-hardening capability (opposite polarity to the
 # install / secret / network / AI-tool capabilities), so it must NOT be in the
 # environmentKind forbidden table: a restrictive kind (work) may set it true.

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -393,11 +393,13 @@ validate_profile() {
     esac
   done < "$known_caps_file"
 
-  # environmentKind cross-check: capabilities the environmentKind forbids
-  # must be false. This makes the work/client/agent/sandbox restrictions a
-  # hard invariant rather than a convention (see docs/policy-model.md).
-  # Only meaningful for a valid kind; an unknown/missing environmentKind
-  # has already failed above, and must not print "satisfied".
+  # environmentKind cross-check: boolean capabilities the environmentKind
+  # forbids must be false, and enum capabilities must not carry a forbidden
+  # value (#45: npmHardeningMode=off is below the work/client/agent floor).
+  # This makes the work/client/agent/sandbox restrictions a hard invariant
+  # rather than a convention (see docs/policy-model.md). Only meaningful for
+  # a valid kind; an unknown/missing environmentKind has already failed
+  # above, and must not print "satisfied".
   if is_allowed_environment_kind "$environment_kind"; then
     ek_violations=0
     while IFS= read -r forbidden; do
@@ -409,6 +411,17 @@ validate_profile() {
         ek_violations=$((ek_violations + 1))
       fi
     done < <(environment_kind_forbidden_capabilities "$environment_kind")
+    while IFS= read -r pair; do
+      [[ -z "$pair" ]] && continue
+      enum_cap="${pair%%=*}"
+      forbidden_value="${pair#*=}"
+      value="$(capability_value "$profile" "$enum_cap")"
+      if [[ "$value" == "$forbidden_value" ]]; then
+        fail "environmentKind $environment_kind forbids $enum_cap=$forbidden_value (profile $profile)"
+        status=1
+        ek_violations=$((ek_violations + 1))
+      fi
+    done < <(environment_kind_forbidden_enum_values "$environment_kind")
     if [[ "$ek_violations" -eq 0 ]]; then
       ok "environmentKind constraints satisfied: $environment_kind"
     fi

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -413,8 +413,25 @@ validate_profile() {
     done < <(environment_kind_forbidden_capabilities "$environment_kind")
     while IFS= read -r pair; do
       [[ -z "$pair" ]] && continue
+      # The table row itself is checked fail-closed: a malformed pair or a
+      # capability/value that the schema does not know would otherwise be a
+      # silently dead constraint — the exact failure mode this cross-check
+      # exists to prevent (#45).
+      if [[ "$pair" != *=* ]]; then
+        fail "forbidden-enum row malformed for $environment_kind: '$pair' (expected capability=value)"
+        status=1
+        ek_violations=$((ek_violations + 1))
+        continue
+      fi
       enum_cap="${pair%%=*}"
       forbidden_value="${pair#*=}"
+      if [[ "$(capability_type "$enum_cap")" != "enum" ]] \
+        || ! capability_value_is_allowed "$enum_cap" "$forbidden_value"; then
+        fail "forbidden-enum row invalid for $environment_kind: $pair (not a declared enum value)"
+        status=1
+        ek_violations=$((ek_violations + 1))
+        continue
+      fi
       value="$(capability_value "$profile" "$enum_cap")"
       if [[ "$value" == "$forbidden_value" ]]; then
         fail "environmentKind $environment_kind forbids $enum_cap=$forbidden_value (profile $profile)"


### PR DESCRIPTION
## 概要

issue #45(#43 follow-up)の裁定と実装。boolean の environmentKind cross-check に enum の対応を足すが、**「required 値(work は enforce 必須)」は作らず、「禁止値」のみ**を最小にモデル化する。

## 裁定(2026-07-07)

- **work / client / agent で `npmHardeningMode=off` を禁止**(floor=report)。off は install-script 防御の全停止で、制限環境でこれになるのは事故(agent の編集ミス等)しかあり得ない — #43 boolean cross-check と同じ「事故を hard invariant で止める」意味論。
- **enforce 必須は不採用**: 会社 Mac の work は会社 npm 設定との兼ね合いで report 稼働(supply-chain-npm.md)。required にすると稼働中のマシンが hard fail する。
- **corepackMode は制約対象外**: off は「意図的非管理」の正当な選択(doctor が中立報告)で、security downgrade ではない。

## 変更

- `lib-policy.sh`: `environment_kind_forbidden_enum_values`(kind → `capability=値` 行)を新設
- `validate-policy.sh`: 既存 cross-check block に禁止値ループを追加(boolean と同じ message 形・fail-closed)。**表行そのものも検証**(malformed / schema に無い値は hard fail = 壊れた行が黙って死んだ制約になる fail-open を塞ぐ)
- `test-policy.sh`: work/client/agent の 3 kind で発火する fail テスト、enforce が全 kind で通る ok テスト(off だけ禁止の固定)、fail-closed 分岐 2 本(undeclared value / malformed row)を fixture 変異で固定
- docs: policy-model に禁止値表と裁定記録、scripts README に cross-check 項目追記

render 対象ファイルへの影響ゼロ(policy scripts + docs のみ)。

## 検証

- test-policy / validate-policy --all / test-doctor / test-render PASS、shellcheck クリーン(既存 SC1091 info のみ)
- Codex 相互レビュー: 初回 must0/should2 → 両採用 → 増分再レビュー must0・指摘なし

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qw8BkUDu5WdwhYfiFFX5n