### PR TITLE
fix(inventory): 不明な状態での install と Go probe の自動取得を防ぐ

### DIFF
--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -34,9 +34,13 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 - **台帳外**(undeclared / sprawl: 入っているが catalog に無い)→ `warn`。brew は `brew leaves`(top-level のみ。依存は拾わない)、npm は node 同梱の `npm` / `corepack` を除外(runtime の領分、node/go/uv と同じ扱い)、go は toolchain 同梱の `go` / `gofmt` を除外(GOBIN を `$GOROOT/bin` に向ける mise 等では toolchain 本体が scan dir に同居するため。catalog で宣言・削除できる go_install package ではない)、mas は App Store の無関係アプリが大量に誤検知されるため undeclared は出さない(宣言済み mas entry の presence のみ確認)。
 - **source ズレ**(宣言 source の inventory には無いが `command` が PATH 上に在る = 別 source で入っている疑い)→ `info`。manager 横断の名前照合(脆い)はやらず、PATH 上の存在という堅い信号だけを使う。
 
-照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。
+照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。 inventory の取得・解析に失敗した source は未 install / 台帳外と判定せず、`INCOMPLETE` を警告して検査を skip する。他の source は引き続き検査し、doctor は exit 0 を維持する。
 
 install は `install-packages.sh`(手動起動・`chezmoi apply` 非結合)が担う。catalog の未 install entry を、`installPackages`(brew_formula / npm_global / go_install)と `installGuiApps`(brew_cask / mas)で gate して install する。**dry-run 既定**(`--apply` で実行)、既 install は skip して**更新しない**(install と update の分離、[update-policy](update-policy.md))、track-only / manual は対象外、npm/go の manager 不在時は skip+warn。environmentKind 制約で work / client / agent は gate(installPackages/installGuiApps)が false 必須なので install されない(`environment_kind_forbidden_capabilities`)。sandbox は install 制約の対象外(secret のみ禁止)で、profile が install gate を true にすれば install されうる。
+
+Go の install 済み判定は GOBIN(空の場合は GOPATH の先頭 entry 配下の `bin`)を調べる。そこに executable があれば PATH 外でも再 install しない。`go env` の probe は `GOTOOLCHAIN=local` / `GO111MODULE=off` / `GOWORK=off` で実行し、呼出元の `go.mod` / `go.work` による toolchain 自動取得を抑止する。query 失敗、空や不正な GOPATH は「不明」であり、`/bin` へ fallback しない。
+
+installer は inventory の不明と正常な空リストを区別する。取得・解析失敗時は dry-run でも install を計画せず、`--apply` でもその entry を変更しない。失敗を報告して exit nonzero とし、成功した inventory に対する処理は継続する。
 
 ## Rules
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -199,6 +199,8 @@ manager が PATH に無ければ skip + warn(runtime は mise の領分)。
 `profile_installs_source` が personal のみ install を許し work 系は許さないこと、profile 未解決時の
 拒否、解決済み work profile の dry-run が 0 件を計画すること(副作用なし)を確認する。
 
+`test-inventory.sh` はこの test から実行する inventory 回帰検証で、単独でも実行できる。fake manager だけを PATH に置き、Go toolchain 自動取得の抑止、GOBIN / GOPATH の PATH 外 executable の再 install 防止、inventory の取得・解析失敗時に install しないこと、doctor の INCOMPLETE / exit 0 と成功 source の検査継続を確認する。実 manager・実 install・実 home は使わない。
+
 ## private-backup.sh
 
 private な設定(`.local` 上書き + curated アプリ設定)を **age identity 鍵**で単一アーカイブに

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -34,33 +34,24 @@ chezmoi apply.
 EOF
 }
 
-# Whether NAME is already installed for SOURCE. canonical = pkg|name,
-# bincmd = bin|name. Read-only; a present entry is left untouched (no upgrade).
-# Probes via lib-policy's installed_inventory (the same one the doctor drift
-# report reads) and matches against the full capture: the previous
-# `probe | grep -Fxq` shape died of SIGPIPE under pipefail once grep exited
-# on the first hit, so installed casks/apps randomly read as absent and
-# --apply re-ran their installers (#143).
+# Presence is tri-state: 0 installed, 1 confirmed absent, 2 unknown.
+# Inventory failures cannot authorize installation (#213). Capture before
+# matching to preserve the large-inventory/SIGPIPE guard (#143).
 is_installed() {
   local source="$1" canonical="$2" bincmd="$3" inv=""
+  inv="$(installed_inventory "$source")" || return 2
   case "$source" in
-    brew_formula)
-      inv="$(installed_inventory brew_formula)"
+    brew_formula | npm_global)
       grep -Fxq -- "$canonical" <<< "$inv" && return 0
       command -v "$bincmd" >/dev/null 2>&1 ;;
-    brew_cask)
-      inv="$(installed_inventory brew_cask)"
+    brew_cask | mas)
       grep -Fxq -- "$canonical" <<< "$inv" ;;
-    npm_global)
-      inv="$(installed_inventory npm_global)"
-      grep -Fxq -- "$canonical" <<< "$inv" && return 0
-      command -v "$bincmd" >/dev/null 2>&1 ;;
     go_install)
+      # An executable in GOBIN is installed even when GOBIN is outside PATH
+      # (#209). PATH remains a separate availability fallback.
+      grep -Fxq -- "$bincmd" <<< "$inv" && return 0
       command -v "$bincmd" >/dev/null 2>&1 ;;
-    mas)
-      inv="$(installed_inventory mas)"
-      grep -Fxq -- "$canonical" <<< "$inv" ;;
-    *) return 0 ;;
+    *) return 2 ;;
   esac
 }
 
@@ -118,7 +109,7 @@ main() {
   rows="$(catalog_packages)" || { fail "could not read catalog packages"; return 1; }
 
   local name source pkg bin track_only canonical bincmd cap
-  local planned=0 installed_now=0 skipped=0 failed=0
+  local planned=0 installed_now=0 skipped=0 failed=0 presence_status
   local INSTALL_CMD=()
   while IFS='|' read -r name source pkg bin track_only; do
     [[ -z "$name$source" ]] && continue
@@ -149,6 +140,12 @@ main() {
     if is_installed "$source" "$canonical" "$bincmd"; then
       ok "already installed: $name ($source)"
       skipped=$((skipped + 1)); continue
+    else
+      presence_status=$?
+    fi
+    if [[ "$presence_status" -ne 1 ]]; then
+      warn "skip $name: $source inventory unavailable; refusing to install an entry with unknown presence"
+      failed=$((failed + 1)); continue
     fi
 
     if ! build_install_cmd "$source" "$canonical"; then
@@ -175,7 +172,8 @@ main() {
     ok "done: $installed_now installed, $skipped skipped, $failed failed"
     [[ "$failed" -eq 0 ]]
   else
-    ok "dry-run: $planned would be installed, $skipped skipped (pass --apply to perform)"
+    ok "dry-run: $planned would be installed, $skipped skipped, $failed failed (pass --apply to perform)"
+    [[ "$failed" -eq 0 ]]
   fi
 }
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -354,41 +354,55 @@ profile_installs_source() {
 # node/go/uv), and is skipped for mas (the App Store carries many apps
 # unrelated to the dev catalog; flagging them all would be noise).
 
-# The go bin directory: GOBIN, falling back to GOPATH/bin. mise points GOBIN
-# at GOROOT/bin, which is why the toolchain binaries live next to installed
-# packages (see the go|gofmt guard below).
+# Probe the selected local Go without accepting a toolchain request from the
+# caller's go.mod/go.work (#205). A failed query is unknown, never /bin.
 go_bin_dir() {
-  local gobin
-  gobin="$(go env GOBIN 2>/dev/null || true)"
-  [[ -z "$gobin" ]] && gobin="$(go env GOPATH 2>/dev/null || true)/bin"
+  local gobin gopath
+  gobin="$(GOTOOLCHAIN=local GO111MODULE=off GOWORK=off go env GOBIN 2>/dev/null)" || return 1
+  if [[ -z "$gobin" ]]; then
+    gopath="$(GOTOOLCHAIN=local GO111MODULE=off GOWORK=off go env GOPATH 2>/dev/null)" || return 1
+    # Go installs into the first entry when GOPATH is a path list.
+    gopath="${gopath%%:*}"
+    [[ -n "$gopath" ]] || return 1
+    gobin="${gopath%/}/bin"
+  fi
+  case "$gobin" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  [[ "$gobin" != *[[:cntrl:]]* ]] || return 1
   printf '%s' "$gobin"
 }
 
-# Full installed inventory for SOURCE, one id per line; empty when the
-# manager is absent or the probe fails (read-only, never errors). The single
-# probe implementation shared by the drift report below and the installer's
-# is_installed (#143) — before this they were duplicated and could disagree.
-#
-# Contract for callers: capture the WHOLE list (file or variable) and match
-# against the capture. Matching the producer directly (`probe | grep -q`)
-# dies of SIGPIPE under pipefail once grep exits on the first hit, so an
-# installed entry randomly reads as absent (#143).
+# Full installed inventory for SOURCE, one id per line. A successful empty
+# inventory means absent; any probe/read/parse failure returns nonzero and
+# callers must discard its output (#213). Report-only consumers warn and
+# continue; the installer must not turn an unknown inventory into installs.
+# Capture the WHOLE list before matching: `probe | grep -q` can lose an
+# installed entry to SIGPIPE under pipefail (#143).
 installed_inventory() {
-  local source="$1"
+  local source="$1" inventory dir
   case "$source" in
-    brew_formula) brew list --formula -1 2>/dev/null || true ;;
-    brew_leaves) brew leaves 2>/dev/null || true ;;
-    brew_cask) brew list --cask -1 2>/dev/null || true ;;
+    brew_formula) brew list --formula -1 2>/dev/null ;;
+    brew_leaves) brew leaves 2>/dev/null ;;
+    brew_cask) brew list --cask -1 2>/dev/null ;;
     npm_global)
-      npm ls -g --depth=0 --json 2>/dev/null \
-        | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null || true ;;
+      inventory="$(npm ls -g --depth=0 --json 2>/dev/null)" || return 1
+      [[ -n "$inventory" ]] || return 1
+      printf '%s\n' "$inventory" | yq -e -p json \
+        '(tag == "!!map") and ((.dependencies == null) or ((.dependencies | tag) == "!!map"))' >/dev/null 2>&1 || return 1
+      printf '%s\n' "$inventory" | yq -p json '.dependencies // {} | keys | .[]' 2>/dev/null ;;
     go_install)
-      local dir
-      dir="$(go_bin_dir)"
-      if [[ -n "$dir" && -d "$dir" ]]; then
-        find "$dir" -maxdepth 1 -type f -perm -u+x -exec basename {} \; 2>/dev/null || true
-      fi ;;
-    mas) mas list 2>/dev/null | awk '{print $1}' || true ;;
+      dir="$(go_bin_dir)" || return 1
+      if [[ ! -e "$dir" && ! -L "$dir" ]]; then
+        return 0
+      fi
+      [[ -d "$dir" && -r "$dir" && -x "$dir" ]] || return 1
+      find -H "$dir" -maxdepth 1 -type f -perm -u+x -exec basename {} \; 2>/dev/null ;;
+    mas)
+      inventory="$(mas list 2>/dev/null)" || return 1
+      printf '%s\n' "$inventory" | awk '{print $1}' ;;
+    *) return 1 ;;
   esac
 }
 
@@ -420,35 +434,35 @@ report_catalog_drift() {
     "$decl_go_bins"
   )
 
-  # Inventories (read-only), one shared probe per source (installed_inventory
-  # above); a failing probe yields an empty list. Per-source availability
-  # flags gate whether absence means "not installed" or "manager not
-  # present, skip".
+  # A failed inventory is distinct from an absent manager. Keep successful
+  # sources inspectable, but never infer absence or sprawl from failed ones.
   local have_brew=0 have_npm=0 have_go=0 have_mas=0 gobin=""
+  local inventory_failures="" failed_source
   if manager_present brew_formula; then
     have_brew=1
-    installed_inventory brew_formula | sort > "$brew_formulae"
-    installed_inventory brew_leaves | sort > "$brew_leaves"
-    installed_inventory brew_cask | sort > "$brew_casks"
+    installed_inventory brew_formula > "$brew_formulae" || inventory_failures+=$'brew_formula\n'
+    installed_inventory brew_leaves > "$brew_leaves" || inventory_failures+=$'brew_leaves\n'
+    installed_inventory brew_cask > "$brew_casks" || inventory_failures+=$'brew_cask\n'
   fi
   if manager_present npm_global; then
     have_npm=1
-    installed_inventory npm_global \
-      | grep -vxE 'npm|corepack' | sort > "$npm_globals" || true
+    installed_inventory npm_global > "$npm_globals" || inventory_failures+=$'npm_global\n'
   fi
-  # A go-built binary persists in GOPATH/bin even if `go` is later removed,
-  # but treating go like the other managers (absent -> skip, not "not
-  # installed") keeps the contract uniform and avoids guessing GOPATH when
-  # go cannot tell us where it is.
+  # An absent manager is a skip; never guess GOPATH when go cannot answer.
   if manager_present go_install; then
     have_go=1
-    gobin="$(go_bin_dir)"
-    installed_inventory go_install | sort > "$go_bins"
+    if ! gobin="$(go_bin_dir)" || ! installed_inventory go_install > "$go_bins"; then
+      inventory_failures+=$'go_install\n'
+    fi
   fi
   if manager_present mas; then
     have_mas=1
-    installed_inventory mas | sort > "$mas_ids"
+    installed_inventory mas > "$mas_ids" || inventory_failures+=$'mas\n'
   fi
+  while IFS= read -r failed_source; do
+    [[ -z "$failed_source" ]] && continue
+    warn "catalog inventory INCOMPLETE: $failed_source probe failed; absence and sprawl checks skipped for this source"
+  done <<< "$inventory_failures"
 
   # Report which inventories were inspected. npm's global root differs by
   # active node (mise-managed vs system); naming it avoids misreading a
@@ -498,6 +512,11 @@ report_catalog_drift() {
       else
         item "track-only, not present: $name ($source)"
       fi
+      continue
+    fi
+
+    if grep -Fxq -- "$source" <<< "$inventory_failures"; then
+      item "skip $name: $source inventory unavailable"
       continue
     fi
 
@@ -569,7 +588,7 @@ report_catalog_drift() {
   done <<< "$rows"
 
   # Undeclared (sprawl): installed top-level items absent from the catalog.
-  if [[ "$have_brew" -eq 1 ]]; then
+  if [[ "$have_brew" -eq 1 ]] && ! grep -Eq '^(brew_formula|brew_leaves)$' <<< "$inventory_failures"; then
     while IFS= read -r f; do
       [[ -z "$f" ]] && continue
       grep -Fxq -- "$f" "$decl_brew_formula" || {
@@ -577,6 +596,8 @@ report_catalog_drift() {
         drift_count=$((drift_count + 1))
       }
     done < "$brew_leaves"
+  fi
+  if [[ "$have_brew" -eq 1 ]] && ! grep -Fxq brew_cask <<< "$inventory_failures"; then
     while IFS= read -r c; do
       [[ -z "$c" ]] && continue
       grep -Fxq -- "$c" "$decl_brew_cask" || {
@@ -585,16 +606,17 @@ report_catalog_drift() {
       }
     done < "$brew_casks"
   fi
-  if [[ "$have_npm" -eq 1 ]]; then
+  if [[ "$have_npm" -eq 1 ]] && ! grep -Fxq npm_global <<< "$inventory_failures"; then
     while IFS= read -r n; do
       [[ -z "$n" ]] && continue
+      case "$n" in npm|corepack) continue ;; esac
       grep -Fxq -- "$n" "$decl_npm" || {
         warn "undeclared: $n (npm global not in catalog)"
         drift_count=$((drift_count + 1))
       }
     done < "$npm_globals"
   fi
-  if [[ "$have_go" -eq 1 ]]; then
+  if [[ "$have_go" -eq 1 ]] && ! grep -Fxq go_install <<< "$inventory_failures"; then
     while IFS= read -r b; do
       [[ -z "$b" ]] && continue
       # `go` and `gofmt` are the Go distribution's own binaries, shipped in
@@ -613,7 +635,7 @@ report_catalog_drift() {
     done < "$go_bins"
   fi
 
-  if [[ "$drift_count" -eq 0 ]]; then
+  if [[ "$drift_count" -eq 0 && -z "$inventory_failures" ]]; then
     ok "no catalog drift"
   fi
 

--- a/scripts/test-install-packages.sh
+++ b/scripts/test-install-packages.sh
@@ -198,6 +198,8 @@ else
   pass "is_installed still reports a genuinely absent cask as not installed"
 fi
 
+"$SCRIPT_DIR/test-inventory.sh" || status=1
+
 if [[ "$status" -eq 0 ]]; then
   ok "install-packages tests passed"
 fi

--- a/scripts/test-inventory.sh
+++ b/scripts/test-inventory.sh
@@ -162,9 +162,9 @@ mv "$fixture/saved-gobin" "$fixture/gobin"
 ok "GOPATH presence and uninspectable Go bin locations are handled safely"
 
 for mode in dry-run apply; do
-  args=()
+  args=("$installer")
   [[ "$mode" = apply ]] && args+=(--apply)
-  if output="$(INVENTORY_TEST_STATE=fail run_fixture "$installer" "${args[@]}" 2>&1)"; then
+  if output="$(INVENTORY_TEST_STATE=fail run_fixture "${args[@]}" 2>&1)"; then
     fail "inventory errors must fail the installer ($mode)"
     exit 1
   fi

--- a/scripts/test-inventory.sh
+++ b/scripts/test-inventory.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inventory regressions (#205/#209/#213), reached by test-install-packages.sh.
+# Only fake managers are on PATH. Installs and attempted toolchain downloads
+# become fixture markers; no real manager or user configuration is consulted.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib-policy.sh
+source "$SCRIPT_DIR/lib-policy.sh"
+
+fixture="$(mktemp -d "${TMPDIR:-/tmp}/dotfiles-inventory-test.XXXXXX")"
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/bin" "$fixture/repo/scripts" "$fixture/repo/.chezmoidata" \
+  "$fixture/gobin" "$fixture/gopath/bin" "$fixture/caller"
+cp "$SCRIPT_DIR/lib-policy.sh" "$SCRIPT_DIR/install-packages.sh" "$fixture/repo/scripts/"
+cp "$PROFILES_FILE" "$fixture/repo/.chezmoidata/profiles.yaml"
+cat > "$fixture/repo/.chezmoidata/packages.yaml" <<'YAML'
+packages:
+  - {name: fixture-formula, source: brew_formula}
+  - {name: fixture-cask, source: brew_cask}
+  - {name: fixture-npm, source: npm_global}
+  - {name: fixture-go, source: go_install, pkg: example.invalid/fixture/cli}
+  - {name: fixture-mas, source: mas, pkg: "10101010"}
+YAML
+cat > "$fixture/caller/go.mod" <<'MOD'
+module example.invalid/caller
+
+go 99.0.0
+toolchain go99.0.0
+MOD
+cat > "$fixture/caller/go.work" <<'WORK'
+go 99.0.0
+toolchain go99.0.0
+use .
+WORK
+printf '#!/bin/sh\nexit 0\n' > "$fixture/gobin/fixture-go"
+chmod +x "$fixture/gobin/fixture-go"
+
+cat > "$fixture/bin/chezmoi" <<'FAKE'
+#!/bin/sh
+printf '{"profile":"personal"}\n'
+FAKE
+for manager in brew npm mas; do
+  cat > "$fixture/bin/$manager" <<'FAKE'
+#!/bin/sh
+manager="${0##*/}"
+if [ "$1" = install ]; then
+  printf '%s %s\n' "$manager" "$*" >> "$INVENTORY_TEST_ROOT/installs"
+  exit 0
+fi
+if [ "${INVENTORY_TEST_STATE:-present}" = fail ]; then
+  # A partially printed inventory with a failure is still unknown.
+  [ "$manager" = npm ] && printf '{"dependencies":{"partial-entry":{}}}\n'
+  exit 1
+fi
+case "${INVENTORY_TEST_STATE:-present}:$manager:$*" in
+  partial:brew:list\ --formula*) exit 1 ;;
+esac
+case "$manager:$*" in
+  npm:root*) printf '%s/npm-root\n' "$INVENTORY_TEST_ROOT"; exit 0 ;;
+  npm:ls*)
+    case "${INVENTORY_TEST_STATE:-present}" in
+      malformed) printf 'invalid-json\n' ;;
+      wrong-shape) printf '{"dependencies":[]}\n' ;;
+      empty|partial) printf '{}\n' ;;
+      *) printf '{"dependencies":{"fixture-npm":{}}}\n' ;;
+    esac
+    exit 0 ;;
+esac
+[ "${INVENTORY_TEST_STATE:-present}" = empty ] && exit 0
+case "$manager:$*" in
+  brew:list\ --formula*) printf 'fixture-formula\n' ;;
+  brew:leaves) printf 'fixture-formula\n' ;;
+  brew:list\ --cask*) printf 'fixture-cask\n' ;;
+  mas:list) printf '10101010 Fixture App (1.0)\n' ;;
+  *) exit 97 ;;
+esac
+FAKE
+  chmod +x "$fixture/bin/$manager"
+done
+cat > "$fixture/bin/go" <<'FAKE'
+#!/bin/sh
+if [ "$1" = install ]; then
+  printf 'go %s\n' "$*" >> "$INVENTORY_TEST_ROOT/installs"
+  exit 0
+fi
+[ "$1" = env ] || exit 97
+if [ "${GOTOOLCHAIN:-}" != local ] || [ "${GO111MODULE:-}" != off ] || [ "${GOWORK:-}" != off ]; then
+  : > "$INVENTORY_TEST_ROOT/toolchain-download-attempt"
+  exit 98
+fi
+[ "${INVENTORY_TEST_STATE:-present}" = fail ] && exit 1
+case "$2:${INVENTORY_TEST_GO_STATE:-gobin}" in
+  GOBIN:failure) exit 1 ;;
+  GOBIN:gobin) printf '%s/gobin\n' "$INVENTORY_TEST_ROOT" ;;
+  GOBIN:relative) printf 'relative/bin\n' ;;
+  GOBIN:*) printf '\n' ;;
+  GOPATH:gopath-failure) exit 1 ;;
+  GOPATH:empty-gopath) printf '\n' ;;
+  GOPATH:relative-gopath) printf 'relative\n' ;;
+  GOPATH:*) printf '%s/gopath:%s/other-gopath\n' "$INVENTORY_TEST_ROOT" "$INVENTORY_TEST_ROOT" ;;
+  *) exit 97 ;;
+esac
+FAKE
+chmod +x "$fixture/bin/go" "$fixture/bin/chezmoi"
+for tool in bash sh dirname cat grep find basename awk mktemp rm yq; do
+  ln -s "$(command -v "$tool")" "$fixture/bin/$tool"
+done
+
+run_fixture() {
+  (
+    cd "$fixture/caller"
+    env PATH="$fixture/bin" INVENTORY_TEST_ROOT="$fixture" \
+      GOTOOLCHAIN=go99.0.0 GO111MODULE=on GOWORK="$fixture/caller/go.work" "$@"
+  )
+}
+probe_go() {
+  run_fixture bash -c 'source "$1"; go_bin_dir' _ "$fixture/repo/scripts/lib-policy.sh"
+}
+installer="$fixture/repo/scripts/install-packages.sh"
+
+if [[ "$(probe_go)" != "$fixture/gobin" ]] || [[ -e "$fixture/toolchain-download-attempt" ]]; then
+  fail "Go inventory must ignore caller toolchain requests without downloading"
+  exit 1
+fi
+ok "Go probe suppresses toolchain/module/workspace selection from the caller"
+if [[ "$(INVENTORY_TEST_GO_STATE=gopath probe_go)" != "$fixture/gopath/bin" ]]; then
+  fail "empty GOBIN must use the first valid GOPATH entry"
+  exit 1
+fi
+for state in failure gopath-failure empty-gopath relative relative-gopath; do
+  if result="$(INVENTORY_TEST_GO_STATE="$state" probe_go)" || [[ -n "$result" ]]; then
+    fail "Go probe must fail without a guessed path: $state"
+    exit 1
+  fi
+done
+ok "failed or invalid Go env never falls back to /bin"
+
+: > "$fixture/installs"
+output="$(run_fixture "$installer" --apply 2>&1)"
+if ! grep -Fq 'already installed: fixture-go' <<< "$output" || [[ -s "$fixture/installs" ]]; then
+  fail "GOBIN executable outside PATH must be skipped without reinstalling"
+  printf '%s\n' "$output" >&2
+  exit 1
+fi
+ok "installed Go executable outside PATH is not reinstalled"
+cp "$fixture/gobin/fixture-go" "$fixture/gopath/bin/fixture-go"
+output="$(INVENTORY_TEST_GO_STATE=gopath run_fixture "$installer" --apply 2>&1)"
+if ! grep -Fq 'already installed: fixture-go' <<< "$output" || [[ -s "$fixture/installs" ]]; then
+  fail "GOPATH executable outside PATH must also be skipped"
+  exit 1
+fi
+mv "$fixture/gobin" "$fixture/saved-gobin"
+: > "$fixture/gobin"
+if output="$(run_fixture "$installer" --apply 2>&1)" || [[ -s "$fixture/installs" ]] \
+  || ! grep -Fq 'go_install inventory unavailable' <<< "$output"; then
+  fail "an uninspectable Go bin location must not trigger installation"
+  exit 1
+fi
+rm "$fixture/gobin"
+mv "$fixture/saved-gobin" "$fixture/gobin"
+ok "GOPATH presence and uninspectable Go bin locations are handled safely"
+
+for mode in dry-run apply; do
+  args=()
+  [[ "$mode" = apply ]] && args+=(--apply)
+  if output="$(INVENTORY_TEST_STATE=fail run_fixture "$installer" "${args[@]}" 2>&1)"; then
+    fail "inventory errors must fail the installer ($mode)"
+    exit 1
+  fi
+  if [[ -s "$fixture/installs" ]] || ! grep -Fq '0 skipped, 5 failed' <<< "$output" \
+    || grep -Fq 'would install:' <<< "$output"; then
+    fail "unknown inventory must never plan or perform installs ($mode)"
+    printf '%s\n' "$output" >&2
+    exit 1
+  fi
+done
+ok "failed inventories prevent dry-run plans and --apply installs for all sources"
+for state in malformed wrong-shape; do
+  if output="$(INVENTORY_TEST_STATE="$state" run_fixture "$installer" --apply 2>&1)" \
+    || [[ -s "$fixture/installs" ]] || ! grep -Fq 'npm_global inventory unavailable' <<< "$output"; then
+    fail "invalid npm inventory must not trigger an install ($state)"
+    exit 1
+  fi
+done
+ok "npm parse and shape errors remain unknown"
+
+output="$(INVENTORY_TEST_STATE=fail run_fixture bash -c \
+  'set -euo pipefail; source "$1"; report_catalog_drift' _ "$fixture/repo/scripts/lib-policy.sh" 2>&1)"
+for source in brew_formula brew_leaves brew_cask npm_global go_install mas; do
+  if ! grep -Fq "catalog inventory INCOMPLETE: $source" <<< "$output"; then
+    fail "drift must disclose the failed $source inventory"
+    exit 1
+  fi
+done
+if grep -Eq 'no catalog drift|not installed:|undeclared:' <<< "$output"; then
+  fail "failed inventory must not become a clean or absent/sprawl report"
+  exit 1
+fi
+ok "catalog drift stays exit 0 and reports INCOMPLETE for failed sources"
+output="$(INVENTORY_TEST_STATE=partial run_fixture bash -c \
+  'set -euo pipefail; source "$1"; report_catalog_drift' _ "$fixture/repo/scripts/lib-policy.sh" 2>&1)"
+if ! grep -Fq 'catalog inventory INCOMPLETE: brew_formula' <<< "$output" \
+  || ! grep -Fq 'not installed: fixture-npm' <<< "$output" \
+  || grep -Eq 'not installed: fixture-formula|no catalog drift' <<< "$output"; then
+  fail "a failed source must not suppress successful sources or become clean"
+  exit 1
+fi
+ok "catalog drift continues inspecting successful sources after a probe failure"
+
+rm "$fixture/gobin/fixture-go"
+output="$(INVENTORY_TEST_STATE=empty run_fixture "$installer" 2>&1)"
+if ! grep -Fq '5 would be installed' <<< "$output" || [[ -s "$fixture/installs" ]]; then
+  fail "successful empty inventories must plan installs without side effects"
+  exit 1
+fi
+output="$(INVENTORY_TEST_STATE=empty run_fixture "$installer" --apply 2>&1)"
+if ! grep -Fq '5 installed, 0 skipped, 0 failed' <<< "$output" \
+  || [[ "$(awk 'END { print NR }' "$fixture/installs")" != 5 ]]; then
+  fail "successful empty inventories must reach all five fake installers"
+  exit 1
+fi
+ok "confirmed absence still permits installation (fake managers only)"


### PR DESCRIPTION
## 変更内容

Go inventory の照会が呼出元の `go.mod` / `go.work` に従って toolchain を取得しようとする問題と、GOBIN が PATH 外だと既存 CLI を再インストールする問題を修正しました。照会はローカル toolchain に固定し、取得した bin directory の inventory で存在を確認します。照会失敗から `/bin` を推測しません。

各 package manager の inventory 取得・解析失敗を「正常な空リスト」と区別します。installer は不明な entry の計画・install を拒否して非 0 終了し、doctor は該当 source を `INCOMPLETE` と報告して他 source の検査を継続します。

Closes #205
Closes #209
Closes #213

## 検証

- `test-install-packages.sh` / `test-inventory.sh`: 全 source の取得失敗、npm の不正 JSON / 型、正常な空 inventory、PATH 外の GOBIN / GOPATH、Go 照会失敗、部分的な source 失敗を fixture で検証。
- `test-policy.sh`、shellcheck、変更 script の構文検査、`git diff --check` が成功。
- GitHub CI validate / render passed for the reviewed implementation.
- Claude (`claude -p`) independent reviews cover base implementation `8d666115` and Bash 3.2 follow-up `23e2610e`: both pass, must 0. The initial nonblocking should finding (safe npm diagnostic guidance) is tracked in #219 with a prepared follow-up. The exact final tree contains only these reviewed commits.
- `test-doctor.sh` and the combined inventory/secrets/backup fixture tests passed. `test-inventory.sh` passed with macOS Bash 3.2 and Homebrew Bash.

実 package manager によるインストールや実 HOME の設定変更はありません。
