### PR TITLE
fix(inventory): npm query 失敗時に安全な診断ヒントを示す

### DIFF
--- a/docs/policy-model.md
+++ b/docs/policy-model.md
@@ -34,7 +34,7 @@ modules は装飾ラベルではなく、管理対象 path を宣言する単位
 - **台帳外**(undeclared / sprawl: 入っているが catalog に無い)→ `warn`。brew は `brew leaves`(top-level のみ。依存は拾わない)、npm は node 同梱の `npm` / `corepack` を除外(runtime の領分、node/go/uv と同じ扱い)、go は toolchain 同梱の `go` / `gofmt` を除外(GOBIN を `$GOROOT/bin` に向ける mise 等では toolchain 本体が scan dir に同居するため。catalog で宣言・削除できる go_install package ではない)、mas は App Store の無関係アプリが大量に誤検知されるため undeclared は出さない(宣言済み mas entry の presence のみ確認)。
 - **source ズレ**(宣言 source の inventory には無いが `command` が PATH 上に在る = 別 source で入っている疑い)→ `info`。manager 横断の名前照合(脆い)はやらず、PATH 上の存在という堅い信号だけを使う。
 
-照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。 inventory の取得・解析に失敗した source は未 install / 台帳外と判定せず、`INCOMPLETE` を警告して検査を skip する。他の source は引き続き検査し、doctor は exit 0 を維持する。
+照合は source ごとの canonical id(`pkg`、無ければ `name`)で行う。 inventory の取得・解析に失敗した source は未 install / 台帳外と判定せず、`INCOMPLETE` を警告して検査を skip する。他の source は引き続き検査し、doctor は exit 0 を維持する。依存 tree の不整合による `npm ls` の nonzero も inventory 不明として扱い、任意の stderr は転載せず exit code と固定ヒントを表示するので、`npm ls -g --depth=0` を手動実行して診断する。
 
 install は `install-packages.sh`(手動起動・`chezmoi apply` 非結合)が担う。catalog の未 install entry を、`installPackages`(brew_formula / npm_global / go_install)と `installGuiApps`(brew_cask / mas)で gate して install する。**dry-run 既定**(`--apply` で実行)、既 install は skip して**更新しない**(install と update の分離、[update-policy](update-policy.md))、track-only / manual は対象外、npm/go の manager 不在時は skip+warn。environmentKind 制約で work / client / agent は gate(installPackages/installGuiApps)が false 必須なので install されない(`environment_kind_forbidden_capabilities`)。sandbox は install 制約の対象外(secret のみ禁止)で、profile が install gate を true にすれば install されうる。
 

--- a/scripts/lib-policy.sh
+++ b/scripts/lib-policy.sh
@@ -381,13 +381,17 @@ go_bin_dir() {
 # Capture the WHOLE list before matching: `probe | grep -q` can lose an
 # installed entry to SIGPIPE under pipefail (#143).
 installed_inventory() {
-  local source="$1" inventory dir
+  local source="$1" inventory dir query_status
   case "$source" in
     brew_formula) brew list --formula -1 2>/dev/null ;;
     brew_leaves) brew leaves 2>/dev/null ;;
     brew_cask) brew list --cask -1 2>/dev/null ;;
     npm_global)
-      inventory="$(npm ls -g --depth=0 --json 2>/dev/null)" || return 1
+      inventory="$(npm ls -g --depth=0 --json 2>/dev/null)" || {
+        query_status=$?
+        warn "npm global inventory query failed (exit $query_status); run 'npm ls -g --depth=0' manually to inspect dependency-tree problems"
+        return 1
+      }
       [[ -n "$inventory" ]] || return 1
       printf '%s\n' "$inventory" | yq -e -p json \
         '(tag == "!!map") and ((.dependencies == null) or ((.dependencies | tag) == "!!map"))' >/dev/null 2>&1 || return 1

--- a/scripts/test-inventory.sh
+++ b/scripts/test-inventory.sh
@@ -50,7 +50,11 @@ if [ "$1" = install ]; then
 fi
 if [ "${INVENTORY_TEST_STATE:-present}" = fail ]; then
   # A partially printed inventory with a failure is still unknown.
-  [ "$manager" = npm ] && printf '{"dependencies":{"partial-entry":{}}}\n'
+  if [ "$manager" = npm ]; then
+    printf '{"dependencies":{"partial-entry":{}}}\n'
+    printf 'FIXTURE_NPM_PRIVATE_DIAGNOSTIC\n' >&2
+    exit 42
+  fi
   exit 1
 fi
 case "${INVENTORY_TEST_STATE:-present}:$manager:$*" in
@@ -166,6 +170,14 @@ for mode in dry-run apply; do
   [[ "$mode" = apply ]] && args+=(--apply)
   if output="$(INVENTORY_TEST_STATE=fail run_fixture "${args[@]}" 2>&1)"; then
     fail "inventory errors must fail the installer ($mode)"
+    exit 1
+  else
+    inventory_exit=$?
+  fi
+  if [[ "$inventory_exit" -ne 1 ]] || ! grep -Fq 'query failed (exit 42)' <<< "$output" \
+    || ! grep -Fq "run 'npm ls -g --depth=0' manually" <<< "$output" \
+    || grep -Fq 'FIXTURE_NPM_PRIVATE_DIAGNOSTIC' <<< "$output"; then
+    fail "npm failure must report its exit code and fixed hint without raw diagnostics ($mode)"
     exit 1
   fi
   if [[ -s "$fixture/installs" ]] || ! grep -Fq '0 skipped, 5 failed' <<< "$output" \


### PR DESCRIPTION
## 変更内容

npm inventory の取得が非 0 終了したとき、実 exit code と固定の手動診断コマンド `npm ls -g --depth=0` を案内します。依存 tree の不整合でも unknown と判定することを docs に明記しました。

任意の npm stderr や partial JSON の内容は出力しません。失敗時の install 拒否、doctor の report-only、正常な空 inventory の扱いは維持します。

Closes #219

## 検証

- fake npm が partial JSON・private diagnostic canary・exit 42 を出すケースを追加。
- dry-run / apply とも install せず exit 1。exit 42 と固定ヒントを表示し、canary は非表示。
- `test-inventory.sh` は macOS Bash 3.2 と Homebrew Bash の両方で成功。shellcheck と `git diff --check` も成功。
- head `c68000e3ccb2da1a1d3fc576a1cd3d0e050c33f0` の GitHub CI validate / render は SUCCESS。
- main と #221 / #222 / #223 を統合した一時 snapshot でも、system Bash 3.2.57 の inventory / secrets gate / private backup テストがすべて exit 0。

## 相互レビュー

2026-09-06 JST、`claude -p` で上記 head の独立レビューを実施。commit trailers により author=Codex / reviewer=Claude を確認。Claude は提示した差分・source・検証結果を読み、テスト自体は実行していません。

Review process verdict: **pass**。Finding summary: **must 0 / should 0 / nit 2**。

exit code の取得、stderr / partial JSON の抑止、install 拒否、doctor の exit 0 維持、docs と実装の一致を確認済みです。非 blocking の提案は次の 2 件で、この変更による不具合の指摘ではありません。

- 既存の entry ごとの inventory 再問い合わせにより警告が重複する。source 単位のキャッシュは後続改善候補。
- canary 不在の assertion を installer に加えて doctor の drift 経路にも設けると、テスト範囲を広げられる。現行 code で漏れる根拠はなし。

## 副作用と残リスク

検証は一時 fixture のみ。実 package manager による install や実 HOME の変更はありません。上記の非 blocking 提案を残してマージ可能です。
