### PR TITLE
fix(policy): YAML boolean 型を検証と runtime gate で厳密に扱う

### DIFF
--- a/.chezmoitemplates/require-profile
+++ b/.chezmoitemplates/require-profile
@@ -7,3 +7,30 @@
 {{- if not (hasKey .profiles .profile) -}}
 {{-   fail (printf "unknown profile %q (known: %s)" .profile (keys .profiles | sortAlpha | join ", ")) -}}
 {{- end -}}
+{{- /* yq text output cannot distinguish false from "false". Check the
+       decoded types here too: direct chezmoi apply does not run the shell
+       validator, and a non-empty string would arm boolean-gated hooks. */ -}}
+{{- $caps := index (index .profiles .profile) "capabilities" -}}
+{{- range $name, $definition := .capabilities -}}
+{{-   if not (kindIs "bool" $definition.implemented) -}}
+{{-     fail (printf "capability registry: %s implemented must be a YAML boolean" $name) -}}
+{{-   end -}}
+{{-   if eq $definition.type "boolean" -}}
+{{-     if not (kindIs "bool" (index $caps $name)) -}}
+{{-       fail (printf "capability must be boolean: %s.%s (use unquoted true or false)" $.profile $name) -}}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}
+{{- range $moduleName, $module := .modules -}}
+{{-   if hasKey $module "requires" -}}
+{{-     range $name, $want := $module.requires -}}
+{{-       with index $.capabilities $name -}}
+{{-         if eq .type "boolean" -}}
+{{-           if not (kindIs "bool" $want) -}}
+{{-             fail (printf "module requires must be boolean: %s.%s (use unquoted true or false)" $moduleName $name) -}}
+{{-           end -}}
+{{-         end -}}
+{{-       end -}}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -26,6 +26,8 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 
 `.chezmoidata/*.yaml`(profiles / modules / capabilities.schema / packages / backup-paths)の読み取りは shell script 側では mikefarah/yq v4 で行う(chezmoi template 側は Go template が読む)。yq が無い・別 variant の場合は `require_yq` が fail closed する。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない(injection 防止)。
 
+boolean capability、module の boolean `requires:`、schema の `implemented:` は YAML の boolean 型のみを受理する。`true` / `false` は引用符を付けずに書く。文字列 `"true"` / `"false"`、数値、null は型エラーになる。`validate-policy.sh` に加え、直接の `chezmoi apply` / template 展開も共通 `require-profile` guard で検査するため、文字列 `"false"` を truthy とみなして hook を有効化しない。install / secret access の runtime gate も YAML の boolean `true` だけを許可する。enum の値は従来どおり文字列で指定する。
+
 `packages`(`.chezmoidata/packages.yaml`)は software catalog。各 entry の `source`(brew_formula / brew_cask / npm_global / go_install / mas / manual)と canonical id を宣言する。`validate-policy.sh` が source の妥当性・go_install/mas の pkg 必須・name 重複を fail closed で検査する。
 
 実機との drift は `doctor.sh` の `software catalog` section(`report_catalog_drift`)が **report-only**(常に exit 0、欠けている package manager は skip)で報告する。検出は 3 種:

--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -26,7 +26,7 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 
 `.chezmoidata/*.yaml`(profiles / modules / capabilities.schema / packages / backup-paths)の読み取りは shell script 側では mikefarah/yq v4 で行う(chezmoi template 側は Go template が読む)。yq が無い・別 variant の場合は `require_yq` が fail closed する。profile / module / capability 名は `strenv()` 経由で渡し、yq 式へ展開しない(injection 防止)。
 
-boolean capability、module の boolean `requires:`、schema の `implemented:` は YAML の boolean 型のみを受理する。`true` / `false` は引用符を付けずに書く。文字列 `"true"` / `"false"`、数値、null は型エラーになる。`validate-policy.sh` に加え、直接の `chezmoi apply` / template 展開も共通 `require-profile` guard で検査するため、文字列 `"false"` を truthy とみなして hook を有効化しない。install / secret access の runtime gate も YAML の boolean `true` だけを許可する。enum の値は従来どおり文字列で指定する。
+boolean capability、module の boolean `requires:`、schema の `implemented:` は YAML の boolean 型を、引用符なしの小文字 `true` / `false` で指定する。`validate-policy.sh` は型と綴りを検査し、文字列 `"true"` / `"false"`、数値、null に加え、`True` / `FALSE` などの大文字を含む綴りも拒否する。直接の `chezmoi apply` / template 展開は共通 `require-profile` guard でデコード後の型を検査するため、文字列 `"false"` を truthy とみなして hook を有効化しない。install / secret access の runtime gate も YAML の小文字 boolean `true` だけを許可する。enum の値は従来どおり文字列で指定する。
 
 `packages`(`.chezmoidata/packages.yaml`)は software catalog。各 entry の `source`(brew_formula / brew_cask / npm_global / go_install / mas / manual)と canonical id を宣言する。`validate-policy.sh` が source の妥当性・go_install/mas の pkg 必須・name 重複を fail closed で検査する。
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -140,6 +140,16 @@ capability_value() {
     yq '.profiles[strenv(p)].capabilities // {} | select(has(strenv(c))) | .[strenv(c)]' "$PROFILES_FILE"
 }
 
+# Runtime permission gates do not necessarily run validate-policy first.
+# Compare the YAML type and value together so a quoted "true" grants nothing.
+profile_capability_is_true() {
+  local profile="$1" capability="$2" granted
+  granted="$(p="$profile" c="$capability" yq \
+    '.profiles[strenv(p)].capabilities[strenv(c)] | ((tag == "!!bool") and (. == true))' \
+    "$PROFILES_FILE")" || return 1
+  [[ "$granted" == "true" ]]
+}
+
 known_modules() {
   yq '.modules // {} | keys | .[]' "$MODULES_FILE"
 }
@@ -329,7 +339,7 @@ profile_installs_source() {
   local profile="$1" source="$2" cap
   cap="$(source_install_capability "$source")" || return 1
   profile_exists "$profile" || return 1
-  [[ "$(capability_value "$profile" "$cap")" == "true" ]]
+  profile_capability_is_true "$profile" "$cap"
 }
 
 # Report drift between the declared catalog (packages.yaml) and what is
@@ -719,7 +729,7 @@ resolve_runtime_profile() {
 profile_allows_secrets_access() {
   local profile="$1"
   profile_exists "$profile" || return 1
-  [[ "$(capability_value "$profile" allowSecretsAccess)" == "true" ]]
+  profile_capability_is_true "$profile" allowSecretsAccess
 }
 
 # Runtime gate for the private-backup tooling (issue #60). The archive may

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -213,9 +213,10 @@ run_fail_contains \
   "module has requires but no paths: base" \
   "$fixture/scripts/validate-policy.sh" personal
 
-# The YAML node type, not its printed text, is the boolean contract (#206).
-# Quoted values used to validate while Go templates treated "false" as truthy.
-for invalid_bool in '"true"' '"false"' 0 null '[]' '{}'; do
+# Require both the YAML boolean type and canonical lowercase spelling (#206).
+# Quoted "false" is truthy in templates; uppercase booleans bypass lowercase
+# comparisons in registry disclosure and environmentKind checks.
+for invalid_bool in '"true"' '"false"' 0 null '[]' '{}' True TRUE False FALSE; do
   make_fixture
   V="$invalid_bool" yq -i '.profiles.personal.capabilities.enableQualityLoopHooks = env(V)' \
     "$fixture/.chezmoidata/profiles.yaml"
@@ -258,6 +259,16 @@ for invalid_bool in '"true"' '"false"' 0 null '[]' '{}'; do
         fail "invalid boolean granted secret access"; exit 1
       fi
     '
+done
+
+for invalid_true in True TRUE; do
+  make_fixture
+  V="$invalid_true" yq -i '.profiles.work.capabilities.enableAiTools = env(V)' \
+    "$fixture/.chezmoidata/profiles.yaml"
+  run_fail_contains \
+    "uppercase $invalid_true cannot bypass work environmentKind restrictions" \
+    "capability must be boolean: enableAiTools=$invalid_true" \
+    "$fixture/scripts/validate-policy.sh" work
 done
 
 make_fixture

--- a/scripts/test-policy.sh
+++ b/scripts/test-policy.sh
@@ -213,6 +213,68 @@ run_fail_contains \
   "module has requires but no paths: base" \
   "$fixture/scripts/validate-policy.sh" personal
 
+# The YAML node type, not its printed text, is the boolean contract (#206).
+# Quoted values used to validate while Go templates treated "false" as truthy.
+for invalid_bool in '"true"' '"false"' 0 null '[]' '{}'; do
+  make_fixture
+  V="$invalid_bool" yq -i '.profiles.personal.capabilities.enableQualityLoopHooks = env(V)' \
+    "$fixture/.chezmoidata/profiles.yaml"
+  run_fail_contains \
+    "rejects profile boolean with YAML value $invalid_bool" \
+    "capability must be boolean: enableQualityLoopHooks=" \
+    "$fixture/scripts/validate-policy.sh" personal
+
+  make_fixture
+  V="$invalid_bool" yq -i '.modules.runtime.requires.enableRuntimeManagement = env(V)' \
+    "$fixture/.chezmoidata/modules.yaml"
+  run_fail_contains \
+    "rejects module requirement with YAML value $invalid_bool" \
+    "module requires must be boolean: runtime: enableRuntimeManagement=" \
+    "$fixture/scripts/validate-policy.sh" personal
+
+  make_fixture
+  V="$invalid_bool" yq -i '.capabilities.enableQualityLoopHooks.implemented = env(V)' \
+    "$fixture/.chezmoidata/capabilities.schema.yaml"
+  run_fail_contains \
+    "rejects registry implemented with YAML value $invalid_bool" \
+    "enableQualityLoopHooks lacks implemented: true|false" \
+    "$fixture/scripts/validate-policy.sh" personal
+
+  make_fixture
+  V="$invalid_bool" yq -i '
+    .profiles.personal.capabilities.installPackages = env(V) |
+    .profiles.personal.capabilities.installGuiApps = env(V) |
+    .profiles.personal.capabilities.allowSecretsAccess = env(V)' \
+    "$fixture/.chezmoidata/profiles.yaml"
+  run_ok "runtime gates refuse YAML value $invalid_bool without prior validation" \
+    env FIXTURE_LIB="$fixture/scripts/lib-policy.sh" bash -c '
+      source "$FIXTURE_LIB"
+      for source in brew_formula npm_global go_install brew_cask mas; do
+        if profile_installs_source personal "$source"; then
+          fail "invalid boolean granted $source install"; exit 1
+        fi
+      done
+      if profile_allows_secrets_access personal; then
+        fail "invalid boolean granted secret access"; exit 1
+      fi
+    '
+done
+
+make_fixture
+run_ok "runtime gates grant boolean true and refuse boolean false" \
+  env FIXTURE_LIB="$fixture/scripts/lib-policy.sh" bash -c '
+    source "$FIXTURE_LIB"
+    for source in brew_formula npm_global go_install brew_cask mas; do
+      profile_installs_source personal "$source" || exit 1
+      if profile_installs_source work "$source"; then exit 1; fi
+    done
+    profile_allows_secrets_access personal || exit 1
+    ! profile_allows_secrets_access work
+  '
+yq -i '.modules.runtime.requires.enableRuntimeManagement = false' \
+  "$fixture/.chezmoidata/modules.yaml"
+run_ok "accepts a boolean false module requirement" "$fixture/scripts/validate-policy.sh" --all
+
 # Software catalog (packages.yaml) validation.
 make_fixture
 replace_once "$fixture/.chezmoidata/packages.yaml" \

--- a/scripts/test-render.sh
+++ b/scripts/test-render.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib-policy.sh
 source "$SCRIPT_DIR/lib-policy.sh"
+# shellcheck source=scripts/test-lib.sh
+source "$SCRIPT_DIR/test-lib.sh"
 
 require_yq || exit 1
 
@@ -162,6 +164,62 @@ if output="$(env HOME="$root/home" XDG_CONFIG_HOME="$root/config" XDG_DATA_HOME=
 else
   ok "test passed: init without a profile answer fails"
 fi
+
+section "typed boolean guards (direct chezmoi, without validate-policy)"
+
+for invalid_bool in '"true"' '"false"' 0 null '[]' '{}'; do
+  for bool_input in profile requires implemented; do
+    make_root
+    make_flipped_source "$root"
+    write_config personal
+    case "$bool_input" in
+      profile)
+        V="$invalid_bool" yq -i '.profiles.personal.capabilities.enableQualityLoopHooks = env(V)' \
+          "$root/src/.chezmoidata/profiles.yaml"
+        expected_error="capability must be boolean: personal.enableQualityLoopHooks"
+        ;;
+      requires)
+        V="$invalid_bool" yq -i '.modules.runtime.requires.enableRuntimeManagement = env(V)' \
+          "$root/src/.chezmoidata/modules.yaml"
+        expected_error="module requires must be boolean: runtime.enableRuntimeManagement"
+        ;;
+      implemented)
+        V="$invalid_bool" yq -i '.capabilities.enableQualityLoopHooks.implemented = env(V)' \
+          "$root/src/.chezmoidata/capabilities.schema.yaml"
+        expected_error="capability registry: enableQualityLoopHooks implemented must be a YAML boolean"
+        ;;
+    esac
+    if output="$(chezmoi --config "$root/chezmoi.toml" --source "$root/src" \
+      --destination "$root/home" apply 2>&1)"; then
+      fail "test failed: apply accepted $bool_input YAML value $invalid_bool"
+      status=1
+    elif grep -Fq "$expected_error" <<< "$output"; then
+      ok "test passed: apply rejects $bool_input YAML value $invalid_bool"
+    else
+      printf '%s\n' "$output" >&2
+      fail "test failed: apply did not report the $bool_input type error"
+      status=1
+    fi
+    if [[ -e "$root/home/.claude/settings.json" || -e "$root/home/.codex/hooks.json" ]]; then
+      fail "test failed: invalid boolean created a live hook registration"
+      status=1
+    fi
+
+    # Each agent's template must guard itself as well as .chezmoiignore:
+    # execute-template bypasses the managed-set/apply path entirely.
+    for agent_template in dot_claude/settings.json.tmpl dot_codex/hooks.json.tmpl; do
+      if output="$(chezmoi --config "$root/chezmoi.toml" --source "$root/src" \
+        --destination "$root/home" execute-template < "$root/src/$agent_template" 2>&1)"; then
+        fail "test failed: $agent_template accepted $bool_input YAML value $invalid_bool"
+        status=1
+      elif ! grep -Fq "$expected_error" <<< "$output"; then
+        printf '%s\n' "$output" >&2
+        fail "test failed: $agent_template did not report the $bool_input type error"
+        status=1
+      fi
+    done
+  done
+done
 
 if [[ "$status" -eq 0 ]]; then
   ok "render tests passed"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -74,7 +74,9 @@ validate_modules() {
       type="$(capability_type "$capability")"
       case "$type" in
         boolean)
-          if [[ "$value" == "true" || "$value" == "false" ]]; then
+          if m="$module" c="$capability" yq -e \
+            '.modules[strenv(m)].requires[strenv(c)] | tag == "!!bool"' \
+            "$MODULES_FILE" >/dev/null; then
             ok "module requires: $module: $capability=$value"
           else
             fail "module requires must be boolean: $module: $capability=$value"
@@ -131,6 +133,13 @@ validate_capability_registry() {
   while IFS= read -r capability; do
     [[ -z "$capability" ]] && continue
     impl="$(capability_implemented "$capability")"
+    if ! c="$capability" yq -e \
+      '.capabilities[strenv(c)].implemented | tag == "!!bool"' \
+      "$CAPABILITIES_FILE" >/dev/null; then
+      fail "capability registry: $capability lacks implemented: true|false (must be a YAML boolean)"
+      status=1
+      continue
+    fi
     case "$impl" in
       true)
         ok "capability registry: $capability implemented=true"
@@ -142,10 +151,6 @@ validate_capability_registry() {
           fail "capability registry: $capability is implemented=false but doctor.sh never mentions it (undisclosed dormant declaration)"
           status=1
         fi
-        ;;
-      *)
-        fail "capability registry: $capability lacks implemented: true|false"
-        status=1
         ;;
     esac
   done < "$known_caps_file"
@@ -373,7 +378,9 @@ validate_profile() {
     type="$(capability_type "$capability")"
     case "$type" in
       boolean)
-        if [[ "$value" == "true" || "$value" == "false" ]]; then
+        if p="$profile" c="$capability" yq -e \
+          '.profiles[strenv(p)].capabilities[strenv(c)] | tag == "!!bool"' \
+          "$PROFILES_FILE" >/dev/null; then
           ok "capability value: $capability=$value"
         else
           fail "capability must be boolean: $capability=$value"

--- a/scripts/validate-policy.sh
+++ b/scripts/validate-policy.sh
@@ -75,7 +75,7 @@ validate_modules() {
       case "$type" in
         boolean)
           if m="$module" c="$capability" yq -e \
-            '.modules[strenv(m)].requires[strenv(c)] | tag == "!!bool"' \
+            '.modules[strenv(m)].requires[strenv(c)] | ((tag == "!!bool") and (. == true or . == false))' \
             "$MODULES_FILE" >/dev/null; then
             ok "module requires: $module: $capability=$value"
           else
@@ -134,7 +134,7 @@ validate_capability_registry() {
     [[ -z "$capability" ]] && continue
     impl="$(capability_implemented "$capability")"
     if ! c="$capability" yq -e \
-      '.capabilities[strenv(c)].implemented | tag == "!!bool"' \
+      '.capabilities[strenv(c)].implemented | ((tag == "!!bool") and (. == true or . == false))' \
       "$CAPABILITIES_FILE" >/dev/null; then
       fail "capability registry: $capability lacks implemented: true|false (must be a YAML boolean)"
       status=1
@@ -151,6 +151,10 @@ validate_capability_registry() {
           fail "capability registry: $capability is implemented=false but doctor.sh never mentions it (undisclosed dormant declaration)"
           status=1
         fi
+        ;;
+      *)
+        fail "capability registry: $capability lacks implemented: true|false"
+        status=1
         ;;
     esac
   done < "$known_caps_file"
@@ -379,7 +383,7 @@ validate_profile() {
     case "$type" in
       boolean)
         if p="$profile" c="$capability" yq -e \
-          '.profiles[strenv(p)].capabilities[strenv(c)] | tag == "!!bool"' \
+          '.profiles[strenv(p)].capabilities[strenv(c)] | ((tag == "!!bool") and (. == true or . == false))' \
           "$PROFILES_FILE" >/dev/null; then
           ok "capability value: $capability=$value"
         else


### PR DESCRIPTION
## 変更内容

YAML の文字列 `"false"` が検証を通り、Go template で非空文字列として hook を有効にしていた問題を修正します。profile capability・module requires・implemented metadata に実際の boolean 型を要求し、shell validator は既存契約の小文字 `true` / `false` だけを受理します。大文字の `True` / `FALSE` が下流の文字列比較から外れ、環境種別の禁止条件や未実装 capability の開示検査を通過する経路も拒否します。

validator を経由しない `chezmoi apply` / `execute-template` は、共通 guard でデコード後の型を検査します。install / secret の runtime gate も型と値を合わせて確認し、文字列 `"true"` から権限を与えません。enum と汎用値 getter の既存契約は維持します。

Closes #206

## 検証

- quoted true/false、数値、null、配列、map を各入口で拒否。正常 true/false の対照と、hook registration が作られないことを確認。
- 大文字 boolean による work の禁止 capability・module requires・未実装 capability 開示の検証すり抜けを旧 head で再現し、修正後はすべて拒否。
- policy テストは 102 ケース成功。大文字4種の profile / requires / implemented / runtime gate と work の禁止条件について18ケースを追加。
- render、install-packages（inventory を含む）、secrets-gate、Claude / Codex settings、`validate-policy.sh --all`、全 script shellcheck・構文検査、`git diff --check` が成功。
- 直接 template に未引用の `FALSE` を渡す positive control では、Claude hooks なし・Codex hooks 空出力を確認。Go のデコード後には元の綴りを区別できないため、template に大文字表記の拒否は要求しません。

## 相互レビューと CI

現在の head: `f8e35b44e0d6796b9a83fda61c05e3d9257ef71c`。commit trailers により2 commit とも author=Codex / reviewer=Claude を確認。

2026-09-06 JST、`claude -p` による初回の独立レビューで大文字 boolean の必須指摘1件を受け、上記の再現・修正・回帰テストを反映しました。最新 head の独立再レビューで profile / module requires / registry の3経路の解消を確認済みです。

Review process verdict: **pass**。コード判定: **approve**。Finding summary: **must 0 / should 0 / nit 2**。Claude は提示した差分・source・検証結果を読み、テスト自体は実行していません。承認条件だった最新 head の GitHub CI validate / render は、両方とも SUCCESS を確認しました。

## 副作用と残リスク

検証は一時 fixture のみ。実 HOME・credential・package install は変更していません。非 blocking の提案は、綴り比較と template テストの意図を説明するコメント追加、および欠落した capability に対する template エラーの文言改善です。`test-render.sh` の `test-lib.sh` 読み込みは `make_flipped_source` の利用に必要で、初回の未使用という懸念は再レビューで解消されました。
