### PR TITLE
refactor: テスト基盤の fixture 集約 — render/flip/repo-copy/fake-status を test-lib.sh へ (PR-2/4, Refs #189)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,10 +86,15 @@ policy validation 失敗時のみ非 0、をカバーする。
 
 ## test-lib.sh
 
-test-*.sh が共有する fixture 編集 helper(source 専用、lib-policy.sh の後に source する)。
+test-*.sh が共有する fixture helper(source 専用、lib-policy.sh の後に source する)。
 `set_capability_all` / `remove_module_all` が fixture の profiles.yaml を yq で構造的に
 編集し、対象が存在しなければ fail する(行形式一致の awk 直書きが無言で no-op 化して
-テストが vacuous pass する事故の再発防止。#149)。
+テストが vacuous pass する事故の再発防止。#149)。ほかに render/fixture 構築の共有形:
+`render_personal_into`(throwaway home への personal apply。root は呼び出し側が mktemp +
+cleanup 登録する caller-creates-root 契約 — `$(...)` 内で mktemp する形は cleanup trap から
+漏れる、#150)、`make_flipped_source` / `flip_personal_capability`(source copy + personal
+限定 capability flip。boolean 専用)、`copy_repo_fixture`(scripts + .chezmoidata の最小
+repo copy)。
 
 ## test-policy.sh
 

--- a/scripts/test-claude-settings.sh
+++ b/scripts/test-claude-settings.sh
@@ -25,6 +25,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 require_yq || exit 1
 
@@ -44,30 +46,22 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Apply the personal profile from SOURCE_DIR into a throwaway home and print
-# the path to the rendered ~/.claude/settings.json. Returns non-zero on a
-# failed apply.
-render_personal_settings() {
-  local source_dir="$1" root
-  root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings.XXXXXX")"
-  tmp_roots+=("$root")
-  mkdir -p "$root/home"
-  printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
-  if ! chezmoi --config "$root/chezmoi.toml" \
-      --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1; then
-    return 1
-  fi
-  printf '%s\n' "$root/home/.claude/settings.json"
-}
+# Renders use render_personal_into (test-lib.sh): the caller mktemps the
+# root and registers it in tmp_roots, then reads the rendered
+# ~/.claude/settings.json out of ROOT/home (caller-creates-root contract;
+# see the #150 leak note in test-lib.sh).
 
 section "claude settings sandbox content"
 
 # 1) Committed default: enforceAiSandbox=false -> no sandbox block, and the
 #    file is still valid JSON (the conditional must not corrupt it).
-if ! off_file="$(render_personal_settings "$DOTFILES_ROOT")"; then
+off_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings.XXXXXX")"
+tmp_roots+=("$off_root")
+if ! render_personal_into "$DOTFILES_ROOT" "$off_root"; then
   fail "test failed: personal apply (default) did not render"
   exit 1
 fi
+off_file="$off_root/home/.claude/settings.json"
 if ! yq -p json '.' "$off_file" >/dev/null 2>&1; then
   fail "test failed: default settings.json is not valid JSON"
   status=1
@@ -83,15 +77,16 @@ fi
 #    default stays false.
 src_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings-src.XXXXXX")"
 tmp_roots+=("$src_root")
-cp -R "$DOTFILES_ROOT" "$src_root/src"
-rm -rf "$src_root/src/.git"
-yq -i '.profiles.personal.capabilities.enforceAiSandbox = true' \
-  "$src_root/src/.chezmoidata/profiles.yaml"
+make_flipped_source "$src_root"
+flip_personal_capability "$src_root/src" enforceAiSandbox true
 
-if ! on_file="$(render_personal_settings "$src_root/src")"; then
+on_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings.XXXXXX")"
+tmp_roots+=("$on_root")
+if ! render_personal_into "$src_root/src" "$on_root"; then
   fail "test failed: personal apply (enforceAiSandbox=true) did not render"
   exit 1
 fi
+on_file="$on_root/home/.claude/settings.json"
 if ! yq -p json '.' "$on_file" >/dev/null 2>&1; then
   fail "test failed: enabled settings.json is not valid JSON"
   status=1
@@ -189,14 +184,15 @@ fi
 #    throwaway copy so the committed default stays false.
 mcp_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings-mcp.XXXXXX")"
 tmp_roots+=("$mcp_src")
-cp -R "$DOTFILES_ROOT" "$mcp_src/src"
-rm -rf "$mcp_src/src/.git"
-yq -i '.profiles.personal.capabilities.gateGitHubMcp = true' \
-  "$mcp_src/src/.chezmoidata/profiles.yaml"
-if ! mcp_file="$(render_personal_settings "$mcp_src/src")"; then
+make_flipped_source "$mcp_src"
+flip_personal_capability "$mcp_src/src" gateGitHubMcp true
+mcp_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings.XXXXXX")"
+tmp_roots+=("$mcp_root")
+if ! render_personal_into "$mcp_src/src" "$mcp_root"; then
   fail "test failed: personal apply (gateGitHubMcp=true) did not render"
   exit 1
 fi
+mcp_file="$mcp_root/home/.claude/settings.json"
 # Valid JSON (comma regression guard for the conditional deny block) + the bare
 # server-name deny (mcp__github covers all tools; mcp__github__* is redundant).
 if yq -p json '.' "$mcp_file" >/dev/null 2>&1 \
@@ -211,14 +207,16 @@ fi
 #     (catches a comma regression when several conditional keys are present).
 both_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings-both.XXXXXX")"
 tmp_roots+=("$both_src")
-cp -R "$DOTFILES_ROOT" "$both_src/src"
-rm -rf "$both_src/src/.git"
-yq -i '.profiles.personal.capabilities.gateGitHubMcp = true | .profiles.personal.capabilities.enforceAiSandbox = true' \
-  "$both_src/src/.chezmoidata/profiles.yaml"
-if ! both_file="$(render_personal_settings "$both_src/src")"; then
+make_flipped_source "$both_src"
+flip_personal_capability "$both_src/src" gateGitHubMcp true
+flip_personal_capability "$both_src/src" enforceAiSandbox true
+both_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings.XXXXXX")"
+tmp_roots+=("$both_root")
+if ! render_personal_into "$both_src/src" "$both_root"; then
   fail "test failed: personal apply (both gates true) did not render"
   exit 1
 fi
+both_file="$both_root/home/.claude/settings.json"
 if yq -p json '.' "$both_file" >/dev/null 2>&1 \
   && grep -Fq '"mcp__github"' "$both_file" \
   && grep -Fq '"Bash(git push * main)"' "$both_file"; then
@@ -291,14 +289,15 @@ fi
 #     spirit as the deny test, without a fixture that drifts).
 reader_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings-reader.XXXXXX")"
 tmp_roots+=("$reader_src")
-cp -R "$DOTFILES_ROOT" "$reader_src/src"
-rm -rf "$reader_src/src/.git"
-yq -i '.profiles.personal.capabilities.enableGitHubIsolatedReader = false' \
-  "$reader_src/src/.chezmoidata/profiles.yaml"
-if ! reader_off_file="$(render_personal_settings "$reader_src/src")"; then
+make_flipped_source "$reader_src"
+flip_personal_capability "$reader_src/src" enableGitHubIsolatedReader false
+reader_off_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-claude-settings.XXXXXX")"
+tmp_roots+=("$reader_off_root")
+if ! render_personal_into "$reader_src/src" "$reader_off_root"; then
   fail "test failed: personal apply (enableGitHubIsolatedReader=false) did not render"
   exit 1
 fi
+reader_off_file="$reader_off_root/home/.claude/settings.json"
 on_minus_hooks="$(yq -p json -o json 'del(.hooks)' "$off_file")"
 reader_off_norm="$(yq -p json -o json '.' "$reader_off_file")"
 if [[ "$(yq -p json '.hooks // "absent"' "$reader_off_file")" == "absent" ]] \

--- a/scripts/test-codex-settings.sh
+++ b/scripts/test-codex-settings.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 require_yq || exit 1
 
@@ -43,21 +45,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Apply the personal profile from SOURCE_DIR into a throwaway home and print the
-# path to that home (so callers can inspect the presence/absence of files).
-# Returns non-zero on a failed apply.
-render_personal_home() {
-  local source_dir="$1" root
-  root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings.XXXXXX")"
-  tmp_roots+=("$root")
-  mkdir -p "$root/home"
-  printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
-  if ! chezmoi --config "$root/chezmoi.toml" \
-      --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1; then
-    return 1
-  fi
-  printf '%s\n' "$root/home"
-}
+# Renders use render_personal_into (test-lib.sh): the caller mktemps the
+# root and registers it in tmp_roots, then inspects ROOT/home
+# (caller-creates-root contract; see the #150 leak note in test-lib.sh).
 
 section "codex settings PreToolUse hook registration (#181)"
 
@@ -68,10 +58,13 @@ section "codex settings PreToolUse hook registration (#181)"
 #    (event count, matcher, hook count, type, command, timeout), not just "a hook
 #    exists": this is security wiring, so a swapped matcher / extra event / wrong
 #    path must fail the test.
-if ! home="$(render_personal_home "$DOTFILES_ROOT")"; then
+home_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings.XXXXXX")"
+tmp_roots+=("$home_root")
+if ! render_personal_into "$DOTFILES_ROOT" "$home_root"; then
   fail "test failed: personal apply (default) did not render"
   exit 1
 fi
+home="$home_root/home"
 hooks_file="$home/.codex/hooks.json"
 expected_hook_cmd="$HOME/.codex/agent-tools/scripts/personal-safe-gh-hook"
 if [[ ! -f "$hooks_file" ]]; then
@@ -129,10 +122,8 @@ fi
 #    template self-gate renders empty and chezmoi prunes the managed target).
 off_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-off-src.XXXXXX")"
 tmp_roots+=("$off_src")
-cp -R "$DOTFILES_ROOT" "$off_src/src"
-rm -rf "$off_src/src/.git"
-yq -i '.profiles.personal.capabilities.enableGitHubIsolatedReader = false' \
-  "$off_src/src/.chezmoidata/profiles.yaml"
+make_flipped_source "$off_src"
+flip_personal_capability "$off_src/src" enableGitHubIsolatedReader false
 
 removal_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-removal.XXXXXX")"
 tmp_roots+=("$removal_root")
@@ -185,10 +176,8 @@ fi
 #        removal, same lingering scenario as case 3) while hooks.json survives.
 ai_off_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-aioff.XXXXXX")"
 tmp_roots+=("$ai_off_src")
-cp -R "$DOTFILES_ROOT" "$ai_off_src/src"
-rm -rf "$ai_off_src/src/.git"
-yq -i '.profiles.personal.capabilities.enableAiPolicy = false' \
-  "$ai_off_src/src/.chezmoidata/profiles.yaml"
+make_flipped_source "$ai_off_src"
+flip_personal_capability "$ai_off_src/src" enableAiPolicy false
 rules_removal_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-codex-settings-rulesrm.XXXXXX")"
 tmp_roots+=("$rules_removal_root")
 mkdir -p "$rules_removal_root/home"

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -17,6 +17,38 @@ source "$SCRIPT_DIR/test-lib.sh"
 # here; the AT-override case re-sets it explicitly for its own invocation.
 unset AGENT_TOOLS
 
+# write_root_pinned_status_sh DEST JSON_PAYLOAD
+# Write a fake agent-tools status.sh at DEST that models the status
+# contract: accept `--root DIR` and `--json` in any order, and assert the
+# caller pins the inspection root to the checkout DEST lives in, not its
+# own cwd (#73; the AGENT_TOOLS-override case regresses #71 the same way).
+# status.sh defaults its root to cwd, so a doctor that omits --root would
+# inspect the wrong dir; exit non-zero on a wrong/missing root to regress
+# that loudly. Touches ../ran-marker so tests can prove it ran, then
+# prints JSON_PAYLOAD verbatim (one line + newline).
+write_root_pinned_status_sh() {
+  local dest="$1" payload="$2"
+  cat > "$dest" <<'SH'
+#!/bin/sh
+root=""; json=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root) root="$2"; shift 2 ;;
+    --json) json=1; shift ;;
+    *) shift ;;
+  esac
+done
+[ "$json" = 1 ] || exit 1
+[ -n "$root" ] || exit 3
+root="$(CDPATH= cd -- "$root" 2>/dev/null && pwd)" || exit 3
+expected="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+[ "$root" = "$expected" ] || exit 3
+: > "$(dirname "$0")/../ran-marker"
+SH
+  printf '%s\n' "cat <<'JSON'" "$payload" "JSON" >> "$dest"
+  chmod +x "$dest"
+}
+
 status=0
 fixture_home="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-doctor-test.XXXXXX")"
 trap 'rm -rf "$fixture_home"' EXIT
@@ -112,39 +144,15 @@ agent_dir="$fixture_home/src/agent/agent-tools"
 agent_scripts="$agent_dir/scripts"
 agent_marker="$agent_dir/ran-marker"
 mkdir -p "$agent_scripts"
-cat > "$agent_scripts/status.sh" <<'SH'
-#!/bin/sh
-# Model the status contract: accept `--root DIR` and `--json` in any order, and
-# assert doctor pins the inspection root to this checkout, not its own cwd (#73).
-# status.sh defaults its root to cwd, so a doctor that omits --root would inspect
-# the wrong dir; exit non-zero on a wrong/missing root to regress that loudly.
-root=""; json=0
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --root) root="$2"; shift 2 ;;
-    --json) json=1; shift ;;
-    *) shift ;;
-  esac
-done
-[ "$json" = 1 ] || exit 1
-[ -n "$root" ] || exit 3
-root="$(CDPATH= cd -- "$root" 2>/dev/null && pwd)" || exit 3
-expected="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-[ "$root" = "$expected" ] || exit 3
-: > "$(dirname "$0")/../ran-marker"
-cat <<'JSON'
-{"contract_version":2,"repo":{"present":true,"clean":true},"assets":{"total":1,"manifest_errors":0},"checks":{"manifest_validation":"pass","prompt_injection_static":"pass"},"generated":{"total":1,"stale":0},"register":{"catalog_present":true,"registered":1,"human_review_required":0,"unsupported":0},"sync_targets":[{"tool":"codex","name":"x","state":"conflict"}]}
-JSON
-SH
-chmod +x "$agent_scripts/status.sh"
+# Root-pinning fake (see write_root_pinned_status_sh): regression for #73.
+write_root_pinned_status_sh "$agent_scripts/status.sh" \
+  '{"contract_version":2,"repo":{"present":true,"clean":true},"assets":{"total":1,"manifest_errors":0},"checks":{"manifest_validation":"pass","prompt_injection_static":"pass"},"generated":{"total":1,"stale":0},"register":{"catalog_present":true,"registered":1,"human_review_required":0,"unsupported":0},"sync_targets":[{"tool":"codex","name":"x","state":"conflict"}]}'
 
 # A) Opt-in disabled: present but status.sh must not run. Force the capability
 #    off in a throwaway copy so the test is independent of the real default
 #    (personal opts in by default since #73), mirroring the opt-in copy below.
 optout_root="$fixture_home/.dotfiles-optout"
-mkdir -p "$optout_root/.chezmoidata"
-cp -R "$DOTFILES_ROOT/scripts" "$optout_root/scripts"
-cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$optout_root/.chezmoidata/"
+copy_repo_fixture "$optout_root"
 set_capability_all "$optout_root" enableAgentToolsStatus false
 rm -f "$agent_marker"
 if at_out="$(HOME="$fixture_home" "$optout_root/scripts/doctor.sh" personal 2>&1)"; then
@@ -164,9 +172,7 @@ fi
 # Throwaway repo copy with the opt-in enabled for every profile, so the
 # test does not depend on which profile comes first.
 optin_root="$fixture_home/.dotfiles-optin"
-mkdir -p "$optin_root/.chezmoidata"
-cp -R "$DOTFILES_ROOT/scripts" "$optin_root/scripts"
-cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$optin_root/.chezmoidata/"
+copy_repo_fixture "$optin_root"
 set_capability_all "$optin_root" enableAgentToolsStatus true
 
 # B) Opt-in enabled: status.sh runs, summary shown, conflict flagged.
@@ -284,29 +290,10 @@ override_dir="$fixture_home/custom/agent-tools"
 override_scripts="$override_dir/scripts"
 override_marker="$override_dir/ran-marker"
 mkdir -p "$override_scripts"
-cat > "$override_scripts/status.sh" <<'SH'
-#!/bin/sh
 # Same root-pinning contract as the default-path fake: doctor must pass
 # --root equal to the AGENT_TOOLS-overridden checkout (#71 + #73).
-root=""; json=0
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --root) root="$2"; shift 2 ;;
-    --json) json=1; shift ;;
-    *) shift ;;
-  esac
-done
-[ "$json" = 1 ] || exit 1
-[ -n "$root" ] || exit 3
-root="$(CDPATH= cd -- "$root" 2>/dev/null && pwd)" || exit 3
-expected="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-[ "$root" = "$expected" ] || exit 3
-: > "$(dirname "$0")/../ran-marker"
-cat <<'JSON'
-{"contract_version":2,"repo":{"present":true,"clean":true},"assets":{"total":0,"manifest_errors":0},"checks":{"manifest_validation":"pass","prompt_injection_static":"pass"},"generated":{"total":0,"stale":0},"register":{"catalog_present":false,"registered":0,"human_review_required":0,"unsupported":0},"sync_targets":[]}
-JSON
-SH
-chmod +x "$override_scripts/status.sh"
+write_root_pinned_status_sh "$override_scripts/status.sh" \
+  '{"contract_version":2,"repo":{"present":true,"clean":true},"assets":{"total":0,"manifest_errors":0},"checks":{"manifest_validation":"pass","prompt_injection_static":"pass"},"generated":{"total":0,"stale":0},"register":{"catalog_present":false,"registered":0,"human_review_required":0,"unsupported":0},"sync_targets":[]}'
 rm -f "$override_marker"
 if at_out="$(HOME="$fixture_home" AGENT_TOOLS="$override_dir" "$optin_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "agent-tools present; status contract v2" <<< "$at_out" && [[ -e "$override_marker" ]]; then
@@ -424,9 +411,7 @@ fi
 # git-signing module inactive) cases. Throwaway repo copy so the edits do not
 # touch the real data files.
 sign_root="$fixture_home/.dotfiles-signing"
-mkdir -p "$sign_root/.chezmoidata"
-cp -R "$DOTFILES_ROOT/scripts" "$sign_root/scripts"
-cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$sign_root/.chezmoidata/"
+copy_repo_fixture "$sign_root"
 
 # L) enableGitSigning=true with the git-signing module active -> managed mechanism.
 set_capability_all "$sign_root" enableGitSigning true
@@ -466,9 +451,7 @@ fi
 # (capability true but ssh-1password module inactive) cases. Throwaway repo
 # copy so the edits do not touch the real data files.
 ssh_root="$fixture_home/.dotfiles-ssh"
-mkdir -p "$ssh_root/.chezmoidata"
-cp -R "$DOTFILES_ROOT/scripts" "$ssh_root/scripts"
-cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$ssh_root/.chezmoidata/"
+copy_repo_fixture "$ssh_root"
 
 # N) enable1PasswordSSH=true with the ssh-1password module active -> managed agent.
 #    personal's committed default is true + module present, so no mutation needed.
@@ -511,9 +494,7 @@ fi
 # fail-open no-op warn). doctor stays exit 0 (no dead capability).
 # Throwaway repo copy so the flip does not touch the real data files.
 gh_root="$fixture_home/.dotfiles-ghguard"
-mkdir -p "$gh_root/.chezmoidata"
-cp -R "$DOTFILES_ROOT/scripts" "$gh_root/scripts"
-cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$gh_root/.chezmoidata/"
+copy_repo_fixture "$gh_root"
 
 # P) committed personal: gateGitHubMcp AND enableGitHubIsolatedReader are ON
 #    (Phase 2 / #137) and claude-settings is active, so doctor reports the
@@ -892,9 +873,7 @@ fi
 # with a corepack on PATH reports its version line (fake for determinism —
 # the CI validate job may or may not ship corepack) (#150).
 cp_root="$fixture_home/.dotfiles-corepack"
-mkdir -p "$cp_root/.chezmoidata"
-cp -R "$DOTFILES_ROOT/scripts" "$cp_root/scripts"
-cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$cp_root/.chezmoidata/"
+copy_repo_fixture "$cp_root"
 set_capability_all "$cp_root" corepackMode off
 if cp_out="$(HOME="$fixture_home" "$cp_root/scripts/doctor.sh" personal 2>&1)"; then
   if grep -Fq "corepack intentionally unmanaged" <<< "$cp_out"; then

--- a/scripts/test-git-signing.sh
+++ b/scripts/test-git-signing.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 require_yq || exit 1
 
@@ -33,20 +35,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Apply the personal profile from SOURCE_DIR into a throwaway home and print the
-# home path. Returns non-zero on a failed apply.
-apply_personal() {
-  local source_dir="$1" root
-  root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing.XXXXXX")"
-  tmp_roots+=("$root")
-  mkdir -p "$root/home"
-  printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
-  if ! chezmoi --config "$root/chezmoi.toml" \
-      --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1; then
-    return 1
-  fi
-  printf '%s\n' "$root/home"
-}
+# Renders use render_personal_into (test-lib.sh): the caller mktemps the
+# root and registers it in tmp_roots, then inspects ROOT/home
+# (caller-creates-root contract; see the #150 leak note in test-lib.sh).
 
 section "git-signing gating"
 
@@ -54,14 +45,15 @@ section "git-signing gating"
 #    a copy so the test is independent of the committed default.
 off_src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing-off.XXXXXX")"
 tmp_roots+=("$off_src")
-cp -R "$DOTFILES_ROOT" "$off_src/src"
-rm -rf "$off_src/src/.git"
-yq -i '.profiles.personal.capabilities.enableGitSigning = false' \
-  "$off_src/src/.chezmoidata/profiles.yaml"
-if ! off_home="$(apply_personal "$off_src/src")"; then
+make_flipped_source "$off_src"
+flip_personal_capability "$off_src/src" enableGitSigning false
+off_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing.XXXXXX")"
+tmp_roots+=("$off_root")
+if ! render_personal_into "$off_src/src" "$off_root"; then
   fail "test failed: personal apply (enableGitSigning=false) did not render"
   exit 1
 fi
+off_home="$off_root/home"
 if [[ -e "$off_home/.config/git/signing.gitconfig" ]]; then
   fail "test failed: signing.gitconfig applied while enableGitSigning=false"
   status=1
@@ -72,15 +64,16 @@ fi
 # 2) enableGitSigning=true: signing.gitconfig is applied with the SSH mechanism.
 src="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing-src.XXXXXX")"
 tmp_roots+=("$src")
-cp -R "$DOTFILES_ROOT" "$src/src"
-rm -rf "$src/src/.git"
-yq -i '.profiles.personal.capabilities.enableGitSigning = true' \
-  "$src/src/.chezmoidata/profiles.yaml"
+make_flipped_source "$src"
+flip_personal_capability "$src/src" enableGitSigning true
 
-if ! on_home="$(apply_personal "$src/src")"; then
+on_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-git-signing.XXXXXX")"
+tmp_roots+=("$on_root")
+if ! render_personal_into "$src/src" "$on_root"; then
   fail "test failed: personal apply (enableGitSigning=true) did not render"
   exit 1
 fi
+on_home="$on_root/home"
 f="$on_home/.config/git/signing.gitconfig"
 if [[ ! -f "$f" ]]; then
   fail "test failed: signing.gitconfig not applied while enableGitSigning=true"

--- a/scripts/test-lib.sh
+++ b/scripts/test-lib.sh
@@ -62,3 +62,56 @@ remove_module_all() {
   fi
   M="$module" yq -i 'del(.profiles[].modules[] | select(. == strenv(M)))' "$file"
 }
+
+# render_personal_into SOURCE_DIR ROOT
+# Apply the personal profile from SOURCE_DIR into ROOT/home (writes
+# ROOT/chezmoi.toml; requires chezmoi — render tests check for it upfront).
+# ROOT is created by the CALLER and registered in tmp_roots there: a helper
+# that mktemps and returns via command substitution would append to
+# tmp_roots only inside the substitution subshell, so the cleanup trap
+# would never see it and the render roots would leak (Codex review, #150).
+render_personal_into() {
+  local source_dir="$1" root="$2"
+  mkdir -p "$root/home"
+  printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
+  chezmoi --config "$root/chezmoi.toml" \
+    --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1
+}
+
+# make_flipped_source DEST_PARENT
+# Copy the committed source into DEST_PARENT/src (dropping .git) so a test
+# can flip capabilities without touching the real data files. DEST_PARENT
+# is created and registered for cleanup by the caller. Call as a plain
+# statement, never inside $(...) (the subshell would hide caller-side
+# cleanup registration — same trap as render_personal_into).
+make_flipped_source() {
+  local dest_parent="$1"
+  cp -R "$DOTFILES_ROOT" "$dest_parent/src"
+  rm -rf "$dest_parent/src/.git"
+}
+
+# flip_personal_capability SRC CAP VALUE
+# Set CAP to VALUE for the personal profile only, in
+# SRC/.chezmoidata/profiles.yaml (SRC is a make_flipped_source copy).
+# Boolean capabilities only: env(V) parses true/false into booleans; an
+# enum-valued capability would need strenv. Personal-only on purpose —
+# set_capability_all (above) is the all-profile, fail-closed variant with
+# a different contract (test-policy.sh pins that contract).
+flip_personal_capability() {
+  local src="$1" cap="$2" value="$3"
+  C="$cap" V="$value" yq -i \
+    '.profiles.personal.capabilities[strenv(C)] = env(V)' \
+    "$src/.chezmoidata/profiles.yaml"
+}
+
+# copy_repo_fixture DEST
+# Minimal repo-copy fixture: scripts/ plus the .chezmoidata data files —
+# just enough for doctor / preflight / validate-policy to run against
+# DEST. mktemp, cleanup registration, and any per-case fixture mutation
+# (capability flips, extra files) stay with the caller. No output.
+copy_repo_fixture() {
+  local dest="$1"
+  mkdir -p "$dest/.chezmoidata"
+  cp -R "$DOTFILES_ROOT/scripts" "$dest/scripts"
+  cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$dest/.chezmoidata/"
+}

--- a/scripts/test-npmrc.sh
+++ b/scripts/test-npmrc.sh
@@ -176,18 +176,8 @@ else
   }
   trap cleanup EXIT
 
-  # Apply personal from SOURCE_DIR into ROOT/home. ROOT is created by the
-  # CALLER and registered in tmp_roots there: a helper that mktemps and
-  # returns via command substitution would append to tmp_roots only inside
-  # the substitution subshell, so the cleanup trap would never see it and
-  # the render roots would leak (Codex review, #150).
-  render_personal_into() {
-    local source_dir="$1" root="$2"
-    mkdir -p "$root/home"
-    printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
-    chezmoi --config "$root/chezmoi.toml" \
-      --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1
-  }
+  # render_personal_into comes from test-lib.sh (caller-creates-root
+  # contract; see the #150 leak note there).
 
   # enforce (personal default): every hardening line renders, tokens never do.
   enforce_root="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-npmrc-render.XXXXXX")"

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -23,9 +23,7 @@ trap cleanup EXIT
 make_fixture() {
   fixture="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-policy-test.XXXXXX")"
   tmp_roots+=("$fixture")
-  mkdir -p "$fixture/.chezmoidata"
-  cp -R "$DOTFILES_ROOT/scripts" "$fixture/scripts"
-  cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$fixture/.chezmoidata/"
+  copy_repo_fixture "$fixture"
 }
 
 insert_once() {

--- a/scripts/test-preflight.sh
+++ b/scripts/test-preflight.sh
@@ -135,9 +135,7 @@ fi
 #    profiles.yaml in a repo copy — the mutation is fail-closed because the
 #    exit-1 assertion itself would fail on a no-op).
 broken_root="$fixture_home/broken"
-mkdir -p "$broken_root/.chezmoidata"
-cp -R "$DOTFILES_ROOT/scripts" "$broken_root/scripts"
-cp "$DOTFILES_ROOT/.chezmoidata/"*.yaml "$broken_root/.chezmoidata/"
+copy_repo_fixture "$broken_root"
 printf 'profiles: {}\n' > "$broken_root/.chezmoidata/profiles.yaml"
 if HOME="$empty_home" "$broken_root/scripts/preflight.sh" personal >/dev/null 2>&1; then
   miss "preflight must exit non-zero when policy validation fails"

--- a/scripts/test-ssh.sh
+++ b/scripts/test-ssh.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 require_yq || exit 1
 
@@ -33,15 +35,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Apply the personal profile from $1 into a fresh home under root $2, and echo
-# the rendered home path. Each call gets its own root (config + home) under base.
-apply_personal() {
-  local source_dir="$1" root="$2"
-  mkdir -p "$root/home"
-  printf '[data]\nprofile = "personal"\n' > "$root/chezmoi.toml"
-  chezmoi --config "$root/chezmoi.toml" \
-    --source "$source_dir" --destination "$root/home" apply >/dev/null 2>&1
-}
+# Renders use render_personal_into (test-lib.sh): each call gets its own
+# root (config + home) under base, which the single trap cleans up.
 
 section "ssh-1password gating"
 
@@ -49,7 +44,7 @@ section "ssh-1password gating"
 #    github.com (scoped) and the local Include. personal's committed default is
 #    true, so render from the real source.
 on_root="$base/on"
-if ! apply_personal "$DOTFILES_ROOT" "$on_root"; then
+if ! render_personal_into "$DOTFILES_ROOT" "$on_root"; then
   fail "test failed: personal apply (enable1PasswordSSH=true) did not render"
   exit 1
 fi
@@ -70,13 +65,12 @@ fi
 # 2) enable1PasswordSSH=false: the config is still applied (module membership),
 #    but the agent setting is NOT emitted; the Include escape hatch remains.
 #    Force the value in a copy so the test is independent of the committed default.
-off_src="$base/off-src"
-cp -R "$DOTFILES_ROOT" "$off_src"
-rm -rf "$off_src/.git"
-yq -i '.profiles.personal.capabilities.enable1PasswordSSH = false' \
-  "$off_src/.chezmoidata/profiles.yaml"
+off_fixture="$base/off-fixture"
+mkdir -p "$off_fixture"
+make_flipped_source "$off_fixture"
+flip_personal_capability "$off_fixture/src" enable1PasswordSSH false
 off_root="$base/off"
-if ! apply_personal "$off_src" "$off_root"; then
+if ! render_personal_into "$off_fixture/src" "$off_root"; then
   fail "test failed: personal apply (enable1PasswordSSH=false) did not render"
   exit 1
 fi


### PR DESCRIPTION
Refs #189(全体リファクタリング・挙動不変)の PR-2/4。ultracode 監査の CONFIRMED 所見のうちテスト基盤系 4 件を実施する。テストの assert 対象・出力・exit code は不変。

## 変更内容

1. **`render_personal_into SOURCE_DIR ROOT` を test-lib.sh へ集約**(6 本に複製されていた throwaway chezmoi apply ヘルパ)
   - caller-creates-root 契約(#150)に統一。**副次効果として実バグ修正**: test-claude-settings / test-codex-settings / test-git-signing の 3 本は `x="$(helper)"` の command substitution 内で `tmp_roots+=` していたため cleanup trap から漏れ、実行のたびに render root が TMPDIR に残っていた(#150 と同一欠陥のコピー残存)。pass/fail には無影響。
2. **`make_flipped_source` / `flip_personal_capability` を追加**し、「source 丸ごと copy + .git 除去 + personal 限定 capability flip」fixture ×9 を置換
   - `yq` の `env(V)` 代入が現行リテラル式と profiles.yaml byte-identical であることは監査の検証フェーズで実測済み(true / false / 複合 flip の 3 ケース)。boolean 専用と明記。**all-profile 版 `set_capability_all` とは統合しない**(fail-closed guard 込みの別契約で、test-policy.sh がその契約自体を pin している)。
3. **`copy_repo_fixture DEST` を追加**し、「scripts + .chezmoidata/*.yaml の最小 repo copy」fixture ×8 を置換(機械置換でちょうど 8 hit を確認)。test-policy の `make_fixture` は名前・グローバル変数・cleanup 登録の契約を維持した thin wrapper に。
4. **test-doctor.sh の root-pinning 契約付き fake status.sh ×2 を `write_root_pinned_status_sh DEST JSON` に集約**(payload は逐語移送・`printf '%s\n'` で quoted heredoc 内へ挿入・#73/#71 の regression 説明は helper と call site のコメントに保持)

## 挙動不変の検証(実施済み)

- `bash -n` / `shellcheck -S warning`: 完全 clean
- **全テスト suite green**(16 本)
- **旧新出力の byte 比較**: 影響 8 suite(claude/codex/git-signing/ssh/npmrc/doctor/preflight/policy)を main worktree と本 branch で実行し、**rc + stdout + stderr が yq WARN 行のタイムスタンプ正規化後に全 suite byte-identical**
- **leak 修正の実証**: 新コードは 1 実行で TMPDIR への render root 追加ゼロ / 旧コード(main)は同一実行で render root が残留することを実測
- render 出力: scripts/ のみの変更で managed target に構造的に無関係(baseline diff も PR-1 で確立済みの手順で確認)

## レビュー観点(お願いしたいこと)

- caller-creates-root への書き換え 3 ファイルで、root の生存期間(後続 assert が `$home` 等を参照)が EXIT まで維持されているか
- `flip_personal_capability` の yq 式(`env(V)`)が boolean flip でリテラル式と等価であること
- `write_root_pinned_status_sh` が生成する status.sh の実行意味(exit 1/3・ran-marker・JSON 1 行)が旧 heredoc と同一か
- fixture 置換(×8 / ×9)の取りこぼし・過剰置換がないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qw8BkUDu5WdwhYfiFFX5n
