### PR TITLE
docs: README に更新の反映手順(pull → chezmoi diff → apply → doctor)を追記 (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,12 @@ chezmoi apply --source ~/dotfiles          # 反映(target を絞るなら末尾
 ./scripts/doctor.sh personal               # 反映後の健康診断
 ```
 
-profile を切り替える別マシン(例: 会社 Mac)では、**先に `git pull` してから** `chezmoi init --promptString profile=<kind>` で profile を更新する(古い profile 値のまま apply すると `require-profile` が fail-closed で止まる=設計どおり)。
+profile を切り替える別マシン(例: 会社 Mac)では、**先に `git -C ~/dotfiles pull` してから** profile を更新する(古い profile 値のまま apply すると `require-profile` が fail-closed で止まる=設計どおり)。
+
+```sh
+git -C ~/dotfiles pull
+chezmoi init --source ~/dotfiles --promptString profile=<kind>
+```
 
 ## 何が得られるか
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ EOF
 ./scripts/preflight.sh personal # 新マシン適用前の危険検知
 ```
 
+### 更新を反映する
+
+dotfiles を更新したら、pull してから diff を確認して apply する。`apply` の前に必ず `diff` を読む(何が変わるかを見てから反映する)。
+
+```sh
+git -C ~/dotfiles pull                     # dotfiles を最新化
+chezmoi diff --source ~/dotfiles           # 何が変わるか確認(必ず読む)
+chezmoi apply --source ~/dotfiles          # 反映(target を絞るなら末尾に path)
+./scripts/doctor.sh personal               # 反映後の健康診断
+```
+
+profile を切り替える別マシン(例: 会社 Mac)では、**先に `git pull` してから** `chezmoi init --promptString profile=<kind>` で profile を更新する(古い profile 値のまま apply すると `require-profile` が fail-closed で止まる=設計どおり)。
+
 ## 何が得られるか
 
 - **Git identity が context を跨いで漏れない。** `user.useConfigOnly=true` と `includeIf` により、context 外では identity が解決されず commit が止まる(間違った identity で commit するより安全側に倒れる)。


### PR DESCRIPTION
## 概要

README Quickstart には「導入(init → diff → apply)」と「日常(doctor / preflight の状態確認)」はあったが、その中間の **dotfiles を更新した後どう実機へ反映するか**(pull → chezmoi diff → apply → doctor)が欠けていた。実運用で毎回発生する動作なので「日常」節に最小手順を追記する。

## 変更

- README「日常」節に「更新を反映する」小節を追加(pull → diff → apply → doctor。apply 前に必ず diff を読む)
- profile 切替マシン(会社 Mac 等)向けに「先に pull → `chezmoi init --source ~/dotfiles --promptString profile=<kind>`」を明記(古い profile 値のまま apply は require-profile が fail-closed で止まる=設計どおり。実機知見 #146)

docs のみ・render 影響なし。全 chezmoi コマンドは既存導入節と同じ `--source ~/dotfiles` で統一。

## 検証

- Codex 相互レビュー: 初回 must1(profile 切替 init の `--source` 抜け=既定 source 依存に読める)→ 修正 → 増分再レビュー APPROVE(must0)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qw8BkUDu5WdwhYfiFFX5n