### PR TITLE
refactor: template 層の集約 — require-profile guard 統一 + safe-gh hook JSON の partial 化 (PR-4/4, Refs #189)

### DIFF
--- a/.chezmoitemplates/safe-gh-hook-json
+++ b/.chezmoitemplates/safe-gh-hook-json
@@ -1,0 +1,26 @@
+{{- /* Shared safe-gh PreToolUse hook JSON — the #137 (Claude) / #181 (Codex)
+       parity pair, kept in one place so the two registrations cannot drift
+       apart (fixing one side and forgetting the other was the standing
+       hazard). dict args: homeDir (.chezmoi.homeDir), agentDir (".claude" or
+       ".codex"), optional timeout (number; Codex only today). Renders the
+       "hooks" object at two-space indent with NO trailing comma and NO
+       trailing newline — the caller owns both (Claude appends ",", Codex a
+       bare newline), which keeps the include byte-identical to the inline
+       block it replaced. */ -}}
+{{ "" }}  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "{{ .homeDir }}/{{ .agentDir }}/agent-tools/scripts/personal-safe-gh-hook"
+{{- if hasKey . "timeout" }},
+            "timeout": {{ .timeout }}
+{{- end }}
+          }
+        ]
+      }
+    ]
+  }
+{{- /* no trailing newline: see the header comment */ -}}

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -1,4 +1,5 @@
-{{- $caps := index (index .profiles .profile) "capabilities" -}}
+{{- template "require-profile" . -}}
+{{- $caps := index .profiles .profile "capabilities" -}}
 {{- /* GitHub injection guard (epic #119). Best-effort / steering only:
        command-string matchers are bypassable ($(), equivalent read paths like
        xxd / python open(), MCP by other means, subagent gaps) and are NOT an
@@ -36,7 +37,9 @@
        isolated reader. Steering / fail-open: a missing body (exit 127), any
        non-2 non-zero exit, bad JSON, or a timeout all let the tool call
        continue (only exit 2 blocks), so registering before agent-tools has
-       synced is a safe no-op. This is NOT the context-gated write hook above. */ -}}
+       synced is a safe no-op. This is NOT the context-gated write hook above.
+       The JSON body is shared with the Codex registration via
+       .chezmoitemplates/safe-gh-hook-json (#181 parity — edit it once there). */ -}}
 {{- $deny := list "Read(~/.ssh/**)" "Read(~/.aws/**)" "Read(~/.config/gh/**)" "Read(~/.netrc)" "Read(~/.codex/auth.json)" "Bash(cat ~/.ssh/*)" "Bash(gh secret *)" "Bash(gh api *secrets*)" "Bash(env)" "Bash(env *)" "Bash(printenv)" "Bash(printenv *)" -}}
 {{- if index $caps "gateGitHubMcp" -}}{{- $deny = concat $deny (list "mcp__github") -}}{{- end -}}
 {{- $ask := list -}}
@@ -64,19 +67,7 @@
     ]
   },
 {{- if index $caps "enableGitHubIsolatedReader" }}
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "{{ .chezmoi.homeDir }}/.claude/agent-tools/scripts/personal-safe-gh-hook"
-          }
-        ]
-      }
-    ]
-  },
+{{ template "safe-gh-hook-json" (dict "homeDir" .chezmoi.homeDir "agentDir" ".claude") }},
 {{- end }}
   "model": "opus[1m]",
   "statusLine": {

--- a/dot_codex/hooks.json.tmpl
+++ b/dot_codex/hooks.json.tmpl
@@ -1,4 +1,5 @@
-{{- $caps := index (index .profiles .profile) "capabilities" -}}
+{{- template "require-profile" . -}}
+{{- $caps := index .profiles .profile "capabilities" -}}
 {{- /* Codex parity of the Claude PreToolUse hook registration (#181, the
        Codex side of #137). Same GitHub injection guard (epic #119), same
        capability: enableGitHubIsolatedReader registers the safe-gh read-steering
@@ -16,7 +17,10 @@
        (personal-safe-gh-hook) is deployed by agent-tools to a stable path
        (agent-tools#146 contract); dotfiles only references it by absolute path —
        no script body is distributed from here. The schema under "hooks" is
-       identical to Claude Code's (PreToolUse -> matcher -> command hooks).
+       identical to Claude Code's (PreToolUse -> matcher -> command hooks); the
+       JSON body is shared with the Claude registration via
+       .chezmoitemplates/safe-gh-hook-json (#137/#181 parity — edit it once
+       there).
 
        Rendered JSON is the MINIMAL {"hooks": {...}} — no top-level "description"
        or any other key. Codex 0.142.5 rejects unknown top-level keys in
@@ -47,19 +51,6 @@
        the next apply (Codex review #184; verified in test-codex-settings.sh). */ -}}
 {{- if index $caps "enableGitHubIsolatedReader" -}}
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "{{ .chezmoi.homeDir }}/.codex/agent-tools/scripts/personal-safe-gh-hook",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
-  }
+{{ template "safe-gh-hook-json" (dict "homeDir" .chezmoi.homeDir "agentDir" ".codex" "timeout" 10) }}
 }
 {{ end -}}

--- a/dot_codex/rules/default.rules.tmpl
+++ b/dot_codex/rules/default.rules.tmpl
@@ -1,4 +1,5 @@
-{{- $caps := index (index .profiles .profile) "capabilities" -}}
+{{- template "require-profile" . -}}
+{{- $caps := index .profiles .profile "capabilities" -}}
 {{- /* Codex approval-rules baseline (#139). The canonical, vetted allowlist for
        Codex's command-approval rules: READ-ONLY subcommands and local-only git
        operations. Nothing here may auto-allow an outward action (push, PR/issue

--- a/private_dot_ssh/config.tmpl
+++ b/private_dot_ssh/config.tmpl
@@ -4,6 +4,7 @@
 # managed blocks win (ssh_config is first-match-wins = managed-wins). The local
 # file may only ADD hosts this file does not define. See docs/ssh.md and
 # docs/local-overrides.md.
+{{ template "require-profile" . -}}
 {{ $caps := index .profiles .profile "capabilities" -}}
 {{ if $caps.enable1PasswordSSH -}}
 


### PR DESCRIPTION
Refs #189 の PR-4/4(最終)。ultracode 監査 CONFIRMED 所見(template ×2)。

## 変更内容(render byte-identical)

1. **capability-lookup 前文の統一**
   - 二重 index 綴り(`index (index .profiles .profile) "capabilities"`)を単一 index に正規化(dot_claude/settings.json.tmpl / dot_codex/hooks.json.tmpl / dot_codex/rules/default.rules.tmpl)
   - guard 無しだった 4 template の先頭に `require-profile` include を追加(unknown profile 時の nil-index panic → 可読 fail。到達可能なのは template 単独評価時のみで、通常経路は .chezmoiignore の require-profile が先に fail するため実挙動不変)
   - **trim marker の要注意点**: private_dot_ssh/config.tmpl のみ `{{ template ... -}}`(左 trim 無し)。直前がリテラルのコメント行で、`{{-` だと直前の改行を食って 1 byte 変わる(監査の検証フェーズで実在確認済みの落とし穴)
2. **safe-gh PreToolUse hook JSON の partial 化**(`.chezmoitemplates/safe-gh-hook-json`)
   - #137(Claude)/#181(Codex)の parity 対で今後も同期変更される block を単一 source に。差分 3 点(agentDir / timeout / 末尾カンマ)は dict 引数 + caller 所有で表現
   - partial は**末尾改行なし・末尾カンマなし**で出力(末尾の trim comment が要。無いと include が改行を足して render が 2 byte 変わる — これも監査で実在確認済み)
   - #185(hooks.json 最小形)/#137 の設計コメントは caller 側に残置

## 挙動不変の検証(実施済み)

- **render byte-identical**: personal / work 両 profile の全 managed target を変更前 baseline と `diff -r` → 完全一致(hooks block は personal の committed render に含まれるため partial 経路も byte 検証済み)
- **全テスト suite green**: test-claude-settings(hook 登録の exact pin: event/matcher/command 絶対 path)/ test-codex-settings(exact pin + timeout=10 + top-level keys={hooks} の #185 parse-safety)/ test-render(managed set + unknown profile の fail-closed)/ test-ssh / ほか全 suite
- 監査の敵対検証フェーズが同一提案を scratchpad 複製 repo に独立適用し、chezmoi v2.70.5 で byte-identical を再現済み(本実装はその処方どおり)

## レビュー観点

- partial の trim 構造(先頭 `{{ "" }}` アンカー / 末尾 trim comment / timeout の `{{- if hasKey }}`)が byte-identity を壊さないか
- ssh config の挿入行が `{{ template ... -}}`(左 trim 無し)になっているか
- require-profile 追加による副作用(出力 0 byte・fail-only)の見落とし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qw8BkUDu5WdwhYfiFFX5n