### PR TITLE
fix: doctor/preflight の core.hooksPath 読取に --includes (#196 smoke 発見)

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -101,7 +101,11 @@ if [[ "$(capability_value "$profile" enableGitHookGates)" == "true" ]]; then
       fi
     done
     if command -v git >/dev/null 2>&1; then
-      hook_gates_path="$(git config --global --get core.hooksPath || true)"
+      # --includes is load-bearing: the value lives in the INCLUDED
+      # hooks.gitconfig, and `git config --global --get` skips includes by
+      # default when a scope file is given — without the flag a correctly
+      # wired machine misreports as unwired (found in the #196 live smoke).
+      hook_gates_path="$(git config --global --includes --get core.hooksPath || true)"
       # shellcheck disable=SC2088 # the first pattern is the literal value stored in gitconfig (git expands the tilde, not the shell)
       case "$hook_gates_path" in
         "~/.config/git-hook-gates/hooks" | "$hook_gates_dir/hooks")
@@ -140,7 +144,8 @@ else
     [[ -e "$hook_gates_dir/hooks/$hook_stage" ]] && hook_gates_lingering=1
   done
   if command -v git >/dev/null 2>&1; then
-    hook_gates_path="$(git config --global --get core.hooksPath || true)"
+    # --includes for the same reason as the enabled branch above.
+    hook_gates_path="$(git config --global --includes --get core.hooksPath || true)"
     # shellcheck disable=SC2088 # literal gitconfig value comparison, as above
     case "$hook_gates_path" in
       "~/.config/git-hook-gates/hooks" | "$hook_gates_dir/hooks") hook_gates_lingering=1 ;;

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -153,7 +153,11 @@ if [[ "$(capability_value "$profile" enableGitHookGates)" == "true" ]]; then
     ok "agent-tools deploy complete: apply arms the commit gates (fail-closed on the normal git commit path)"
   fi
   if command -v git >/dev/null 2>&1; then
-    hook_gates_path="$(git config --global --get core.hooksPath || true)"
+    # --includes is load-bearing: the managed value lives in the INCLUDED
+    # hooks.gitconfig, and `git config --global --get` skips includes by
+    # default when a scope file is given — without the flag a correctly
+    # wired machine misreports (found in the #196 live smoke).
+    hook_gates_path="$(git config --global --includes --get core.hooksPath || true)"
     # shellcheck disable=SC2088 # literal gitconfig value comparison (git expands the tilde, not the shell)
     case "$hook_gates_path" in
       "")

--- a/scripts/test-git-hook-gates.sh
+++ b/scripts/test-git-hook-gates.sh
@@ -354,6 +354,29 @@ else
   status=1
 fi
 
+section "observer read form (doctor / preflight)"
+
+# 7) doctor and preflight read core.hooksPath with --includes. The managed
+#    value lives in the INCLUDED hooks.gitconfig, and `git config --global
+#    --get` skips includes by default when a scope file is given, so without
+#    the flag a correctly wired machine misreports as unwired (found in the
+#    #196 live smoke: wiring worked, the observers said "not set"). Static
+#    pin on purpose — the observers' own read form IS the contract here.
+for observer in doctor preflight; do
+  if grep -Fq 'git config --global --includes --get core.hooksPath' "$SCRIPT_DIR/$observer.sh"; then
+    ok "test passed: $observer reads core.hooksPath with --includes"
+  else
+    fail "test failed: $observer reads core.hooksPath without --includes (misreports a wired machine as unwired)"
+    status=1
+  fi
+done
+if grep -Eq 'git config --global --get core\.hooksPath' "$SCRIPT_DIR/doctor.sh" "$SCRIPT_DIR/preflight.sh"; then
+  fail "test failed: an includes-less core.hooksPath read remains in doctor/preflight"
+  status=1
+else
+  ok "test passed: no includes-less core.hooksPath read remains"
+fi
+
 if [[ "$status" -eq 0 ]]; then
   ok "git hook gates tests passed"
 fi


### PR DESCRIPTION
## 概要

#196 の実機 smoke で発見した観測バグの修正。**配線自体は実効**(git 本体は読み時に include を処理し、repo 内で `core.hooksPath` が解決される)だが、doctor / preflight の読取 `git config --global --get core.hooksPath` が **scope file 指定時は include を既定で展開しない** ため、正しく配線済みのマシンを「not set」と誤報告していた(report-only の warn ノイズ + 配線 chain の偽の非緑)。

## 変更

- doctor(2 箇所)/ preflight(1 箇所)の読取に `--includes` を付与 + 理由コメント
- test-git-hook-gates に観測形の static pin を追加(`--includes` 付き読取の存在 + includes 無し読取の不在)。観測側の読取形そのものが契約なので static pin が適切

## 検証

- test-git-hook-gates / static(bash -n / shellcheck)PASS
- 実機 doctor: 配線 chain 全 green(shim ×2 / hooksPath → managed dir / deploy 3 本)
- この PR の commit 自体が live gate(pre-commit public-safety + commit-msg trailer)を通過 = smoke の clean commit 項目を兼ねる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qw8BkUDu5WdwhYfiFFX5n