### PR TITLE
codex-settings: user 層 hooks.json で personal-safe-gh-hook を Codex 活性化 (#181)

### DIFF
--- a/.chezmoidata/modules.yaml
+++ b/.chezmoidata/modules.yaml
@@ -59,9 +59,7 @@ modules:
       - .claude
       - .claude/settings.json
   codex-settings:
-    description: Codex CLI harness 設定。user 層 ~/.codex/hooks.json に safe-gh 誘導の PreToolUse hook を登録する(#181・#137 の Codex parity)。registration=dotfiles / body=agent-tools。config.toml は codex 所有の live ファイルなので管理しない。
+    description: Codex CLI harness 設定。user 層 ~/.codex/hooks.json に safe-gh 誘導の PreToolUse hook を登録する(#181・#137 の Codex parity)。registration=dotfiles / body=agent-tools。config.toml は codex 所有の live ファイルなので管理しない。cap gate は module の requires ではなく template 自己 gate で行う(enableGitHubIsolatedReader=false は空 render → chezmoi が既存 target も削除)。requires を使うと chezmoiignore が既存 file を prune せず残置するため(Codex review #184)。
     paths:
       - .codex
       - .codex/hooks.json
-    requires:
-      enableGitHubIsolatedReader: true

--- a/.chezmoidata/modules.yaml
+++ b/.chezmoidata/modules.yaml
@@ -58,3 +58,10 @@ modules:
     paths:
       - .claude
       - .claude/settings.json
+  codex-settings:
+    description: Codex CLI harness 設定。user 層 ~/.codex/hooks.json に safe-gh 誘導の PreToolUse hook を登録する(#181・#137 の Codex parity)。registration=dotfiles / body=agent-tools。config.toml は codex 所有の live ファイルなので管理しない。
+    paths:
+      - .codex
+      - .codex/hooks.json
+    requires:
+      enableGitHubIsolatedReader: true

--- a/.chezmoidata/profiles.yaml
+++ b/.chezmoidata/profiles.yaml
@@ -17,6 +17,7 @@ profiles:
       - update-policy
       - ai-policy
       - claude-settings
+      - codex-settings
       - git-signing
     capabilities:
       installPackages: true
@@ -45,12 +46,16 @@ profiles:
       # docs/ai-environment-boundary.md). No github MCP is configured today, so
       # this is harmless defense-in-depth: an MCP added later is pre-denied.
       gateGitHubMcp: true
-      # #137: register the PreToolUse hook (personal-safe-gh-hook) in the managed
-      # settings.json so raw `gh` reads of untrusted GitHub content are steered
-      # to the safe-gh isolated reader. Steering / fail-open (missing body, non-2
-      # exit, bad JSON all continue the tool call) — NOT an enforcement boundary.
-      # Hook/reader bodies are deployed by agent-tools (registration=dotfiles,
-      # body=agent-tools; docs/config-ownership.md, agent-tools#146).
+      # #137 / #181: register the PreToolUse hook (personal-safe-gh-hook) so raw
+      # `gh` reads of untrusted GitHub content are steered to the safe-gh isolated
+      # reader. ONE capability drives BOTH AI homes: claude-settings emits it into
+      # the managed ~/.claude/settings.json (#137) and codex-settings emits it into
+      # the user-layer ~/.codex/hooks.json (#181, Codex parity). Steering / fail-
+      # open (missing body, non-2 exit, bad JSON all continue the tool call) — NOT
+      # an enforcement boundary. Codex adds an extra inert stage: even a registered
+      # hook is silently skipped until a one-time `/hooks` trust. Hook/reader bodies
+      # are deployed by agent-tools (registration=dotfiles, body=agent-tools;
+      # docs/config-ownership.md, agent-tools#146).
       enableGitHubIsolatedReader: true
 
   work:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -129,6 +129,9 @@ jobs:
       - name: claude settings sandbox content tests
         run: ./scripts/test-claude-settings.sh
 
+      - name: codex settings hook registration tests
+        run: ./scripts/test-codex-settings.sh
+
       - name: git-signing gating tests
         run: ./scripts/test-git-signing.sh
 

--- a/docs/ai-environment-boundary.md
+++ b/docs/ai-environment-boundary.md
@@ -179,15 +179,21 @@ live 化した。`enforceAiSandbox` は全 profile false 継続。有効化し�
 - `gateGitHubMcp`: managed `~/.claude/settings.json` の `permissions.deny` に `mcp__github`
   を足し、GitHub MCP server を丸ごと deny する(`claude-settings` module が active な
   profile のみ実効。dangling は doctor が report)。
-- `enableGitHubIsolatedReader`(#137): managed `~/.claude/settings.json` に **PreToolUse
-  hook 登録**(matcher `Bash`)を出し、raw な `gh` 読取(untrusted な GitHub content)を
-  safe-gh 隔離 reader へ誘導する。hook body(`personal-safe-gh-hook`)と safe-gh reader の
-  実体は **agent-tools が配布**し(登録=dotfiles・実体=agent-tools の 2 管轄合流点。path
-  安定は agent-tools#146 の契約。[config-ownership](config-ownership.md))、dotfiles は
-  絶対 path を参照するだけで script body を配布しない。**steering / fail-open**: body 不在
-  (exit 127)・非 2 の非ゼロ exit・不正 JSON・timeout はすべて tool call 続行(block は
-  exit 2 のみ)なので、agent-tools 未 sync の新規マシンでも登録は安全な no-op。dangling
-  (claude-settings 非 active / body 不在)は doctor が report。
+- `enableGitHubIsolatedReader`(#137 / #181): **PreToolUse hook 登録**(matcher `Bash`)を
+  出し、raw な `gh` 読取(untrusted な GitHub content)を safe-gh 隔離 reader へ誘導する。
+  **1 capability が 2 つの AI home 両方**に登録を出す — Claude は managed
+  `~/.claude/settings.json` の `hooks` キー(#137、`claude-settings` module)、Codex は
+  user 層の **別ファイル** `~/.codex/hooks.json`(#181、`codex-settings` module)。Codex で
+  config.toml の `[hooks]` ではなく別ファイルにするのは、config.toml が codex 所有の live
+  ファイル(`[hooks.state]` 等を codex が書く)で上書き衝突を避けるため。hook body
+  (`personal-safe-gh-hook`)と safe-gh reader の実体は **agent-tools が両 home へ配布**し
+  (登録=dotfiles・実体=agent-tools の 2 管轄合流点。path 安定は agent-tools#146 の契約。
+  [config-ownership](config-ownership.md))、dotfiles は絶対 path を参照するだけで script
+  body を配布しない。**steering / fail-open**: body 不在(exit 127)・非 2 の非ゼロ exit・
+  不正 JSON・timeout はすべて tool call 続行(block は exit 2 のみ)なので、agent-tools 未
+  sync の新規マシンでも登録は安全な no-op。**Codex はさらに inert stage**: 登録済みでも一度
+  `/hooks` で trust するまで無警告で silent skip される(registration ≠ activation)。
+  dangling(claude-settings / codex-settings 非 active、body 不在)は doctor が report。
 - GitHub 由来の deny は **3 tier**(#119 Phase 2 task B。専用 capability は作らない):
   - **(1) never-legit secret floor は無条件**(常時 render)。SSH 秘密鍵読取(`~/.ssh`)・
     credential-store 読取(`~/.aws` / `~/.config/gh` の OAuth token / `~/.netrc` /

--- a/docs/config-ownership.md
+++ b/docs/config-ownership.md
@@ -12,6 +12,7 @@ build / sync)あり、さらにどちらにも属さない unmanaged なファ�
 | 資産 | 正本 | 配布 | 変更フロー |
 | --- | --- | --- | --- |
 | ハーネス環境設定 `~/.claude/settings.json`(model / permissions / hooks **登録** / plugin / statusLine / tui 等の global preference) | dotfiles(`dot_claude/settings.json.tmpl`) | `chezmoi apply` | dotfiles の Issue + PR |
+| Codex user 層 hooks **登録** `~/.codex/hooks.json`(safe-gh 誘導の PreToolUse hook・#181) | dotfiles(`dot_codex/hooks.json.tmpl`) | `chezmoi apply`(+ Codex で一度 `/hooks` trust) | dotfiles の Issue + PR |
 | skill・指示文・hook スクリプト**実体**(`~/.claude/skills/`、`~/.claude/agent-tools/`、`~/.codex` への配布物) | agent-tools | agent-tools の build / sync | agent-tools の Issue + PR |
 | 個人の参照先入りファイル(`~/.claude/CLAUDE.md`、各 repo の `.agent-context.local.md`) | ユーザー手書き | なし(unmanaged) | 手動のみ(agent は read-only) |
 | マシン固有・動的値(`~/.claude/settings.local.json`、`~/.zshrc.local`、`~/.ssh/config.local` 等の `.local` 系、`~/.config/git/personal.gitconfig`) | ローカル(git / chezmoi 管理外) | なし(一部は暗号化バックアップ #60 が運ぶ) | 直接編集 |
@@ -19,9 +20,14 @@ build / sync)あり、さらにどちらにも属さない unmanaged なファ�
 
 補足:
 
-- **hooks は 2 管轄の合流点**(#137): settings.json への hooks **登録**は dotfiles、
-  スクリプト**実体**の配備と path の安定は agent-tools。どちらか一方だけでは活性化
-  しない。片方を変えるときはもう片方の Issue を確認する。
+- **hooks は 2 管轄の合流点**(#137 / #181): hooks **登録**は dotfiles、スクリプト
+  **実体**の配備と path の安定は agent-tools。どちらか一方だけでは活性化しない。
+  片方を変えるときはもう片方の Issue を確認する。登録先はハーネスごとに異なる:
+  Claude は `~/.claude/settings.json` の `hooks` キー、Codex は **別ファイル**
+  `~/.codex/hooks.json`(user 層)。Codex の `config.toml` は codex 自身が
+  `[hooks.state]` 等を書き込む live ファイルなので **dotfiles は触らない**(登録は
+  別ファイルへ分離。backup-paths で運ぶ codex 所有物)。Codex はさらに、登録済みでも
+  一度 `/hooks` で trust するまで無警告で不活性という段がある(#181)。
 - `~/.claude/CLAUDE.md`(ユーザー手書き)から参照される `~/.claude/agent-tools/CLAUDE.md`
   は 2 行目の配布物。本体と参照先で正本が異なる。
 - `settings.json` / `settings.local.json` の 2 層境界の正本は

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -106,13 +106,18 @@ GitHub runtime prompt-injection 防御(epic #119)の capability 2 本。射程�
 - `gateGitHubMcp`(boolean): managed `~/.claude/settings.json` の `permissions.deny` に
   `mcp__github` を出して GitHub MCP server を deny する。効くのは `claude-settings` module
   が active な profile だけ(今は personal)。dangling は doctor が report。
-- `enableGitHubIsolatedReader`(boolean): managed `~/.claude/settings.json` に **PreToolUse
-  hook 登録**(matcher `Bash`)を出し、raw な `gh` 読取を safe-gh 隔離 reader へ誘導する
-  (#137)。hook body(`personal-safe-gh-hook`)は agent-tools が配布し、dotfiles は絶対
+- `enableGitHubIsolatedReader`(boolean): **PreToolUse hook 登録**(matcher `Bash`)を出し、
+  raw な `gh` 読取を safe-gh 隔離 reader へ誘導する(#137 / #181)。**1 capability が 2 つの
+  AI home 両方**に登録を出す — Claude は managed `~/.claude/settings.json` の `hooks`
+  (#137、`claude-settings` module)、Codex は user 層の別ファイル `~/.codex/hooks.json`
+  (#181、`codex-settings` module。config.toml は codex 所有の live ファイルなので分離)。
+  hook body(`personal-safe-gh-hook`)は agent-tools が両 home へ配布し、dotfiles は絶対
   path 参照のみ(登録=dotfiles・実体=agent-tools。path 安定は agent-tools#146 の契約)。
   **steering / fail-open で enforcement ではない**(body 不在・非 2 exit・不正 JSON は
-  すべて tool call 続行)。効くのは `claude-settings` module が active な profile だけ。
-  dangling(module 非 active / body 不在)は doctor が report。
+  すべて tool call 続行)。Codex は加えて、登録済みでも一度 `/hooks` trust するまで silent
+  skip される inert stage がある(registration ≠ activation)。効くのは対応 module
+  (`claude-settings` / `codex-settings`)が active な profile だけ。dangling(module 非
+  active / body 不在)は doctor が report。
 - GitHub 由来の deny は専用 capability を作らず **3 tier**(#119 Phase 2 task B): never-legit な
   secret 読取(`~/.ssh` と credential-store の `~/.aws` / `~/.config/gh` / `~/.netrc` /
   `~/.codex/auth.json`(#136)/ `printenv` / `env` / `gh secret` / `gh api *secrets*`)は
@@ -128,9 +133,9 @@ GitHub runtime prompt-injection 防御(epic #119)の capability 2 本。射程�
   限界・接続規約の正本は [ai-environment-boundary](ai-environment-boundary.md)。
 - **状態**: `gateGitHubMcp` は **personal=true**(Phase 2 で github MCP deny を live 化。
   render→diff→実機 dry-run の検証ゲート済み)、work=false(`claude-settings` 非 active)。
-  `enableGitHubIsolatedReader` も **personal=true**(#137 で PreToolUse hook 登録を live 化)、
-  work=false。github MCP は現状未構成なので deny は実質 no-op = 将来 MCP を足したとき
-  先回りで deny する defense-in-depth。
+  `enableGitHubIsolatedReader` も **personal=true**(#137 で Claude、#181 で Codex の
+  PreToolUse hook 登録を live 化。両 home 同一 body)、work=false。github MCP は現状未構成
+  なので deny は実質 no-op = 将来 MCP を足したとき先回りで deny する defense-in-depth。
 
 ## dormant capability の扱い(残す基準)
 

--- a/dot_codex/hooks.json.tmpl
+++ b/dot_codex/hooks.json.tmpl
@@ -1,0 +1,50 @@
+{{- $caps := index (index .profiles .profile) "capabilities" -}}
+{{- /* Codex parity of the Claude PreToolUse hook registration (#181, the
+       Codex side of #137). Same GitHub injection guard (epic #119), same
+       capability: enableGitHubIsolatedReader registers the safe-gh read-steering
+       hook in the user-layer ~/.codex/hooks.json so raw `gh` reads of untrusted
+       GitHub content are nudged toward the safe-gh isolated reader.
+
+       Why a SEPARATE file and not ~/.codex/config.toml's [hooks] table:
+       config.toml is a codex-owned live file (codex writes [hooks.state] etc.),
+       so templating it risks an overwrite conflict. The user-layer hooks.json is
+       an equivalent registration point (agent-tools probe, Codex 0.142.2) and
+       keeps dotfiles' managed surface disjoint from codex's live state
+       (registration = dotfiles / config.toml = codex; docs/config-ownership.md).
+
+       registration = dotfiles, body = agent-tools: the hook body
+       (personal-safe-gh-hook) is deployed by agent-tools to a stable path
+       (agent-tools#146 contract); dotfiles only references it by absolute path —
+       no script body is distributed from here. The schema under "hooks" is
+       identical to Claude Code's (PreToolUse -> matcher -> command hooks).
+
+       Steering / fail-open, NOT an enforcement boundary (docs/ai-environment-
+       boundary.md): a missing body (exit 127), any non-2 non-zero exit, bad JSON,
+       or a timeout all let the tool call continue (only exit 2 blocks), so
+       rendering this before agent-tools has synced is a safe no-op.
+
+       Codex-specific inert stage (honest-label): even a registered+present hook
+       is silently skipped until a one-time interactive `/hooks` trust in Codex
+       (trust recorded in ~/.codex/config.toml [hooks.state]). Registration alone
+       does not activate it. This whole file is gated by the codex-settings module
+       (requires enableGitHubIsolatedReader: true); when the capability is off the
+       template renders empty and chezmoi removes the target. */ -}}
+{{- if index $caps "enableGitHubIsolatedReader" -}}
+{
+  "description": "dotfiles-managed (registration): safe-gh read-steering PreToolUse hook. Body deployed by agent-tools. Steering / fail-open — not an enforcement boundary. Requires a one-time /hooks trust in Codex to activate.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{ .chezmoi.homeDir }}/.codex/agent-tools/scripts/personal-safe-gh-hook",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+{{ end -}}

--- a/dot_codex/hooks.json.tmpl
+++ b/dot_codex/hooks.json.tmpl
@@ -26,9 +26,17 @@
        Codex-specific inert stage (honest-label): even a registered+present hook
        is silently skipped until a one-time interactive `/hooks` trust in Codex
        (trust recorded in ~/.codex/config.toml [hooks.state]). Registration alone
-       does not activate it. This whole file is gated by the codex-settings module
-       (requires enableGitHubIsolatedReader: true); when the capability is off the
-       template renders empty and chezmoi removes the target. */ -}}
+       does not activate it.
+
+       Gating (template self-gate, NOT a module `requires`): the file is managed
+       for profiles that list codex-settings (personal). The capability is gated
+       HERE — enableGitHubIsolatedReader=false renders EMPTY, and chezmoi removes a
+       managed target whose render is empty. A `requires:` on the module would
+       instead make .chezmoiignore drop the source, which leaves an already-applied
+       ~/.codex/hooks.json lingering (chezmoiignore does not prune existing
+       targets) — so disabling the capability would NOT remove a live hook. Doing
+       it in-template means flipping the capability off truly removes the file on
+       the next apply (Codex review #184; verified in test-codex-settings.sh). */ -}}
 {{- if index $caps "enableGitHubIsolatedReader" -}}
 {
   "description": "dotfiles-managed (registration): safe-gh read-steering PreToolUse hook. Body deployed by agent-tools. Steering / fail-open — not an enforcement boundary. Requires a one-time /hooks trust in Codex to activate.",

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -475,13 +475,15 @@ if module_active_for_profile "$profile" claude-settings; then
   # server-side branch protection or the Phase 3 isolated reader (#131).
   item "note: the main-push deny is leaky steering — catches 'git push … main', misses bare 'git push' / HEAD / refspec; real block is branch protection or the Phase 3 isolated reader (#131)"
 fi
-# enableGitHubIsolatedReader wires the isolated-reader steering (#137): the
-# managed settings.json registers the PreToolUse hook (matcher Bash) that steers
-# raw `gh` reads of untrusted GitHub content to the safe-gh reader. Steering /
-# fail-open (a missing body, non-2 exit, bad JSON or timeout all let the tool
-# call continue; only exit 2 blocks) — NOT an enforcement boundary. The hook
-# body is agent-tools-deployed (registration=dotfiles, body=agent-tools;
-# agent-tools#146 pins the path); report its presence only, contents-blind.
+# enableGitHubIsolatedReader wires the isolated-reader steering (#137 + #181): one
+# capability registers the PreToolUse hook (matcher Bash) that steers raw `gh`
+# reads of untrusted GitHub content to the safe-gh reader, in BOTH AI homes — the
+# managed ~/.claude/settings.json (claude-settings) and the user-layer
+# ~/.codex/hooks.json (codex-settings). Steering / fail-open (a missing body,
+# non-2 exit, bad JSON or timeout all let the tool call continue; only exit 2
+# blocks) — NOT an enforcement boundary. The hook body is agent-tools-deployed
+# (registration=dotfiles, body=agent-tools; agent-tools#146 pins the path);
+# report its presence only, contents-blind.
 if [[ "$(capability_value "$profile" enableGitHubIsolatedReader)" == "true" ]]; then
   if module_active_for_profile "$profile" claude-settings; then
     hook_body="$HOME/.claude/agent-tools/scripts/personal-safe-gh-hook"
@@ -492,6 +494,22 @@ if [[ "$(capability_value "$profile" enableGitHubIsolatedReader)" == "true" ]]; 
     fi
   else
     warn "enableGitHubIsolatedReader=true but the claude-settings module is inactive for this profile; no managed settings carry the hook registration (dangling capability)"
+  fi
+  # Codex parity (#181): the same capability registers the hook in the user-layer
+  # ~/.codex/hooks.json (codex-settings module). Codex has an EXTRA inert stage vs
+  # Claude — even a registered+present hook is silently skipped until a one-time
+  # interactive `/hooks` trust (trust recorded in ~/.codex/config.toml
+  # [hooks.state]). Report registration + body presence contents-blind and honest-
+  # label the trust requirement; never read config.toml here.
+  if module_active_for_profile "$profile" codex-settings; then
+    codex_hook_body="$HOME/.codex/agent-tools/scripts/personal-safe-gh-hook"
+    if [[ -x "$codex_hook_body" ]]; then
+      ok "enableGitHubIsolatedReader=true; managed ~/.codex/hooks.json registers the PreToolUse hook -> safe-gh steering (fail-open, not a boundary); hook body present (Codex: inert until a one-time /hooks trust)"
+    else
+      warn "enableGitHubIsolatedReader=true; PreToolUse hook registered in managed ~/.codex/hooks.json but the body is absent or non-executable ($codex_hook_body; agent-tools sync deploys it) — fail-open no-op until deployed (Codex also needs a one-time /hooks trust)"
+    fi
+  else
+    warn "enableGitHubIsolatedReader=true but the codex-settings module is inactive for this profile; no managed ~/.codex/hooks.json carries the hook registration (dangling capability on the Codex side)"
   fi
 else
   ok "enableGitHubIsolatedReader not active (false)"

--- a/scripts/test-codex-settings.sh
+++ b/scripts/test-codex-settings.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Content test for the managed ~/.codex/hooks.json PreToolUse hook registration
+# (#181, the Codex parity of the Claude side in #137 / test-claude-settings.sh
+# section 8). test-render.sh fixes the managed *set* per profile (that personal
+# manages .codex/hooks.json and work does not); this fixes the *content* the
+# enableGitHubIsolatedReader capability drives on the Codex side:
+#   - enableGitHubIsolatedReader=true (personal): a user-layer hooks.json with
+#     EXACTLY one PreToolUse/Bash command hook pointing at the agent-tools-deployed
+#     ~/.codex/agent-tools/scripts/personal-safe-gh-hook (absolute path), timeout 10.
+#   - enableGitHubIsolatedReader=false: no ~/.codex/hooks.json at all (the whole
+#     file is gated, unlike Claude where only the hooks *key* drops).
+# The registration is declarative and must render without the body deployed
+# (bootstrap-safe); runtime is fail-open (missing body / non-2 exit / bad JSON /
+# timeout continue the tool call — only exit 2 blocks), and Codex adds an inert
+# stage (silently skipped until a one-time `/hooks` trust). Steering, NOT an
+# enforcement boundary — see docs/ai-environment-boundary.md.
+# Renders into throwaway destinations; never touches the real home directory.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+require_yq || exit 1
+
+if ! command -v chezmoi >/dev/null 2>&1; then
+  fail "chezmoi not found; render tests require it"
+  exit 1
+fi
+
+status=0
+tmp_roots=()
+
+cleanup() {
+  local dir
+  for dir in "${tmp_roots[@]:-}"; do
+    [[ -n "$dir" ]] && rm -rf "$dir"
+  done
+}
+trap cleanup EXIT
+
+# Apply the personal profile from SOURCE_DIR into a throwaway home and print the
+# path to that home (so callers can inspect the presence/absence of files).
+# Returns non-zero on a failed apply.
+render_personal_home() {
+  local source_dir="$1" root
+  root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings.XXXXXX")"
+  tmp_roots+=("$root")
+  mkdir -p "$root/home"
+  printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
+  if ! chezmoi --config "$root/chezmoi.toml" \
+      --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1; then
+    return 1
+  fi
+  printf '%s\n' "$root/home"
+}
+
+section "codex settings PreToolUse hook registration (#181)"
+
+# 1) Committed personal: enableGitHubIsolatedReader is ON, so ~/.codex/hooks.json
+#    exists and registers EXACTLY one hook: PreToolUse / matcher Bash / one command
+#    hook pointing at the agent-tools-deployed body (absolute path per the
+#    agent-tools#146 stable-path contract), timeout 10. Pinned as an exact set
+#    (event count, matcher, hook count, type, command, timeout), not just "a hook
+#    exists": this is security wiring, so a swapped matcher / extra event / wrong
+#    path must fail the test.
+if ! home="$(render_personal_home "$DOTFILES_ROOT")"; then
+  fail "test failed: personal apply (default) did not render"
+  exit 1
+fi
+hooks_file="$home/.codex/hooks.json"
+expected_hook_cmd="$HOME/.codex/agent-tools/scripts/personal-safe-gh-hook"
+if [[ ! -f "$hooks_file" ]]; then
+  fail "test failed: committed personal did not render ~/.codex/hooks.json (enableGitHubIsolatedReader is ON)"
+  status=1
+elif ! yq -p json '.' "$hooks_file" >/dev/null 2>&1; then
+  fail "test failed: ~/.codex/hooks.json is not valid JSON"
+  status=1
+else
+  events="$(yq -p json '.hooks | keys | length' "$hooks_file")"
+  pre_len="$(yq -p json '.hooks.PreToolUse | length' "$hooks_file")"
+  matcher="$(yq -p json '.hooks.PreToolUse[0].matcher' "$hooks_file")"
+  inner_len="$(yq -p json '.hooks.PreToolUse[0].hooks | length' "$hooks_file")"
+  inner_type="$(yq -p json '.hooks.PreToolUse[0].hooks[0].type' "$hooks_file")"
+  inner_cmd="$(yq -p json '.hooks.PreToolUse[0].hooks[0].command' "$hooks_file")"
+  inner_timeout="$(yq -p json '.hooks.PreToolUse[0].hooks[0].timeout' "$hooks_file")"
+  if [[ "$events" == "1" && "$pre_len" == "1" && "$matcher" == "Bash" \
+    && "$inner_len" == "1" && "$inner_type" == "command" \
+    && "$inner_cmd" == "$expected_hook_cmd" && "$inner_timeout" == "10" ]]; then
+    ok "test passed: committed personal registers exactly one PreToolUse/Bash command hook -> personal-safe-gh-hook (absolute path, timeout 10)"
+  else
+    fail "test failed: codex hook registration wrong (events=$events pre_len=$pre_len matcher=$matcher inner_len=$inner_len type=$inner_type cmd=$inner_cmd timeout=$inner_timeout)"
+    status=1
+  fi
+fi
+
+# 2) Bootstrap order is safe: the throwaway render home has NO agent-tools scripts,
+#    yet the apply succeeded and rendered the registration. The registration is
+#    declarative — it must not depend on the body being deployed. At runtime a
+#    missing body is fail-open, and doctor reports the absent body (plus the Codex
+#    /hooks trust requirement).
+if [[ -n "${home:-}" && ! -e "$home/.codex/agent-tools/scripts/personal-safe-gh-hook" ]]; then
+  ok "test passed: registration renders without the hook body present (agent-tools sync can come later; runtime is fail-open)"
+else
+  fail "test failed: throwaway render home unexpectedly contains a codex hook body (fixture assumption broken)"
+  status=1
+fi
+
+# 3) enableGitHubIsolatedReader=false -> the WHOLE ~/.codex/hooks.json is gone
+#    (the codex-settings module requires the capability, so chezmoiignore drops
+#    the path entirely — file-level gating, unlike Claude's key-level gating).
+#    Flip in a throwaway source copy so the committed default stays true.
+reader_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-off.XXXXXX")"
+tmp_roots+=("$reader_src")
+cp -R "$DOTFILES_ROOT" "$reader_src/src"
+rm -rf "$reader_src/src/.git"
+yq -i '.profiles.personal.capabilities.enableGitHubIsolatedReader = false' \
+  "$reader_src/src/.chezmoidata/profiles.yaml"
+if ! off_home="$(render_personal_home "$reader_src/src")"; then
+  fail "test failed: personal apply (enableGitHubIsolatedReader=false) did not render"
+  exit 1
+fi
+if [[ ! -e "$off_home/.codex/hooks.json" ]]; then
+  ok "test passed: enableGitHubIsolatedReader=false removes ~/.codex/hooks.json entirely (file-level gating)"
+else
+  fail "test failed: enableGitHubIsolatedReader=false still rendered ~/.codex/hooks.json"
+  status=1
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  ok "codex settings tests passed"
+fi
+exit "$status"

--- a/scripts/test-codex-settings.sh
+++ b/scripts/test-codex-settings.sh
@@ -9,8 +9,11 @@ set -euo pipefail
 #   - enableGitHubIsolatedReader=true (personal): a user-layer hooks.json with
 #     EXACTLY one PreToolUse/Bash command hook pointing at the agent-tools-deployed
 #     ~/.codex/agent-tools/scripts/personal-safe-gh-hook (absolute path), timeout 10.
-#   - enableGitHubIsolatedReader=false: no ~/.codex/hooks.json at all (the whole
-#     file is gated, unlike Claude where only the hooks *key* drops).
+#   - enableGitHubIsolatedReader=false: no ~/.codex/hooks.json at all, AND an
+#     already-applied file is REMOVED on the next apply (template self-gate renders
+#     empty -> chezmoi prunes the managed target). This is why the module uses a
+#     template self-gate instead of a `requires:` gate: chezmoiignore would drop
+#     the source but leave a live hook lingering (Codex review #184).
 # The registration is declarative and must render without the body deployed
 # (bootstrap-safe); runtime is fail-open (missing body / non-2 exit / bad JSON /
 # timeout continue the tool call — only exit 2 blocks), and Codex adds an inert
@@ -107,24 +110,40 @@ else
   status=1
 fi
 
-# 3) enableGitHubIsolatedReader=false -> the WHOLE ~/.codex/hooks.json is gone
-#    (the codex-settings module requires the capability, so chezmoiignore drops
-#    the path entirely — file-level gating, unlike Claude's key-level gating).
-#    Flip in a throwaway source copy so the committed default stays true.
-reader_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-off.XXXXXX")"
-tmp_roots+=("$reader_src")
-cp -R "$DOTFILES_ROOT" "$reader_src/src"
-rm -rf "$reader_src/src/.git"
+# 3) enableGitHubIsolatedReader=false REMOVES an ALREADY-APPLIED ~/.codex/hooks.json
+#    on the next apply — not just "does not newly create it". This is the exact
+#    lingering scenario a `requires:` module gate would miss (chezmoiignore drops
+#    the source but never prunes an existing target), so we drive both applies into
+#    the SAME home: cap ON renders the file, then cap OFF must delete it (the
+#    template self-gate renders empty and chezmoi prunes the managed target).
+off_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-off-src.XXXXXX")"
+tmp_roots+=("$off_src")
+cp -R "$DOTFILES_ROOT" "$off_src/src"
+rm -rf "$off_src/src/.git"
 yq -i '.profiles.personal.capabilities.enableGitHubIsolatedReader = false' \
-  "$reader_src/src/.chezmoidata/profiles.yaml"
-if ! off_home="$(render_personal_home "$reader_src/src")"; then
-  fail "test failed: personal apply (enableGitHubIsolatedReader=false) did not render"
-  exit 1
-fi
-if [[ ! -e "$off_home/.codex/hooks.json" ]]; then
-  ok "test passed: enableGitHubIsolatedReader=false removes ~/.codex/hooks.json entirely (file-level gating)"
+  "$off_src/src/.chezmoidata/profiles.yaml"
+
+removal_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-removal.XXXXXX")"
+tmp_roots+=("$removal_root")
+mkdir -p "$removal_root/home"
+printf '[data]\nprofile = "personal"\n' > "$removal_root/chezmoi.toml"
+apply_into_removal_home() {
+  chezmoi --config "$removal_root/chezmoi.toml" \
+    --source "$1" --destination "$removal_root/home" apply >/dev/null 2>&1
+}
+if ! apply_into_removal_home "$DOTFILES_ROOT"; then
+  fail "test failed: cap-on apply into removal home did not render"
+  status=1
+elif [[ ! -f "$removal_root/home/.codex/hooks.json" ]]; then
+  fail "test failed: cap-on apply did not create ~/.codex/hooks.json (removal test precondition)"
+  status=1
+elif ! apply_into_removal_home "$off_src/src"; then
+  fail "test failed: cap-off apply into removal home did not run"
+  status=1
+elif [[ ! -e "$removal_root/home/.codex/hooks.json" ]]; then
+  ok "test passed: enableGitHubIsolatedReader=false removes an already-applied ~/.codex/hooks.json (template self-gate prunes the target — no lingering hook)"
 else
-  fail "test failed: enableGitHubIsolatedReader=false still rendered ~/.codex/hooks.json"
+  fail "test failed: enableGitHubIsolatedReader=false left a lingering ~/.codex/hooks.json (a requires: gate regression?)"
   status=1
 fi
 

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -524,9 +524,10 @@ cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$gh_root/.chezmoidata/"
 if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "denies the github MCP server" <<< "$gh_out" \
     && grep -Fq "hook registered in managed settings.json but the body is absent" <<< "$gh_out" \
+    && grep -Fq "registered in managed ~/.codex/hooks.json but the body is absent" <<< "$gh_out" \
     && grep -Fq "secret floor active" <<< "$gh_out" \
     && grep -Fq "human-legit write gate INERT" <<< "$gh_out"; then
-    ok "test passed: MCP deny + secret floor active + human-legit gate inert + hook registered with absent body warned (fail-open)"
+    ok "test passed: MCP deny + secret floor active + human-legit gate inert + Claude & Codex hooks registered with absent bodies warned (fail-open)"
   else
     printf '%s\n' "$gh_out" >&2
     fail "test failed: GitHub guard capability not reported"
@@ -584,13 +585,20 @@ set_capability_all "$gh_root" enableGitHubIsolatedReader true
 mkdir -p "$fixture_home/.claude/agent-tools/scripts"
 printf '#!/bin/sh\nexit 0\n' > "$fixture_home/.claude/agent-tools/scripts/personal-safe-gh-hook"
 chmod +x "$fixture_home/.claude/agent-tools/scripts/personal-safe-gh-hook"
+# Codex parity (#181): deploy the Codex-home body too so the codex-settings line
+# flips to its wired ok (present, contents-blind). Its stable path mirrors the
+# Claude one under ~/.codex (agent-tools#146).
+mkdir -p "$fixture_home/.codex/agent-tools/scripts"
+printf '#!/bin/sh\nexit 0\n' > "$fixture_home/.codex/agent-tools/scripts/personal-safe-gh-hook"
+chmod +x "$fixture_home/.codex/agent-tools/scripts/personal-safe-gh-hook"
 if gh_out="$(HOME="$fixture_home" "$gh_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "denies the github MCP server" <<< "$gh_out" \
-    && grep -Fq "safe-gh steering (fail-open, not a boundary); hook body present" <<< "$gh_out"; then
-    ok "test passed: gateGitHubMcp=true reported as enforced; hook registration + present body reported as wired steering"
+    && grep -Fq "managed settings.json registers the PreToolUse hook -> safe-gh steering (fail-open, not a boundary); hook body present" <<< "$gh_out" \
+    && grep -Fq "managed ~/.codex/hooks.json registers the PreToolUse hook -> safe-gh steering (fail-open, not a boundary); hook body present" <<< "$gh_out"; then
+    ok "test passed: gateGitHubMcp=true enforced; Claude & Codex hook registration + present bodies reported as wired steering"
   else
     printf '%s\n' "$gh_out" >&2
-    fail "test failed: gateGitHubMcp wired-state or isolated-reader wired state not reported"
+    fail "test failed: gateGitHubMcp wired-state or isolated-reader (Claude/Codex) wired state not reported"
     status=1
   fi
 else
@@ -599,6 +607,7 @@ else
   status=1
 fi
 rm -f "$fixture_home/.claude/agent-tools/scripts/personal-safe-gh-hook"
+rm -f "$fixture_home/.codex/agent-tools/scripts/personal-safe-gh-hook"
 
 # R) enforceAiSandbox=true: the injection-guard section discloses the human-legit
 #    write gate as ACTIVE (it rides on enforceAiSandbox), with the always-on secret

--- a/scripts/test-render.sh
+++ b/scripts/test-render.sh
@@ -53,7 +53,7 @@ expected_managed() {
   local profile="$1"
   case "$profile" in
     personal)
-      printf '%s\n' .claude .claude/settings.json .config .config/git .config/git/signing.gitconfig .config/mise .config/mise/config.toml .config/starship.toml .gitconfig .npmrc .ssh .ssh/config .zprofile .zshenv .zshrc
+      printf '%s\n' .claude .claude/settings.json .codex .codex/hooks.json .config .config/git .config/git/signing.gitconfig .config/mise .config/mise/config.toml .config/starship.toml .gitconfig .npmrc .ssh .ssh/config .zprofile .zshenv .zshrc
       ;;
     work)
       printf '%s\n' .config .config/mise .config/mise/config.toml .config/starship.toml .gitconfig .zprofile .zshenv .zshrc


### PR DESCRIPTION
## 概要

#137(Claude 側 PreToolUse hook 登録)の **Codex parity**。同じ capability `enableGitHubIsolatedReader` が **2 つの AI home 両方**に safe-gh 誘導の PreToolUse hook を登録する。

- **Claude**: managed `~/.claude/settings.json` の `hooks` キー(#137、既存)
- **Codex**: user 層の **別ファイル** `~/.codex/hooks.json`(本 PR、`codex-settings` module)

## 設計判断

- **なぜ別ファイル(config.toml の `[hooks]` ではない)**: `~/.codex/config.toml` は codex 所有の live ファイル(`[hooks.state]` 等を codex が書く)。templating すると上書き衝突する。user 層 `hooks.json` は等価な登録点(Codex 0.142.2 実機 probe)で、dotfiles の managed surface を codex の live state と disjoint に保てる(registration=dotfiles / config.toml=codex。`docs/config-ownership.md`)。
- **schema**: Codex 0.142.2 の plugin `hooks.json` 実例に一致(`hooks.PreToolUse[].{matcher, hooks[]{type, command, timeout}}`。Claude Code と同型)。
- **1 capability で 2 home 連動**: `enableGitHubIsolatedReader` を再利用(新 capability を作らない)。`codex-settings` module は `requires: enableGitHubIsolatedReader: true` で file 単位 gate — off なら chezmoiignore が path ごと落とす。

## 強度(honest-label)

**steering / fail-open であって enforcement boundary ではない**: body 不在(exit 127)・非 2 の非ゼロ exit・不正 JSON・timeout はすべて tool call 続行(block は exit 2 のみ)。実体 body の配布と path 安定は agent-tools の責務(agent-tools#146)。

**Codex 固有の inert stage**: Claude の「登録漏れ=不活性」に加え、Codex は**登録済みでも一度 `/hooks` trust するまで無警告で silent skip**(registration ≠ activation)。doctor がこれを honest-label する。

## 変更

| ファイル | 内容 |
| --- | --- |
| `.chezmoidata/modules.yaml` | `codex-settings` module 新設 |
| `.chezmoidata/profiles.yaml` | personal に module 追加 + cap コメント追従 |
| `dot_codex/hooks.json.tmpl` | 登録本体(cap off は空 render) |
| `scripts/doctor.sh` | isolated-reader 節を Codex parity で拡張(contents-blind・trust 注記・exit 0) |
| `scripts/test-render.sh` | personal expected set に `.codex` 系 |
| `scripts/test-codex-settings.sh` | 新規 content test + validate.yml 配線 |
| `scripts/test-doctor.sh` | case P/Q を両 body で拡張 |
| `docs/{config-ownership,ai-environment-boundary,policy-model}.md` | 追従 |

## 検証(ローカル、全 green)

- `test-render.sh`(managed set)/ `test-codex-settings.sh`(登録の exact 構造・bootstrap 安全・cap off で file 消失)/ `test-doctor.sh`(P/Q 両 body)
- `validate-policy.sh --all`(personal / work)
- `shellcheck -S warning`(clean)/ `preflight.sh`
- 実機 `doctor.sh personal`: `managed ~/.codex/hooks.json registers the PreToolUse hook ... hook body present (Codex: inert until a one-time /hooks trust)`、exit 0

## 受け入れの残り(merge 後、実機)

`chezmoi apply` → Codex で `/hooks` trust → `gh issue view <n> --comments` で steer 受領を確認。あわせて #181 コメントの **trust hash 範囲**(hook body に観測可能な変更を入れ再配備 → 再 trust なしで steer が出続けるか)を判別し、結果を agent-tools `docs/runtime-injection-defense.md` の Codex parity 項に反映(反映ループ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)