### PR TITLE
fix(doctor): Codex rules の最終判定だけを警告に使う

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -483,7 +483,7 @@ fi
 # report-only — every path ends in ok/item/warn (return 0), so the plain
 # calls below are set -e safe without || true.
 report_codex_rules_probes() {
-  local codex_rules outward_probes outward_allowed probe_failures probe verdict
+  local codex_rules outward_probes outward_allowed probe_failures probe verdict decision
   codex_rules="$HOME/.codex/rules/default.rules"
   if [[ -f "$codex_rules" ]]; then
     ok "Codex approval-rules baseline managed: ~/.codex/rules/default.rules (accumulated grants show as drift; apply resets to the vetted read-only baseline)"
@@ -536,9 +536,26 @@ report_codex_rules_probes() {
       for probe in "${outward_probes[@]}"; do
         # shellcheck disable=SC2086 # probes are fixed strings; word-splitting into tokens is intended
         if verdict="$(codex execpolicy check --rules "$codex_rules" $probe 2>/dev/null)"; then
-          if grep -Fq '"decision":"allow"' <<< "$verdict"; then
-            outward_allowed=$((outward_allowed + 1))
-            warn "outward/escalation probe auto-allowed by live Codex rules: '$probe' (revoke the covering allow rule or move it behind approval; apply resets to the baseline)"
+          # Only the effective, top-level decision is authoritative. A
+          # matched allow rule can coexist with a stronger forbidden rule.
+          # The engine omits decision when no rules match; all other unknown
+          # or malformed output is an incomplete scan, never a clean result.
+          if decision="$(yq -p=json -r -e '
+            select(tag == "!!map") |
+            select(.decision == "allow" or .decision == "prompt" or .decision == "forbidden" or
+              ((has("decision") | not) and (.matchedRules | tag) == "!!seq" and (.matchedRules | length) == 0)) |
+            .decision // "no-match"
+          ' <<< "$verdict" 2>/dev/null)"; then
+            case "$decision" in
+              allow)
+                outward_allowed=$((outward_allowed + 1))
+                warn "outward/escalation probe auto-allowed by live Codex rules: '$probe' (revoke the covering allow rule or move it behind approval; apply resets to the baseline)"
+                ;;
+              prompt|forbidden|no-match) ;;
+              *) probe_failures=$((probe_failures + 1)) ;;
+            esac
+          else
+            probe_failures=$((probe_failures + 1))
           fi
         else
           # rc!=0 = the engine could not evaluate (broken rules file, old
@@ -548,7 +565,7 @@ report_codex_rules_probes() {
         fi
       done
       if [[ "$probe_failures" -gt 0 ]]; then
-        warn "rules-semantics scan INCOMPLETE: $probe_failures of ${#outward_probes[@]} probes failed to evaluate (codex execpolicy error — broken rules file or incompatible codex?); do NOT read this as clean"
+        warn "rules-semantics scan INCOMPLETE: $probe_failures of ${#outward_probes[@]} probes failed to evaluate (codex execpolicy error or invalid result — broken rules file or incompatible codex?); do NOT read this as clean"
       elif [[ "$outward_allowed" -eq 0 ]]; then
         ok "no outward/escalation probe is auto-allowed by the live Codex rules (${#outward_probes[@]} probes via codex execpolicy; read-only baseline holding)"
       fi

--- a/scripts/test-doctor.sh
+++ b/scripts/test-doctor.sh
@@ -785,6 +785,10 @@ shift 2
 probe="$*"
 [ -n "${CODEX_FAKE_LOG:-}" ] && printf '%s\n' "$probe" >> "$CODEX_FAKE_LOG"
 [ "${CODEX_FAKE_MODE:-}" = "fail" ] && exit 1
+if [ -n "${CODEX_FAKE_RESULT:-}" ]; then
+  cat "$CODEX_FAKE_RESULT"
+  exit 0
+fi
 case ",${CODEX_FAKE_ALLOWS:-}," in
   *",$probe,"*) printf '{"matchedRules":[{"x":1}],"decision":"allow"}\n' ;;
   *)            printf '{"matchedRules":[]}\n' ;;
@@ -901,6 +905,54 @@ else
   fail "test failed: doctor must stay exit 0 (probe-evaluation failure)"
   status=1
 fi
+# AIP-4) Interpret the effective decision, not a nested rule match (#210).
+# Invalid JSON and unknown result shapes must remain report-only INCOMPLETE.
+aip_result="$fixture_home/.codex-result"
+for aip_case in forbidden prompt pretty-allow malformed empty unknown missing null-decision non-object; do
+  case "$aip_case" in
+    forbidden|prompt)
+      printf '{"decision":"%s","matchedRules":[{"decision":"allow"}]}\n' "$aip_case" > "$aip_result"
+      aip_expected="clean"
+      ;;
+    pretty-allow)
+      printf '{\n  "decision": "allow",\n  "matchedRules": []\n}\n' > "$aip_result"
+      aip_expected="allow"
+      ;;
+    *)
+      case "$aip_case" in
+        malformed) printf '{CANARY_INVALID_RESULT' > "$aip_result" ;;
+        empty) : > "$aip_result" ;;
+        unknown) printf '{"decision":"CANARY_UNKNOWN_RESULT","matchedRules":[]}' > "$aip_result" ;;
+        missing) printf '{}' > "$aip_result" ;;
+        null-decision) printf '{"decision":null,"matchedRules":[]}' > "$aip_result" ;;
+        non-object) printf '[{"decision":"allow"}]' > "$aip_result" ;;
+      esac
+      aip_expected="incomplete"
+      ;;
+  esac
+  if aip_out="$(HOME="$fixture_home" PATH="$codex_fakebin:$PATH" \
+      CODEX_FAKE_RESULT="$aip_result" "$DOTFILES_ROOT/scripts/doctor.sh" personal 2>&1)"; then
+    aip_actual="unexpected"
+    if grep -Fq "rules-semantics scan INCOMPLETE" <<< "$aip_out"; then
+      aip_actual="incomplete"
+    elif grep -Fq "outward/escalation probe auto-allowed" <<< "$aip_out"; then
+      aip_actual="allow"
+    elif grep -Fq "no outward/escalation probe is auto-allowed" <<< "$aip_out"; then
+      aip_actual="clean"
+    fi
+    if [[ "$aip_actual" == "$aip_expected" ]] && ! grep -Fq "CANARY_" <<< "$aip_out" \
+      && { [[ "$aip_expected" == "clean" ]] || ! grep -Fq "no outward/escalation probe is auto-allowed" <<< "$aip_out"; }; then
+      ok "test passed: Codex result $aip_case reports $aip_expected without leaking output"
+    else
+      fail "test failed: Codex result $aip_case expected $aip_expected, got $aip_actual"
+      status=1
+    fi
+  else
+    fail "test failed: doctor must stay exit 0 (Codex result $aip_case)"
+    status=1
+  fi
+done
+rm -f "$aip_result"
 rm -rf "$fixture_home/.codex/rules" "$fixture_home/.codex/config.toml" \
   "$fixture_home/real-project" "$codex_fakebin" "$aip_probe_log"
 


### PR DESCRIPTION
## 変更内容

Codex rules の最終判定が `forbidden` / `prompt` でも、内部の一致ルールに `allow` があると doctor が自動許可と誤報していました。JSON のトップレベル判定を読み、最終判定だけで警告します。

no-match の既知の形式は正常として扱い、壊れた JSON・未知の判定・不正な結果形式は `INCOMPLETE` を報告します。doctor の report-only / exit 0 と、rules や結果の任意文字列を出力しない契約を維持します。

Closes #210

## 検証

- `test-doctor.sh` 全件成功。nested allow と最終 forbidden/prompt、整形済み allow、壊れた/空/未知/欠落/null/非 object 結果の回帰テストを追加。
- shellcheck、変更 script の個別構文検査、`git diff --check` が成功。
- GitHub CI validate / render passed.
- Claude (`claude -p`) cross-review and follow-up: pass, must 0 / should 0 / nit 1, verified head `e865cb57`.
- Actual codex-cli 0.153.2 with an empty temporary rules file returned `{"matchedRules":[]}` (exit 0). A second fixture with `git` allow and `git push` forbidden returned top-level `forbidden` while retaining nested `allow`. No probed command was executed. This resolved the initial request for actual-engine output evidence.
- Local and CI yq v4.53.3 both support the remaining nonblocking `-r` flag nit.

検証は fixture HOME と隔離した PATH で実行し、実環境の設定は変更していません。
