### PR TITLE
fix(backup): manifest 検証と復元時の元ファイル保護を強化する

### DIFF
--- a/.chezmoidata/backup-paths.yaml
+++ b/.chezmoidata/backup-paths.yaml
@@ -11,7 +11,8 @@
 # Each entry:
 #   path      home-relative path (required). A leading "/" or any ".." is
 #             rejected, as are glob metacharacters (* ? [); the backup
-#             captures exactly these paths, never a pattern.
+#             captures exactly these paths, never a pattern. Paths must be
+#             canonical: no "." component, repeated/trailing "/", or control characters.
 #   type      file | dir (optional). Declares what the path is expected to
 #             be so the tooling can validate and restore it correctly.
 #   category  free-form public-safe label (optional), e.g. shell / ssh.

--- a/docs/private-backup.md
+++ b/docs/private-backup.md
@@ -39,7 +39,7 @@ public な dotfiles git には置けない **private な設定**(`.local` 上書
 
 | field | 必須 | 内容 |
 | --- | --- | --- |
-| `path` | ✓ | home-relative パス。先頭 `/`・`..`・glob メタ文字(`* ? [`)は禁止。`path` を最後に持つ行形式なので path 中の `|` も曖昧にならない |
+| `path` | ✓ | canonical な home-relative パス。先頭 `/`・`..`・`.` component・重複 `/`・末尾 `/`・制御文字・glob メタ文字(`* ? [`)は禁止。`path` を最後に持つ行形式なので path 中の `|` も曖昧にならない |
 | `type` | | `file` / `dir`(期待する種別)|
 | `category` | | public-safe な自由ラベル(例 `shell` / `ssh`)|
 
@@ -73,10 +73,14 @@ private-backup.sh restore --in PATH (--identity PATH | --identity-command CMD) \
   TTY が無い(cron / CI など無人実行)場合は明示エラーで **exit 非 0**、対話で decline
   した場合も **exit 非 0**(アーカイブを書かなかった実行は成功を返さない。無人実行での
   バックアップ欠落が exit 0 で監視をすり抜けるのを防ぐ)。無人実行は `--yes` を明示する。
+- verify / restore は schema version 1 と metadata の型、非空の files 配列、各 path の安全性・一意性、
+  各 file の SHA-256・mode・size、archive 内 file 集合との一致を検証する。JSON parse や列挙 query が
+  失敗した場合も拒否し、restore は検証済みの path 一覧だけを使用する。
 - restore は verify を通った後のみ復元する(整合 NG なら拒否)。**既定 dry-run**(何も書かない)、
   `--apply` で実行。既存ファイルは上書き前に **timestamp 付き退避 dir**(`~/.local/state/dotfiles/
   restore-backup-<ts>/`)へ move。`--skip-existing` で既存は触らない。**symlink 化した親ディレクトリ
-  経由の書き込みを拒否**して HOME 外への escape を防ぐ。verify と同じ展開前 member 検証を共有。
+  経由の書き込みを拒否**して HOME 外への escape を防ぐ。退避先が既に存在する場合も上書きせず拒否する。
+  verify と同じ展開前 member 検証を共有。
 
 ## 段階
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -648,13 +648,12 @@ backup_paths() {
 }
 
 # Single source of truth for the mechanical safety rules a backup-paths
-# entry must satisfy: a non-empty, home-relative path with no ".." segment
-# and no glob metacharacters (* ? [). Returns 0 if safe, 1 otherwise;
+# entry must satisfy: a non-empty, canonical home-relative path with no "..",
+# control characters, or glob metacharacters (* ? [). Returns 0 if safe, 1 otherwise;
 # prints nothing (the caller decides how to report). Shared by
 # validate-policy.sh (catalog validation) and the private-backup tooling
 # (runtime target resolution) so the rule cannot drift between them. The
-# private-backup runtime additionally rejects control characters and
-# symlinks; those are runtime concerns, not catalog-shape rules.
+# private-backup runtime additionally rejects symlinks.
 backup_path_is_safe() {
   local path="$1"
   [[ -n "$path" ]] || return 1
@@ -662,6 +661,7 @@ backup_path_is_safe() {
     /*) return 1 ;;
     *..*) return 1 ;;
     *[*?[]*) return 1 ;;
+    . | ./* | */./* | */. | *//* | */ | *[[:cntrl:]]*) return 1 ;;
   esac
   return 0
 }

--- a/scripts/private-backup.sh
+++ b/scripts/private-backup.sh
@@ -52,7 +52,7 @@ EOF
 }
 
 sha256_of() {
-  shasum -a 256 "$1" | awk '{print $1}'
+  shasum -a 256 < "$1" | awk '{print $1}'
 }
 
 # Whether a single tar member NAME is allowed in a private-backup archive.
@@ -248,13 +248,6 @@ cmd_backup() {
       skipped=$((skipped + 1))
       continue
     fi
-    case "$path" in
-      *[[:cntrl:]]*)
-        warn "skip path with control characters (origin=$origin)"
-        skipped=$((skipped + 1))
-        continue
-        ;;
-    esac
     if grep -Fxq -- "$path" "$seen_paths"; then
       continue
     fi
@@ -295,13 +288,6 @@ cmd_backup() {
           skipped=$((skipped + 1))
           continue
         fi
-        case "$rel" in
-          *[[:cntrl:]]*)
-            warn "skip captured path with control characters under $path"
-            skipped=$((skipped + 1))
-            continue
-            ;;
-        esac
         # Deduplicate against paths already captured (a declared file inside
         # this dir, or an overlapping dir declaration) so the manifest never
         # lists the same file twice; restore would otherwise process it
@@ -456,71 +442,112 @@ decrypt_and_extract() {
   return 0
 }
 
-# Check the extracted archive against its manifest: every listed file is
-# present with a matching sha256 and mode, is a regular file (no symlink),
-# carries a safe home-relative path, and no file exists beyond the
-# manifest. Args: extract workdir. Returns 0 if the archive is intact.
-# Inspects only the extracted copy; never writes into $HOME.
+# Validate types before emitting TSV: missing/empty fields and embedded
+# separators must not make read collapse columns or silently skip entries.
+# Every query is checked explicitly because restore calls this under ||,
+# where Bash disables errexit throughout the function.
 check_manifest() {
   local extract="$1" workdir="$2"
   local manifest="$extract/manifest.json"
   [[ -f "$manifest" ]] || { fail "archive has no manifest.json"; return 1; }
-  local status=0
-  # Read sha256+mode+path as TSV in one pass: tab-delimited, so a tab in a
-  # path would split it, but tabs (control chars) are rejected below, and
-  # path is the last field so other content stays intact.
-  local manifest_paths="$workdir/manifest_paths"
-  yq -p=json -o=tsv '.files[].path' "$manifest" > "$manifest_paths"
-  local count=0 path sha mode actual actual_mode f
-  while IFS=$'\t' read -r sha mode path; do
-    [[ -z "$path" ]] && continue
-    count=$((count + 1))
+  if ! yq -e -p=json '
+    (tag == "!!map") and
+    ((.schema_version | tag) == "!!int") and (.schema_version == 1) and
+    ((.tool | tag) == "!!str") and (.tool == "private-backup.sh") and
+    ((.tool_version | tag) == "!!str") and (.tool_version != "") and
+    ((.created_at | tag) == "!!str") and (.created_at != "") and
+    ((.entries | tag) == "!!seq") and
+    ([.entries[] | ((tag == "!!map") and
+      ((.path | tag) == "!!str") and (.path != "") and
+      (.path | test("^[^\\x00-\\x1f\\x7f]+$")) and
+      ((.type | tag) == "!!str") and
+      (.type == "" or .type == "file" or .type == "dir") and
+      ((.category | tag) == "!!str") and
+      ((.origin | tag) == "!!str") and (.origin == "baseline" or .origin == "local")
+    )] | all) and
+    ((.files | tag) == "!!seq") and ((.files | length) > 0) and
+    ([.files[] | ((tag == "!!map") and
+      ((.path | tag) == "!!str") and (.path != "") and
+      (.path | test("^[^\\x00-\\x1f\\x7f]+$")) and
+      ((.sha256 | tag) == "!!str") and (.sha256 | test("^[0-9a-f]{64}$")) and
+      ((.mode | tag) == "!!str") and (.mode | test("^[0-7]{1,4}$")) and
+      ((.size | tag) == "!!int") and (.size >= 0)
+    )] | all)
+  ' "$manifest" >/dev/null 2>&1; then
+    fail "invalid manifest schema or file metadata"
+    return 1
+  fi
+
+  local manifest_paths="$workdir/manifest_paths" rows="$workdir/manifest_rows"
+  local entry_paths="$workdir/entry_paths" archive_files="$workdir/archive_files"
+  if ! yq -p=json -o=tsv '.entries[].path' "$manifest" > "$entry_paths" \
+    || ! yq -p=json -o=tsv '.files[] | [.sha256, .mode, .size, .path]' "$manifest" > "$rows"; then
+    fail "could not read manifest entries"
+    return 1
+  fi
+  : > "$manifest_paths" || return 1
+  local path sha mode size actual actual_mode actual_size f count=0 status=0
+  while IFS= read -r path; do
     if ! backup_path_is_safe "$path"; then
-      fail "manifest path is unsafe: $path"
-      status=1
-      continue
+      fail "manifest entry path is unsafe or non-canonical"
+      return 1
     fi
-    case "$path" in
-      *[[:cntrl:]]*) fail "manifest path has control characters"; status=1; continue ;;
-    esac
+  done < "$entry_paths"
+
+  while IFS=$'\t' read -r sha mode size path; do
+    if ! backup_path_is_safe "$path"; then
+      fail "manifest path is unsafe or non-canonical"
+      return 1
+    fi
+    if grep -Fxq -- "$path" "$manifest_paths"; then
+      fail "duplicate manifest path: $path"
+      return 1
+    fi
+    printf '%s\n' "$path" >> "$manifest_paths" || return 1
+    count=$((count + 1))
     f="$extract/files/$path"
-    if [[ -L "$f" ]]; then
-      fail "archived entry is a symlink (rejected): $path"
+    if [[ -L "$f" || ! -f "$f" ]]; then
+      fail "manifest file missing or not regular: $path"
       status=1
       continue
     fi
-    if [[ ! -f "$f" ]]; then
-      fail "manifest file missing from archive: $path"
-      status=1
-      continue
-    fi
-    actual="$(sha256_of "$f")"
+    actual="$(sha256_of "$f")" || return 1
     if [[ "$actual" != "$sha" ]]; then
       fail "checksum mismatch: $path"
       status=1
       continue
     fi
-    actual_mode="$(file_mode "$f")"
+    actual_mode="$(file_mode "$f")" || return 1
     if [[ "$actual_mode" != "$mode" ]]; then
       fail "mode mismatch: $path (manifest $mode, archive $actual_mode)"
       status=1
       continue
     fi
-  done < <(yq -p=json -o=tsv '.files[] | [.sha256, .mode, .path]' "$manifest")
-
-  # No extra files beyond the manifest's declared files (manifest.json and
-  # backup-paths.local live outside files/, so they are not flagged).
-  local extra=0 rel
-  while IFS= read -r rel; do
-    [[ -z "$rel" ]] && continue
-    if ! grep -Fxq -- "$rel" "$manifest_paths"; then
-      fail "archive file not in manifest: $rel"
-      extra=$((extra + 1))
+    actual_size="$(wc -c < "$f" | tr -d ' ')" || return 1
+    if [[ "$actual_size" != "$size" ]]; then
+      fail "size mismatch: $path"
       status=1
     fi
-  done < <(cd "$extract/files" 2>/dev/null && find . -type f 2>/dev/null | sed 's#^\./##')
+  done < "$rows"
+  if [[ "$count" -eq 0 ]]; then
+    fail "manifest contains no files"
+    return 1
+  fi
 
-  if [[ "$extra" -eq 0 && "$status" -eq 0 ]]; then
+  if ! (cd "$extract/files" && find . -type f -print0) > "$archive_files" 2>/dev/null; then
+    fail "could not enumerate archive files"
+    return 1
+  fi
+  local rel
+  while IFS= read -r -d '' rel; do
+    rel="${rel#./}"
+    if ! backup_path_is_safe "$rel" || ! grep -Fxq -- "$rel" "$manifest_paths"; then
+      fail "archive file not in manifest or unsafe"
+      status=1
+    fi
+  done < "$archive_files"
+
+  if [[ "$status" -eq 0 ]]; then
     ok "verified $count file(s); manifest and archive agree"
   else
     fail "verification failed"
@@ -642,7 +669,6 @@ cmd_restore() {
     return 1
   }
 
-  local manifest="$extract/manifest.json"
   local label="dry-run"
   [[ "$apply" -eq 1 ]] && label="apply"
   section "private-backup: restore ($label)"
@@ -673,9 +699,6 @@ cmd_restore() {
     if ! backup_path_is_safe "$path"; then
       warn "skip unsafe path: $path"; skipped=$((skipped + 1)); status=1; continue
     fi
-    case "$path" in
-      *[[:cntrl:]]*) warn "skip control-char path"; skipped=$((skipped + 1)); status=1; continue ;;
-    esac
     f="$extract/files/$path"
     target="$target_home/$path"
     # Refuse to write through a symlinked parent (escape prevention).
@@ -691,8 +714,17 @@ cmd_restore() {
       fi
       if [[ "$apply" -eq 1 ]]; then
         mkdir -p "$(dirname "$backup_dir/$path")"
-        # mv moves a symlink target as the link itself (does not follow).
-        mv "$target" "$backup_dir/$path"
+        if [[ -e "$backup_dir/$path" || -L "$backup_dir/$path" ]]; then
+          fail "refusing to overwrite a displaced file: $path"
+          return 1
+        fi
+        # -n preserves a displaced file even if another target aliases it on
+        # a case-insensitive filesystem; a skipped move must abort the copy.
+        mv -n "$target" "$backup_dir/$path"
+        if [[ -e "$target" || -L "$target" ]]; then
+          fail "could not displace existing target: $path"
+          return 1
+        fi
         mkdir -p "$(dirname "$target")"
         cp -p "$f" "$target"
       else
@@ -708,7 +740,7 @@ cmd_restore() {
       fi
       created=$((created + 1))
     fi
-  done < <(yq -p=json -o=tsv '.files[].path' "$manifest")
+  done < "$workdir/manifest_paths"
 
   if [[ "$apply" -eq 1 ]]; then
     ok "restored: $created created, $overwritten overwritten, $skipped skipped"

--- a/scripts/test-private-backup.sh
+++ b/scripts/test-private-backup.sh
@@ -116,7 +116,7 @@ printf 'real content\n' > "$bad/files/.zshrc.local"
 TS="2026-01-01T00:00:00Z" yq -n -o=json '{
   "schema_version": 1, "tool": "private-backup.sh", "tool_version": "1",
   "created_at": strenv(TS), "entries": [],
-  "files": [{"path": ".zshrc.local", "mode": "600", "size": 13, "sha256": "deadbeef"}]
+  "files": [{"path": ".zshrc.local", "mode": "600", "size": 13, "sha256": "0000000000000000000000000000000000000000000000000000000000000000"}]
 }' > "$bad/manifest.json"
 make_archive "$bad" "$fixture_home/out/badsum.age"
 # Capture then grep: verify exits non-zero on these negative cases, which
@@ -456,6 +456,180 @@ else
   printf '%s\n' "$unr_out" >&2
   miss "unreadable files should be skipped without aborting, got rc=$unr_rc"
 fi
+
+# 23. Alias declarations must never make restore displace a target twice.
+alias_home="$fixture_home/alias-home"
+alias_dst="$fixture_home/alias-dst"
+mkdir -p "$alias_home/.config/dotfiles" "$alias_home/.ssh" "$alias_dst"
+printf 'restored\n' > "$alias_home/.zshrc.local"
+printf 'ssh restored\n' > "$alias_home/.ssh/config.local"
+printf 'original\n' > "$alias_dst/.zshrc.local"
+cat > "$alias_home/.config/dotfiles/backup-paths.local" <<'YAML'
+backup_paths:
+  - { path: ./.zshrc.local, type: file }
+  - { path: .ssh//config.local, type: file }
+  - { path: .ssh/, type: dir }
+YAML
+if HOME="$alias_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+  backup --out "$alias_home/a.age" --recipient "$recipient" --yes >/dev/null 2>&1 \
+  && run restore --in "$alias_home/a.age" --identity "$fixture_home/keys/id.txt" \
+    --target-home "$alias_dst" --apply >/dev/null 2>&1; then
+  displaced="$(find "$alias_dst/.local/state/dotfiles" -name .zshrc.local -type f)"
+  if [[ -f "$displaced" ]] && [[ "$(cat "$displaced")" == "original" ]] \
+    && [[ "$(cat "$alias_dst/.zshrc.local")" == "restored" ]]; then
+    pass "alias declarations cannot overwrite the original displaced file"
+  else
+    miss "alias declarations lost the original displaced file"
+  fi
+else
+  miss "backup/restore failed with a canonical baseline and alias supplement"
+fi
+
+# Hash the content, not shasum's escaped filename output (a backslash in a
+# filename prefixes the printed digest with a backslash unless stdin is used).
+printf 'odd name\n' > "$alias_home/space | back\\slash"
+cat > "$alias_home/.config/dotfiles/backup-paths.local" <<'YAML'
+backup_paths:
+  - { path: 'space | back\slash', type: file }
+YAML
+if HOME="$alias_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+  backup --out "$alias_home/odd.age" --recipient "$recipient" --yes >/dev/null 2>&1 \
+  && run restore --in "$alias_home/odd.age" --identity "$fixture_home/keys/id.txt" \
+    --target-home "$alias_dst" --apply >/dev/null 2>&1 \
+  && cmp -s "$alias_home/space | back\\slash" "$alias_dst/space | back\\slash"; then
+  pass "canonical path with spaces, pipe and backslash round-trips"
+else
+  miss "canonical odd filename failed backup/restore"
+fi
+
+# Distinct canonical names can still collide on the restore filesystem.
+# Preserve the displaced original even when case folding makes the second
+# target resolve to the first; case-sensitive filesystems restore both names.
+case_stage="$fixture_home/case-stage"
+case_dst="$fixture_home/case-dst"
+mkdir -p "$case_stage/files" "$case_dst"
+printf 'restored\n' > "$case_stage/files/lower"
+printf 'restored\n' > "$case_stage/files/LOWER"
+printf 'original\n' > "$case_dst/lower"
+case_folded=0
+[[ -e "$case_dst/LOWER" ]] && case_folded=1
+case_hash="$(shasum -a 256 "$case_stage/files/lower" | awk '{print $1}')"
+H="$case_hash" M="$(file_mode "$case_stage/files/lower")" yq -n -o=json '{
+  "schema_version": 1, "tool": "private-backup.sh", "tool_version": "1",
+  "created_at": "2026-01-01T00:00:00Z", "entries": [],
+  "files": [
+    {"path": "lower", "mode": strenv(M), "size": 9, "sha256": strenv(H)},
+    {"path": "LOWER", "mode": strenv(M), "size": 9, "sha256": strenv(H)}
+  ]
+}' > "$case_stage/manifest.json"
+make_archive "$case_stage" "$fixture_home/out/case.age"
+case_rc=0
+run restore --in "$fixture_home/out/case.age" --identity "$fixture_home/keys/id.txt" \
+  --target-home "$case_dst" --apply >/dev/null 2>&1 || case_rc=$?
+case_displaced="$(find "$case_dst/.local/state/dotfiles" -name lower -type f)"
+if [[ -f "$case_displaced" && "$(cat "$case_displaced")" == "original" ]] \
+  && { [[ "$case_folded" -eq 1 && "$case_rc" -ne 0 ]] \
+    || [[ "$case_folded" -eq 0 && "$case_rc" -eq 0 && "$(cat "$case_dst/LOWER")" == "restored" ]]; }; then
+  pass "case-distinct restore paths preserve the displaced original on this filesystem"
+else
+  miss "case-distinct restore paths lost the original or returned the wrong status"
+fi
+
+# 24. Exercise all three consumers with a valid first payload followed by
+#     malformed metadata: no rejected archive may reach target mutations.
+manifest_base="$fixture_home/manifest-base"
+manifest_stage="$fixture_home/manifest-stage"
+manifest_dst="$fixture_home/manifest-dst"
+mkdir -p "$manifest_base" "$manifest_stage" "$manifest_dst"
+age -d -i "$fixture_home/keys/id.txt" "$archive" | tar -xpf - -C "$manifest_base"
+printf 'original\n' > "$manifest_dst/.zshrc.local"
+
+assert_manifest_rejected() {
+  local label="$1" bad_archive="$fixture_home/out/manifest-$1.age" rejected=1
+  make_archive "$manifest_stage" "$bad_archive"
+  if run verify --in "$bad_archive" --identity "$fixture_home/keys/id.txt" >/dev/null 2>&1; then
+    rejected=0
+  fi
+  if run restore --in "$bad_archive" --identity "$fixture_home/keys/id.txt" \
+    --target-home "$manifest_dst" >/dev/null 2>&1; then
+    rejected=0
+  fi
+  if run restore --in "$bad_archive" --identity "$fixture_home/keys/id.txt" \
+    --target-home "$manifest_dst" --apply >/dev/null 2>&1; then
+    rejected=0
+  fi
+  if [[ "$rejected" -eq 1 && "$(cat "$manifest_dst/.zshrc.local")" == "original" \
+    && ! -e "$manifest_dst/.ssh" && ! -e "$manifest_dst/.local" ]]; then
+    pass "manifest $label rejected by verify/dry-run/apply before any target write"
+  else
+    miss "manifest $label was accepted or changed the restore target"
+  fi
+}
+
+cp -R "$manifest_base/." "$manifest_stage/"
+printf '{invalid' > "$manifest_stage/manifest.json"
+assert_manifest_rejected malformed-json
+while IFS='|' read -r label mutation; do
+  yq -p=json -o=json "$mutation" "$manifest_base/manifest.json" > "$manifest_stage/manifest.json"
+  assert_manifest_rejected "$label"
+done <<'CASES'
+missing-schema|del(.schema_version)
+unknown-schema|.schema_version = 999
+string-schema|.schema_version = "1"
+wrong-tool-type|.tool = []
+wrong-version-type|.tool_version = 1
+wrong-date-type|.created_at = 1
+missing-entries|del(.entries)
+wrong-entries-type|.entries = {}
+wrong-entry-type|.entries[0].type = true
+wrong-category-type|.entries[0].category = []
+wrong-origin|.entries[0].origin = "unknown"
+entry-path-type|.entries[0].path = 5
+entry-path-control|.entries[0].path = "bad\npath"
+missing-files|del(.files)
+wrong-files-type|.files = {}
+empty-files|.files = []
+null-file|.files += [null]
+missing-last-path|del(.files[-1].path)
+empty-last-path|.files[-1].path = ""
+wrong-last-path-type|.files[-1].path = []
+path-control|.files[-1].path = "bad\tpath"
+missing-hash|del(.files[-1].sha256)
+wrong-hash-type|.files[-1].sha256 = []
+invalid-hash|.files[-1].sha256 = "bad"
+missing-mode|del(.files[-1].mode)
+numeric-mode|.files[-1].mode = 644
+invalid-mode|.files[-1].mode = "888"
+missing-size|del(.files[-1].size)
+string-size|.files[-1].size = "5"
+negative-size|.files[-1].size = -1
+fractional-size|.files[-1].size = 1.5
+size-mismatch|.files[-1].size += 1
+duplicate|.files += [.files[0]]
+path-alias|.files += [.files[0]] | .files[-1].path = "./.zshrc.local"
+CASES
+
+# A query process that emits valid rows but fails must not be trusted. These
+# failures happen after schema validation, covering both checked row queries.
+query_fakebin="$fixture_home/queryfake"
+mkdir -p "$query_fakebin"
+real_yq="$(command -v yq)"
+cat > "$query_fakebin/yq" <<'SH'
+#!/bin/sh
+"$REAL_YQ" "$@"
+rc=$?
+for arg in "$@"; do
+  if [ "$arg" = "$FAIL_YQ_QUERY" ]; then exit 7; fi
+done
+exit "$rc"
+SH
+chmod +x "$query_fakebin/yq"
+cp "$manifest_base/manifest.json" "$manifest_stage/manifest.json"
+for query in '.entries[].path' '.files[] | [.sha256, .mode, .size, .path]'; do
+  if [[ "$query" == '.entries[].path' ]]; then label="entry-query-failure"; else label="file-query-failure"; fi
+  REAL_YQ="$real_yq" FAIL_YQ_QUERY="$query" PATH="$query_fakebin:$PATH" \
+    assert_manifest_rejected "$label"
+done
 
 if [[ "$status" -eq 0 ]]; then
   ok "private-backup tests passed"


### PR DESCRIPTION
## 変更内容

同じ復元先を指す別表記の path を復元すると、退避した元ファイルを上書きして失う問題を修正します。backup path を正規形に限定し、manifest の重複を拒否、退避先への上書きも防止します。

不正 JSON や必須 metadata の欠落が verify / restore で見逃される問題も修正しました。schema、型、hash、mode、size、path の一意性、アーカイブとの file 集合の一致を確認し、parser の途中失敗を明示的に検出します。restore は検証済みの一覧だけを使用します。通常の空白・pipe・backslash を含む filename は維持します。

Closes #203
Closes #204

## 検証

- `test-private-backup.sh`: 67 項目成功。異常 manifest を verify / dry-run / apply の全入口で拒否し、復元先が変わらないこと、alias・case folding で退避が失われないことを確認。
- `test-policy.sh`、`test-secrets-gate.sh`、shellcheck、個別 Bash 構文検査、`git diff --check` が成功。
- GitHub CI validate / render passed.
- Claude (`claude -p`) independent review: pass, must 0 / should 1 / nit 3 at head `2af5d69d`. The should finding is explicitly preexisting and outside this PR: quoted / space-prefixed filenames. It is tracked in #220 with a prepared follow-up fix. No introduced regression or merge-blocking finding was reported.

## 互換性

現在の producer が生成する正常な schema 1 archive は復元可能です。未知 schema、不正 metadata、危険な path を持つ archive は明示的に拒否します。検証は一時 HOME と使い捨て鍵のみで行い、実ユーザーのアーカイブは変更していません。
