### PR TITLE
codex hooks.json: top-level description を除去(Codex 0.142.5 parse error 回帰)(#185)

### DIFF
--- a/dot_codex/hooks.json.tmpl
+++ b/dot_codex/hooks.json.tmpl
@@ -18,6 +18,14 @@
        no script body is distributed from here. The schema under "hooks" is
        identical to Claude Code's (PreToolUse -> matcher -> command hooks).
 
+       Rendered JSON is the MINIMAL {"hooks": {...}} — no top-level "description"
+       or any other key. Codex 0.142.5 rejects unknown top-level keys in
+       hooks.json (a top-level "description" is a parse error in the TUI hook-
+       review path, so the hook fails to load), even though the 0.142.2 plugin
+       example carried one. So all human-facing notes live in THIS template
+       comment, never in the rendered JSON (#185). test-codex-settings.sh pins the
+       top-level key set to exactly {hooks} as a parse-safety regression guard.
+
        Steering / fail-open, NOT an enforcement boundary (docs/ai-environment-
        boundary.md): a missing body (exit 127), any non-2 non-zero exit, bad JSON,
        or a timeout all let the tool call continue (only exit 2 blocks), so
@@ -39,7 +47,6 @@
        the next apply (Codex review #184; verified in test-codex-settings.sh). */ -}}
 {{- if index $caps "enableGitHubIsolatedReader" -}}
 {
-  "description": "dotfiles-managed (registration): safe-gh read-steering PreToolUse hook. Body deployed by agent-tools. Steering / fail-open — not an enforcement boundary. Requires a one-time /hooks trust in Codex to activate.",
   "hooks": {
     "PreToolUse": [
       {

--- a/scripts/test-codex-settings.sh
+++ b/scripts/test-codex-settings.sh
@@ -81,6 +81,17 @@ elif ! yq -p json '.' "$hooks_file" >/dev/null 2>&1; then
   fail "test failed: ~/.codex/hooks.json is not valid JSON"
   status=1
 else
+  # 0.142.5 parse-safety: the top-level object must be EXACTLY {hooks} — Codex
+  # 0.142.5 rejects unknown top-level keys (a top-level "description" is a parse
+  # error and the hook fails to load), so pin the key set, not just "hooks
+  # exists" (#185).
+  top_keys="$(yq -p json -o json '[keys[]] | sort' "$hooks_file" 2>/dev/null | tr -d ' \n')"
+  if [[ "$top_keys" == '["hooks"]' ]]; then
+    ok "test passed: top-level keys are exactly {hooks} (no description/unknown key — Codex 0.142.5 parse-safe)"
+  else
+    fail "test failed: unexpected top-level key(s) in ~/.codex/hooks.json: $top_keys (Codex 0.142.5 rejects unknown top-level keys — #185)"
+    status=1
+  fi
   events="$(yq -p json '.hooks | keys | length' "$hooks_file")"
   pre_len="$(yq -p json '.hooks.PreToolUse | length' "$hooks_file")"
   matcher="$(yq -p json '.hooks.PreToolUse[0].matcher' "$hooks_file")"


### PR DESCRIPTION
## 概要

#181(PR #184)の回帰修正。managed `~/.codex/hooks.json` の **top-level `description`** が **Codex 0.142.5** の TUI hook review 経路で **parse error** になり、hook が読み込めなかった(未知 top-level キーを厳格化。0.142.2 の plugin 実例は description を持つが 0.142.5 で弾かれる)。

## 実機の経緯(ユーザー確認・0.142.5)

- `~/.codex/hooks.json` から `description` 行を外すと parse OK → `/hooks` の "Trust all and continue" で trust 成立、`config.toml` に `[hooks.state."/Users/kosako/.codex/hooks.json:pre_tool_use:0:0"]` が記録された。
- template は description を出したままだったので次の `chezmoi apply` で手修正が上書きされ再発する状態(`MM .codex/hooks.json`)だった。

## 変更

- `dot_codex/hooks.json.tmpl`: rendered JSON を最小形 `{"hooks":{...}}` にし top-level `description` を除去。人間向け注記は Go-template コメント(JSON に出ない)へ移動。
- `scripts/test-codex-settings.sh`: **top-level キーが厳密に `{hooks}` のみ**(未知キー無し=0.142.5 parse-safety)を回帰固定。
- template comment: 0.142.5 の top-level 厳格化を honest-label。

## 検証

- 全テスト green(`test-codex-settings` に parse-safety guard 追加・`test-render`/`test-doctor`/`validate-policy` は影響なし)、`shellcheck -S warning` clean。
- **template == live**(ユーザーの手修正と一致)で `chezmoi status` の codex drift は解消・apply 不要。
- `codex doctor` は hooks.json を厳格 validate しない(description 有無で差なし)ため gate に使えず、テストでスキーマを pin。

## レビュー観点(→ Codex)

- 最小形が Codex 0.142.5 で確実に parse される形か(top-level `hooks` のみ・matcher/command/timeout 構造)。
- parse-safety guard(top-level keys == `{hooks}`)が過不足ないか。
- #181 の他の契約(自己 gate 削除・doctor・parity)を壊していないか。

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)