### PR TITLE
fix(backup): 引用符や先頭空白を含む filename を正確に復元する

### DIFF
--- a/scripts/private-backup.sh
+++ b/scripts/private-backup.sh
@@ -444,6 +444,8 @@ decrypt_and_extract() {
 
 # Validate types before emitting TSV: missing/empty fields and embedded
 # separators must not make read collapse columns or silently skip entries.
+# Emit joined scalars: the TSV array encoder adds CSV quotes that Bash read
+# does not decode (e.g. filenames with double quotes or leading spaces).
 # Every query is checked explicitly because restore calls this under ||,
 # where Bash disables errexit throughout the function.
 check_manifest() {
@@ -481,7 +483,7 @@ check_manifest() {
   local manifest_paths="$workdir/manifest_paths" rows="$workdir/manifest_rows"
   local entry_paths="$workdir/entry_paths" archive_files="$workdir/archive_files"
   if ! yq -p=json -o=tsv '.entries[].path' "$manifest" > "$entry_paths" \
-    || ! yq -p=json -o=tsv '.files[] | [.sha256, .mode, .size, .path]' "$manifest" > "$rows"; then
+    || ! yq -p=json -o=tsv '.files[] | [.sha256, .mode, (.size | tostring), .path] | join("\t")' "$manifest" > "$rows"; then
     fail "could not read manifest entries"
     return 1
   fi

--- a/scripts/test-private-backup.sh
+++ b/scripts/test-private-backup.sh
@@ -489,22 +489,24 @@ else
   miss "backup/restore failed with a canonical baseline and alias supplement"
 fi
 
-# Hash the content, not shasum's escaped filename output (a backslash in a
-# filename prefixes the printed digest with a backslash unless stdin is used).
-printf 'odd name\n' > "$alias_home/space | back\\slash"
-cat > "$alias_home/.config/dotfiles/backup-paths.local" <<'YAML'
-backup_paths:
-  - { path: 'space | back\slash', type: file }
-YAML
-if HOME="$alias_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
-  backup --out "$alias_home/odd.age" --recipient "$recipient" --yes >/dev/null 2>&1 \
-  && run restore --in "$alias_home/odd.age" --identity "$fixture_home/keys/id.txt" \
-    --target-home "$alias_dst" --apply >/dev/null 2>&1 \
-  && cmp -s "$alias_home/space | back\\slash" "$alias_dst/space | back\\slash"; then
-  pass "canonical path with spaces, pipe and backslash round-trips"
-else
-  miss "canonical odd filename failed backup/restore"
-fi
+# Filename metacharacters must survive hashing and row serialization:
+# shasum escapes backslashes, while TSV array output quotes double quotes
+# and leading whitespace. All are valid canonical filename characters.
+for odd_name in 'space | back\slash' 'double"quote' ' leading-space'; do
+  printf 'odd name\n' > "$alias_home/$odd_name"
+  P="$odd_name" yq -n '{"backup_paths": [{"path": strenv(P), "type": "file"}]}' \
+    > "$alias_home/.config/dotfiles/backup-paths.local"
+  if HOME="$alias_home" PATH="$fixture_home/fakebin:$PATH" "$PB" \
+    backup --out "$alias_home/odd.age" --recipient "$recipient" --yes >/dev/null 2>&1 \
+    && run verify --in "$alias_home/odd.age" --identity "$fixture_home/keys/id.txt" >/dev/null 2>&1 \
+    && run restore --in "$alias_home/odd.age" --identity "$fixture_home/keys/id.txt" \
+      --target-home "$alias_dst" --apply >/dev/null 2>&1 \
+    && cmp -s "$alias_home/$odd_name" "$alias_dst/$odd_name"; then
+    pass "canonical filename round-trips exactly: $odd_name"
+  else
+    miss "canonical filename failed backup/verify/restore: $odd_name"
+  fi
+done
 
 # Distinct canonical names can still collide on the restore filesystem.
 # Preserve the displaced original even when case folding makes the second
@@ -629,7 +631,7 @@ exit "$rc"
 SH
 chmod +x "$query_fakebin/yq"
 cp "$manifest_base/manifest.json" "$manifest_stage/manifest.json"
-for query in '.entries[].path' '.files[] | [.sha256, .mode, .size, .path]'; do
+for query in '.entries[].path' '.files[] | [.sha256, .mode, (.size | tostring), .path] | join("\t")'; do
   if [[ "$query" == '.entries[].path' ]]; then label="entry-query-failure"; else label="file-query-failure"; fi
   REAL_YQ="$real_yq" FAIL_YQ_QUERY="$query" PATH="$query_fakebin:$PATH" \
     assert_manifest_rejected "$label"


### PR DESCRIPTION
## 変更内容

正当な filename にダブルクォートや先頭空白があると、backup が成功しても verify / restore が失敗していました。yq の配列 TSV 出力が追加する CSV の引用符を Bash `read` が path として扱うためです。

schema 検証済みの値を scalar のタブ連結で出力し、path を正確に引き継ぎます。制御文字拒否と query の途中失敗検知は維持します。

Closes #220

## 検証

- 旧実装では引用符・先頭空白の実 CLI round-trip が失敗することを確認。
- 修正後 `test-private-backup.sh` 69 項目成功。通常の空白、pipe、backslash を含む path も内容が完全一致。
- shellcheck、Bash 構文検査、`git diff --check` が成功。
- head `786a8759f6b5c2a264389d1e01cf0aaa1ee11ff6` の GitHub CI validate / render は SUCCESS。
- main と #221 / #222 / #223 を統合した一時 snapshot でも、system Bash 3.2.57 の inventory / secrets gate / private backup テストがすべて exit 0。

## 相互レビュー

2026-09-06 JST、`claude -p` で上記 head の独立レビューを実施。commit trailers により author=Codex / reviewer=Claude を確認。Claude は提示した差分・source・検証結果を読み、テスト自体は実行していません。

Review process verdict: **pass**。Finding summary: **must 0 / should 0 / nit 2**。

前回の CSV 引用符の指摘は根本修正済み。schema 検証と field の区切り、Bash の空白・backslash 保持、query 失敗の拒否を確認し、今回の回帰は見つかりませんでした。

非 blocking の提案は以下です。

- tab 区切りは yq の文字列 escape 処理に依存する。CI の固定版と round-trip テストで検証済みであり、今回の修正を妨げない。
- backup 作成時の staging 自己検証は任意の後続改善。今回の既知の restore 不能経路は解消済みで、この PR への追加は不要。

## 副作用と残リスク

検証は一時 fixture と使い捨て鍵のみ。実 HOME や既存 archive は変更していません。自己検証の導入方針は #224 で扱います。
