### PR TITLE
fix(backup): .zprofile.local を標準バックアップへ含める

### DIFF
--- a/.chezmoidata/backup-paths.yaml
+++ b/.chezmoidata/backup-paths.yaml
@@ -19,6 +19,7 @@
 # Read by scripts via mikefarah/yq v4; validated by validate-policy.sh.
 backup_paths:
   - { path: .zshrc.local, type: file, category: shell }
+  - { path: .zprofile.local, type: file, category: shell }
   - { path: .ssh/config.local, type: file, category: ssh }
   # Codex harness config. Contains a mix of public-safe settings and
   # machine/secret-bearing values (project paths incl. ~/work, status_line,

--- a/docs/private-backup.md
+++ b/docs/private-backup.md
@@ -30,7 +30,7 @@ public な dotfiles git には置けない **private な設定**(`.local` 上書
 
 - **public baseline**(`.chezmoidata/backup-paths.yaml`、本 repo にコミット):
   誰の環境でも当たり障りない public-safe なパスのみ。「何を追っているか」を repo で
-  可視化する。
+  可視化する。shell の上書きファイル `.zshrc.local` / `.zprofile.local` も含む。
 - **local 補足**(`~/.config/dotfiles/backup-paths.local`、非コミット):
   client 固有・private なパスはここだけに書く。**暗号化アーカイブに同梱**され、
   復元時に参照される。public-safety を守りつつリストごと復元できる。

--- a/scripts/test-private-backup.sh
+++ b/scripts/test-private-backup.sh
@@ -29,6 +29,8 @@ trap 'rm -rf "$fixture_home"' EXIT
 mkdir -p "$fixture_home/.ssh" "$fixture_home/fakebin" "$fixture_home/keys" "$fixture_home/out"
 # Baseline files declared in .chezmoidata/backup-paths.yaml.
 printf 'export SECRET_TOKEN=abc123\n' > "$fixture_home/.zshrc.local"
+printf 'export LOGIN_SETTING=fixture\n' > "$fixture_home/.zprofile.local"
+chmod 600 "$fixture_home/.zprofile.local"
 printf 'Host private\n  User me\n' > "$fixture_home/.ssh/config.local"
 
 # Fake chezmoi: prints a chosen profile so require_secrets_access resolves
@@ -274,6 +276,8 @@ fi
 # 13. restore --apply restores files with the original content.
 if run restore --in "$archive" --identity "$fixture_home/keys/id.txt" --target-home "$rdst" --apply >/dev/null 2>&1 \
   && [[ "$(cat "$rdst/.zshrc.local" 2>/dev/null)" == "export SECRET_TOKEN=abc123" ]] \
+  && [[ "$(cat "$rdst/.zprofile.local" 2>/dev/null)" == "export LOGIN_SETTING=fixture" ]] \
+  && [[ "$(file_mode "$rdst/.zprofile.local")" == "600" ]] \
   && [[ -f "$rdst/.ssh/config.local" ]]; then
   pass "restore --apply restores files with original content"
 else


### PR DESCRIPTION
## 変更内容

サポート済みの login shell 上書きファイル `.zprofile.local` が標準バックアップから漏れていました。public baseline に加え、暗号化バックアップから内容・権限を復元できることを既存 round-trip テストで確認します。存在しない環境では従来どおり skip されます。

Closes #212

## 検証

- `test-private-backup.sh`、`validate-policy.sh --all`、`git diff --check` が成功。
- GitHub CI validate / render passed.
- Claude (`claude -p`) cross-review: pass, must 0 / should 0 / nit 1. Verified Codex-authored head `46ad463b`. The merge message includes `Closes #212`, and issue auto-close is verified. The subject-language convention is a nonblocking note.

## 影響

明示的な backup 実行時の対象追加のみ。実ユーザーの設定・アーカイブは変更していません。
