### PR TITLE
fix(ci): 全 shell ファイルの構文を検査する

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,7 +47,10 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: bash syntax check
-        run: bash -n scripts/*.sh
+        run: |
+          for file in scripts/*.sh; do
+            bash -n "$file"
+          done
 
       # The managed zsh layer had no syntax gate at all — the #96 compinit
       # glob bug lived exactly here (#150). ubuntu-latest (24.04) does not
@@ -56,7 +59,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zsh
 
       - name: zsh syntax check (managed shell files)
-        run: zsh -n dot_zshenv dot_zshrc dot_zprofile
+        run: |
+          for file in dot_zshenv dot_zshrc dot_zprofile; do
+            zsh -n "$file"
+          done
+
+      - name: shell syntax gate regression tests
+        run: ./scripts/test-shell-syntax.sh
 
       - name: gclone helper tests
         run: ./scripts/test-gclone.sh

--- a/docs/github-workflow.md
+++ b/docs/github-workflow.md
@@ -112,13 +112,16 @@ main 直 commit は例外扱いにする。
 ./scripts/test-install-packages.sh
 ./scripts/test-render.sh
 ./scripts/test-claude-settings.sh
+./scripts/test-codex-settings.sh
 ./scripts/test-git-signing.sh
+./scripts/test-git-hook-gates.sh
 ./scripts/test-starship.sh
 ./scripts/test-ssh.sh
 ./scripts/test-preflight.sh
 ./scripts/test-gclone.sh
-bash -n scripts/*.sh
-zsh -n dot_zshenv dot_zshrc dot_zprofile
+./scripts/test-shell-syntax.sh
+bash -ec 'for file in scripts/*.sh; do bash -n "$file"; done'
+bash -ec 'for file in dot_zshenv dot_zshrc dot_zprofile; do zsh -n "$file"; done'
 shellcheck -S warning scripts/*.sh
 git diff --check
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -96,6 +96,12 @@ cleanup 登録する caller-creates-root 契約 — `$(...)` 内で mktemp す�
 限定 capability flip。boolean 専用)、`copy_repo_fixture`(scripts + .chezmoidata の最小
 repo copy)。
 
+## test-shell-syntax.sh
+
+CI の bash / zsh syntax check をそのまま取り出し、各入力ファイルへ構文エラーを
+順番に挿入して非 0 になることを検証する。先頭ファイルだけの検査や、後続ファイルの
+成功で途中の失敗が隠れる退行を防ぐ(#211)。
+
 ## test-policy.sh
 
 外部 test framework を使わずに policy validation の fail-closed 挙動を検証する。

--- a/scripts/test-shell-syntax.sh
+++ b/scripts/test-shell-syntax.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+require_yq
+command -v zsh >/dev/null || { fail "zsh is required for syntax gate tests"; exit 1; }
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-shell-syntax.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/scripts"
+
+# Exercise the actual CI commands: multiple operands to shell -n parse only
+# the first file, and a valid final file must not hide an earlier failure.
+workflow="$DOTFILES_ROOT/.github/workflows/validate.yml"
+for shell_name in bash zsh; do
+  case "$shell_name" in
+    bash)
+      step="bash syntax check"
+      files=(scripts/a.sh scripts/b.sh scripts/c.sh)
+      ;;
+    zsh)
+      step="zsh syntax check (managed shell files)"
+      files=(dot_zshenv dot_zshrc dot_zprofile)
+      ;;
+  esac
+  check="$(STEP="$step" yq -r '.jobs.validate.steps[] | select(.name == strenv(STEP)) | .run' "$workflow")"
+  [[ -n "$check" && "$check" != "null" ]] || { fail "missing CI syntax step: $step"; exit 1; }
+  for file in "${files[@]}"; do
+    printf ':\n' > "$fixture/$file"
+  done
+  if ! (cd "$fixture" && bash -e -c "$check"); then
+    fail "$shell_name syntax gate rejected valid files"
+    exit 1
+  fi
+  for file in "${files[@]}"; do
+    printf 'if then\n' > "$fixture/$file"
+    if (cd "$fixture" && bash -e -c "$check") >/dev/null 2>&1; then
+      fail "$shell_name syntax gate missed invalid $file"
+      exit 1
+    fi
+    printf ':\n' > "$fixture/$file"
+    ok "$shell_name syntax gate rejects invalid $file"
+  done
+done
+
+ok "shell syntax gate tests passed"


### PR DESCRIPTION
## 変更内容

shell の `-n` に複数ファイルを渡しても先頭しか検査されず、後続の構文エラーが CI を通過していました。bash / zsh をファイルごとに実行し、CI と同じコマンドへ各位置の構文エラーを挿入する回帰テストを追加しました。ローカル検証手順も CI に合わせています。

Closes #211

## 検証

- `test-shell-syntax.sh`: 正常系と bash / zsh の先頭・中間・末尾の異常系を確認。
- `validate-policy.sh --all`、shellcheck、全 shell ファイルの個別構文検査、`git diff --check` が成功。
- GitHub CI の validate / render が成功。
- `claude -p` による独立レビュー: pass、must 0 / should 0 / nit 2。head `de8c34f7` の Codex trailer を確認済み。
- 非 blocking の指摘は runner の既定 `bash -e` への依存と手順書への検証コマンド再掲。現在の runner 契約と既存の検証手順形式に合わせ、今回の動作要件に影響しないため維持しています。

## 影響

CI と検証手順のみ。実ユーザー環境への適用はありません。
