### PR TITLE
refactor: runtime scripts の重複集約 + dead code 除去 (PR-1/4, Refs #189)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -334,6 +334,6 @@ managed file に混入しないことを確認する。chezmoi が必要(render 
 ## lib-policy.sh
 
 他 script から source される共通 helper。
-data file path、profile/module/capability 取得、出力 helper、command availability check、Git remote credential 検出(`git_remotes_with_credentials`。remote 名のみを出力し、URL 値は出力しない)を提供する。
+data file path、profile/module/capability 取得、出力 helper、command availability check、Git remote credential 検出(`git_remotes_with_credentials`。remote 名のみを出力し、URL 値は出力しない)を提供する。ほかに、BSD/GNU をまたぐ octal mode 取得(`file_mode`)、doctor / preflight が共有する policy ゲート(`run_policy_validation`)と標準 project roots 報告(`report_standard_project_roots`)、catalog source → package manager の対応表(`manager_present`。installer と catalog drift 報告の単一 source)を持つ。
 
 policy data(`.chezmoidata/*.yaml`)の読み取りは mikefarah/yq v4 で行う。`require_yq` が yq の存在と variant・版を検査し、満たさなければ fail closed する(`validate-policy.sh` / `test-npmrc.sh` / `test-render.sh` が冒頭で呼ぶ。`doctor.sh` / `preflight.sh` は内部で `validate-policy.sh` を先に実行するため間接的にカバーされる)。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない。

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -10,9 +10,7 @@ profile="${1:-personal}"
 section "doctor profile: $profile"
 
 section "policy"
-if ! "$SCRIPT_DIR/validate-policy.sh" "$profile"; then
-  exit 1
-fi
+run_policy_validation "$profile" || exit 1
 
 environment_kind="$(profile_environment_kind "$profile")"
 ok "environmentKind: $environment_kind"
@@ -748,16 +746,7 @@ if [[ "$tunnel_tools_found" -eq 0 ]]; then
 fi
 
 section "project roots"
-# Standard roots (docs/directory-convention.md). They are optional: repos may
-# live outside ~/src (a non-standard placement) with repo-local identity, so a
-# missing standard root is reported neutrally, not as a warning (#134).
-for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/sandbox" "$HOME/src/agent"; do
-  if [[ -d "$dir" ]]; then
-    ok "exists: $dir"
-  else
-    item "not present (standard root, optional): $dir"
-  fi
-done
+report_standard_project_roots
 
 # doctor is report-only: warnings never change the exit code.
 # The only non-zero path is the policy validation at the top.

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -64,18 +64,8 @@ is_installed() {
   esac
 }
 
-# Whether the manager SOURCE needs is on PATH. npm_global / go_install depend
-# on a runtime (node / go) that mise provides, and mas needs the `mas` CLI;
-# absence means "skip", not "install failed".
-manager_present() {
-  case "$1" in
-    brew_formula | brew_cask) command -v brew >/dev/null 2>&1 ;;
-    npm_global) command -v npm >/dev/null 2>&1 ;;
-    go_install) command -v go >/dev/null 2>&1 ;;
-    mas) command -v mas >/dev/null 2>&1 ;;
-    *) return 1 ;;
-  esac
-}
+# manager_present (source -> required manager mapping) lives in
+# lib-policy.sh so the catalog drift report shares the same table.
 
 # Build the install command for SOURCE into the INSTALL_CMD array (global),
 # using CANONICAL (= pkg, defaulting to name) as the install id. Returns 1

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -67,6 +67,39 @@ require_data_files() {
   [[ "$missing" -eq 0 ]]
 }
 
+# stat mode (octal permission bits) portably across BSD (macOS) and GNU.
+# BSD and GNU stat take different flags; pick by OS rather than chaining
+# them, since `stat -f` means --file-system on GNU.
+file_mode() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+# The policy gate shared by doctor and preflight. Callers print their own
+# section header and keep the exit path (`|| exit 1`) at the call site: it
+# is the only non-zero path in those report-only scripts.
+run_policy_validation() {
+  "$SCRIPT_DIR/validate-policy.sh" "$1"
+}
+
+# Standard project roots (docs/directory-convention.md), shared by doctor
+# and preflight. They are optional: repos may live outside ~/src (a
+# non-standard placement) with repo-local identity, so a missing standard
+# root is reported neutrally, not as a warning (#134).
+report_standard_project_roots() {
+  local dir
+  for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/sandbox" "$HOME/src/agent"; do
+    if [[ -d "$dir" ]]; then
+      ok "exists: $dir"
+    else
+      item "not present (standard root, optional): $dir"
+    fi
+  done
+}
+
 # Names are passed to yq via strenv(), never interpolated into the
 # expression, so a name with special characters cannot break or inject
 # into the query.
@@ -259,12 +292,6 @@ catalog_packages() {
   yq '.packages[]? | [(.name // ""), (.source // ""), (.pkg // ""), (.bin // ""), ((.track_only // false) | tostring)] | join("|")' "$PACKAGES_FILE"
 }
 
-# Emit the advisory source-preference order for a category (cli / gui).
-catalog_source_preference() {
-  local category="$1"
-  c="$category" yq '.source_preference[strenv(c)][]?' "$PACKAGES_FILE"
-}
-
 # Map a catalog source to the capability that gates installing it (#53 stage
 # 2). brew_formula / npm_global / go_install are package installs
 # (installPackages); brew_cask / mas are GUI apps (installGuiApps). manual and
@@ -274,6 +301,20 @@ source_install_capability() {
   case "$1" in
     brew_formula | npm_global | go_install) printf 'installPackages\n' ;;
     brew_cask | mas) printf 'installGuiApps\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+# Whether the manager SOURCE needs is on PATH. npm_global / go_install depend
+# on a runtime (node / go) that mise provides, and mas needs the `mas` CLI;
+# absence means "skip", not "install failed". Single source for the
+# source -> manager mapping (installer and catalog drift both use it).
+manager_present() {
+  case "$1" in
+    brew_formula | brew_cask) command -v brew >/dev/null 2>&1 ;;
+    npm_global) command -v npm >/dev/null 2>&1 ;;
+    go_install) command -v go >/dev/null 2>&1 ;;
+    mas) command -v mas >/dev/null 2>&1 ;;
     *) return 1 ;;
   esac
 }
@@ -384,13 +425,13 @@ report_catalog_drift() {
   # flags gate whether absence means "not installed" or "manager not
   # present, skip".
   local have_brew=0 have_npm=0 have_go=0 have_mas=0 gobin=""
-  if command -v brew >/dev/null 2>&1; then
+  if manager_present brew_formula; then
     have_brew=1
     installed_inventory brew_formula | sort > "$brew_formulae"
     installed_inventory brew_leaves | sort > "$brew_leaves"
     installed_inventory brew_cask | sort > "$brew_casks"
   fi
-  if command -v npm >/dev/null 2>&1; then
+  if manager_present npm_global; then
     have_npm=1
     installed_inventory npm_global \
       | grep -vxE 'npm|corepack' | sort > "$npm_globals" || true
@@ -399,12 +440,12 @@ report_catalog_drift() {
   # but treating go like the other managers (absent -> skip, not "not
   # installed") keeps the contract uniform and avoids guessing GOPATH when
   # go cannot tell us where it is.
-  if command -v go >/dev/null 2>&1; then
+  if manager_present go_install; then
     have_go=1
     gobin="$(go_bin_dir)"
     installed_inventory go_install | sort > "$go_bins"
   fi
-  if command -v mas >/dev/null 2>&1; then
+  if manager_present mas; then
     have_mas=1
     installed_inventory mas | sort > "$mas_ids"
   fi

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -10,9 +10,7 @@ profile="${1:-personal}"
 section "preflight profile: $profile"
 
 section "policy"
-if ! "$SCRIPT_DIR/validate-policy.sh" "$profile"; then
-  exit 1
-fi
+run_policy_validation "$profile" || exit 1
 
 section "system"
 ok "arch: $(uname -m)"
@@ -93,13 +91,7 @@ config_dir="$HOME/.config"
 if [[ -L "$config_dir" ]]; then
   warn "$config_dir is a symlink; apply may replace or follow it (verify with chezmoi diff)"
 elif [[ -d "$config_dir" ]]; then
-  # BSD (macOS) and GNU stat take different flags; pick by OS rather
-  # than chaining them, since `stat -f` means --file-system on GNU.
-  if [[ "$(uname)" == "Darwin" ]]; then
-    config_mode="$(stat -f '%Lp' "$config_dir" 2>/dev/null || echo unknown)"
-  else
-    config_mode="$(stat -c '%a' "$config_dir" 2>/dev/null || echo unknown)"
-  fi
+  config_mode="$(file_mode "$config_dir" 2>/dev/null || echo unknown)"
   if [[ "$config_mode" == "700" ]]; then
     ok "$config_dir mode already 0700"
   else
@@ -158,16 +150,7 @@ else
 fi
 
 section "known project roots"
-# Standard roots (docs/directory-convention.md). Optional: repos may live
-# outside ~/src (a non-standard placement) with repo-local identity, so a
-# missing standard root is reported neutrally, not as a warning (#134).
-for dir in "$HOME/src/personal" "$HOME/src/work" "$HOME/src/client" "$HOME/src/sandbox" "$HOME/src/agent"; do
-  if [[ -d "$dir" ]]; then
-    ok "exists: $dir"
-  else
-    item "not present (standard root, optional): $dir"
-  fi
-done
+report_standard_project_roots
 
 # preflight is report-only: warnings never change the exit code.
 # The only non-zero path is the policy validation at the top.

--- a/scripts/private-backup.sh
+++ b/scripts/private-backup.sh
@@ -51,15 +51,6 @@ All refuse unless the host profile grants allowSecretsAccess.
 EOF
 }
 
-# stat mode (octal permission bits) portably across BSD (macOS) and GNU.
-file_mode() {
-  if [[ "$(uname)" == "Darwin" ]]; then
-    stat -f '%Lp' "$1"
-  else
-    stat -c '%a' "$1"
-  fi
-}
-
 sha256_of() {
   shasum -a 256 "$1" | awk '{print $1}'
 }

--- a/scripts/test-private-backup.sh
+++ b/scripts/test-private-backup.sh
@@ -349,15 +349,9 @@ else
 fi
 set_profile personal
 
-# Octal mode of a path (same OS branch as file_mode in private-backup.sh,
-# which the test cannot source: running the script under test executes main).
-mode_of() {
-  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
-    stat -f '%Lp' "$1"
-  else
-    stat -c '%a' "$1"
-  fi
-}
+# file_mode comes from lib-policy.sh (already sourced): the same helper
+# private-backup.sh itself uses, which the test cannot source directly
+# (running the script under test executes main).
 
 # 19. A group-writable file (664) round-trips: capture, verify, and restore
 #     keep the recorded mode. Regression for the umask bug: extraction
@@ -378,10 +372,10 @@ if [[ "$gw_rc" -eq 0 ]] && HOME="$gw_home" PATH="$fixture_home/fakebin:$PATH" "$
   if HOME="$gw_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
     restore --in "$gw_home/gw.age" --identity "$fixture_home/keys/id.txt" \
     --target-home "$gw_dst" --apply >/dev/null 2>&1 \
-    && [[ "$(mode_of "$gw_dst/.zshrc.local")" == "664" ]]; then
+    && [[ "$(file_mode "$gw_dst/.zshrc.local")" == "664" ]]; then
     pass "group-writable file (664) survives backup/verify/restore with its mode"
   else
-    miss "restored group-writable file lost its mode (want 664, got $(mode_of "$gw_dst/.zshrc.local" 2>/dev/null))"
+    miss "restored group-writable file lost its mode (want 664, got $(file_mode "$gw_dst/.zshrc.local" 2>/dev/null))"
   fi
 else
   miss "verify rejected an archive containing a group-writable file (umask regression)"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -244,7 +244,7 @@ validate_packages() {
 # the mechanical safety rules only.
 validate_backup_paths() {
   local status=0
-  local path type category entry_ok rows
+  local path type _category entry_ok rows
   local types_file paths_file
   types_file="$(mktemp)"
   paths_file="$(mktemp)"
@@ -266,7 +266,10 @@ validate_backup_paths() {
   # entry that resolves to an empty path (a null/empty list item, or a
   # missing path: key) must fail closed, not be silently skipped: backup_paths
   # always emits at least two "|" per entry, so there are no blank rows to skip.
-  while IFS='|' read -r type category path; do
+  # _category is a field-splitting placeholder: backup_paths emits
+  # type|category|path but validation has no category rule (the leading
+  # underscore marks it intentionally unused for SC2034).
+  while IFS='|' read -r type _category path; do
     entry_ok=1
     if [[ -z "$path" ]]; then
       fail "backup path entry missing path"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -16,6 +16,20 @@ Validate profile/module/capability policy data.
 EOF
 }
 
+# Report every line on stdin (a `sort | uniq -d` stream) as a duplicate,
+# prefixed with $1. Returns non-zero when any duplicate was seen; callers
+# fold that into their status with `fail_duplicates "..." < <(...) ||
+# status=1` (keep the `||` — a bare call would trip set -e).
+fail_duplicates() {
+  local d found=0
+  while IFS= read -r d; do
+    [[ -z "$d" ]] && continue
+    fail "$1$d"
+    found=1
+  done
+  [[ "$found" -eq 0 ]]
+}
+
 # Modules that declare paths drive .chezmoiignore generation, so their
 # declarations must be valid on their own (independent of any profile).
 validate_modules() {
@@ -89,11 +103,8 @@ validate_modules() {
   done < "$known_modules_file"
 
   # A path claimed by two modules would make the ignore gate ambiguous.
-  while IFS= read -r path; do
-    [[ -z "$path" ]] && continue
-    fail "path declared by multiple modules: $path"
-    status=1
-  done < <(sort "$all_paths_file" | uniq -d)
+  fail_duplicates "path declared by multiple modules: " \
+    < <(sort "$all_paths_file" | uniq -d) || status=1
   rm -f "$all_paths_file"
 
   if [[ "$status" -eq 0 ]]; then
@@ -154,7 +165,7 @@ validate_capability_registry() {
 # or app id), and names must be unique.
 validate_packages() {
   local status=0
-  local name source pkg bin track_only duplicate entry_ok rows
+  local name source pkg bin track_only entry_ok rows
   local sources_file names_file
   sources_file="$(mktemp)"
   names_file="$(mktemp)"
@@ -212,11 +223,8 @@ validate_packages() {
     [[ "$entry_ok" -eq 1 ]] && ok "package: $name ($source)"
   done <<< "$rows"
 
-  while IFS= read -r duplicate; do
-    [[ -z "$duplicate" ]] && continue
-    fail "duplicate package name: $duplicate"
-    status=1
-  done < <(sort "$names_file" | uniq -d)
+  fail_duplicates "duplicate package name: " \
+    < <(sort "$names_file" | uniq -d) || status=1
   rm -f "$sources_file" "$names_file"
 
   if [[ "$status" -eq 0 ]]; then
@@ -236,7 +244,7 @@ validate_packages() {
 # the mechanical safety rules only.
 validate_backup_paths() {
   local status=0
-  local path type category duplicate entry_ok rows
+  local path type category entry_ok rows
   local types_file paths_file
   types_file="$(mktemp)"
   paths_file="$(mktemp)"
@@ -288,11 +296,8 @@ validate_backup_paths() {
     [[ "$entry_ok" -eq 1 ]] && ok "backup path: $path"
   done <<< "$rows"
 
-  while IFS= read -r duplicate; do
-    [[ -z "$duplicate" ]] && continue
-    fail "duplicate backup path: $duplicate"
-    status=1
-  done < <(sort "$paths_file" | uniq -d)
+  fail_duplicates "duplicate backup path: " \
+    < <(sort "$paths_file" | uniq -d) || status=1
   rm -f "$types_file" "$paths_file"
 
   if [[ "$status" -eq 0 ]]; then
@@ -307,7 +312,7 @@ validate_backup_paths() {
 validate_profile() {
   local profile="$1"
   local status=0
-  local environment_kind module capability value type duplicate forbidden ek_violations
+  local environment_kind module capability value type forbidden ek_violations
 
   if ! profile_exists "$profile"; then
     fail "unknown profile: $profile"
@@ -347,17 +352,11 @@ validate_profile() {
     fi
   done < <(profile_capabilities "$profile")
 
-  while IFS= read -r duplicate; do
-    [[ -z "$duplicate" ]] && continue
-    fail "duplicate capability in $profile: $duplicate"
-    status=1
-  done < <(profile_capabilities "$profile" | sort | uniq -d)
+  fail_duplicates "duplicate capability in $profile: " \
+    < <(profile_capabilities "$profile" | sort | uniq -d) || status=1
 
-  while IFS= read -r duplicate; do
-    [[ -z "$duplicate" ]] && continue
-    fail "duplicate module in $profile: $duplicate"
-    status=1
-  done < <(profile_modules "$profile" | sort | uniq -d)
+  fail_duplicates "duplicate module in $profile: " \
+    < <(profile_modules "$profile" | sort | uniq -d) || status=1
 
   while IFS= read -r capability; do
     [[ -z "$capability" ]] && continue


### PR DESCRIPTION
Refs #189(全体リファクタリング・挙動不変)の PR-1/4。ultracode 監査(5 レンズ Find → 敵対 Verify、REFUTED 0)の CONFIRMED 所見のうち runtime scripts 系 5 件を実施する。

## 変更内容(すべて挙動不変)

1. **`file_mode()` を lib-policy.sh へ集約**(3 重複解消)
   - private-backup.sh の関数定義 / preflight.sh のインライン再実装 / test-private-backup.sh の `mode_of()` を単一定義に。preflight は `2>/dev/null || echo unknown` を call site に残すので出力 byte 不変。
2. **doctor / preflight の byte-identical 複製 2 箇所を lib-policy.sh へ**
   - policy ゲート → `run_policy_validation`(`section "policy"` と `|| exit 1` は call site に残す = report-only 契約の唯一の非 zero path を関数に吸わせない)
   - standard project roots ループ → `report_standard_project_roots`(#134 の「missing root は neutral」の正本が 1 箇所に)
3. **validate-policy.sh の `sort | uniq -d` 重複検出ループ ×5 を `fail_duplicates` に集約**
   - メッセージ prefix は逐語維持(`"duplicate capability in $profile: "` 等)。`helper || status=1` 形で status の単調更新も同値。
4. **`manager_present()` を install-packages.sh → lib-policy.sh へ移動し、`report_catalog_drift` の `have_*` 判定と一本化**
   - source→manager 対応表の単一 source 化。probe(`command -v`)の実行コマンド・回数・順序は不変。移動と置換は同一 commit で原子的に実施(test-policy の drift harness は lib 単独 source のため)。
5. **dead 関数 `catalog_source_preference()` を削除**
   - `git grep` を全リビジョンに対して実行し、導入 commit 以来呼び出しゼロを確認済み。repo 現在形でも参照は定義行のみ。`packages.yaml` の `source_preference` キーは「advisory only(人間向け)」のコメント付き意図的データなので残置。

## 挙動不変の検証(実施済み)

- `bash -n` / `shellcheck -S warning`: green(validate-policy.sh の SC2034 1 件は main でも出る既存件 = ローカル shellcheck 0.11.0 と CI の版差。本 PR では増減なし)
- **全テスト suite green**(test-lib.sh 除く 16 本)
- **render byte-identical**: personal / work 両 profile の throwaway apply 出力を変更前 baseline と `diff -r` → 一致(scripts/ は .chezmoiignore 対象なので構造的にも不変)
- **旧新実出力比較**: main worktree と本 branch で `doctor.sh` / `preflight.sh` × personal / work を実行し stdout+stderr を diff → **環境由来の差分(worktree path 表示・npm probe の実行時刻)以外は byte-identical**。exit code も全一致(rc=0)

## レビュー観点(お願いしたいこと)

- 集約後の関数が呼び出し文脈(`set -e` / `|| status=1` / condition 文脈)で旧コードと等価か
- fail_duplicates の prefix 逐語性(5 箇所)
- manager_present 移動の原子性(lib 側定義 + install-packages 側削除 + drift 置換が同 commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qw8BkUDu5WdwhYfiFFX5n
